### PR TITLE
fix: avoid fake PR URLs in agent simulation

### DIFF
--- a/src/lib/async-execution.ts
+++ b/src/lib/async-execution.ts
@@ -207,7 +207,15 @@ function buildAgentJobSimulationPlan(jobId: string): SimulationPhase[] {
           .update(agentJobs)
           .set({
             status: "succeeded",
-            prUrl: `https://github.com/org/repo/pull/${Math.floor(Math.random() * 1000)}`,
+            prUrl: null,
+            messages: [
+              {
+                role: "agent",
+                content:
+                  "Simulation mode completed this job without creating a GitHub pull request.",
+                timestamp: new Date().toISOString(),
+              },
+            ],
             updatedAt: new Date(),
           })
           .where(and(eq(agentJobs.id, jobId), eq(agentJobs.status, "running")));

--- a/tests/async-execution.test.ts
+++ b/tests/async-execution.test.ts
@@ -1,9 +1,40 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+const updateSetMock = vi.fn();
+const updateWhereMock = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    update: vi.fn(() => ({
+      set: updateSetMock,
+    })),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  agentJobs: {
+    id: "agent_jobs.id",
+    status: "agent_jobs.status",
+  },
+  deployments: {},
+  projects: {},
+}));
+
+vi.mock("@/lib/github-sync", () => ({
+  syncProjectDocsFromGitHub: vi.fn(),
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: (...conditions: unknown[]) => ({ conditions }),
+  eq: (left: unknown, right: unknown) => ({ left, right }),
+}));
+
 describe("async execution", () => {
   afterEach(() => {
     // biome-ignore lint/performance/noDelete: tests must remove the env var rather than assign the string "undefined"
     delete process.env.ENABLE_ASYNC_SIMULATION;
+    updateSetMock.mockReset();
+    updateWhereMock.mockReset();
     vi.resetModules();
     vi.restoreAllMocks();
   });
@@ -89,6 +120,36 @@ describe("async execution", () => {
     expect(setTimeoutSpy.mock.calls.map((call) => call[1])).toEqual([
       500, 5000,
     ]);
+  });
+
+  it("does not invent a pull request URL when simulating agent completion", async () => {
+    process.env.ENABLE_ASYNC_SIMULATION = "true";
+    const scheduledTasks: Array<() => void> = [];
+    vi.spyOn(globalThis, "setTimeout").mockImplementation((task) => {
+      scheduledTasks.push(task as () => void);
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    });
+    updateSetMock.mockReturnValue({ where: updateWhereMock });
+
+    const { enqueueAgentJob } = await import("@/lib/async-execution");
+
+    await enqueueAgentJob("job-1");
+    await scheduledTasks[1]?.();
+
+    expect(updateSetMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "succeeded",
+        prUrl: null,
+        messages: [
+          expect.objectContaining({
+            role: "agent",
+            content: expect.stringContaining(
+              "without creating a GitHub pull request",
+            ),
+          }),
+        ],
+      }),
+    );
   });
 
   it("uses manual follow-up strategy for agent jobs by default", async () => {


### PR DESCRIPTION
## Summary
- stop simulation mode from inventing random GitHub PR URLs for completed agent jobs
- record an explicit simulated completion message instead
- add regression coverage for the scheduled simulation completion payload

## Verification
- npx biome check --write src/lib/async-execution.ts tests/async-execution.test.ts
- npm test -- --run tests/async-execution.test.ts
- npm run typecheck
- npm run lint
- npm run build