### PR TITLE
fix: remove duplicate dashboard refresh action

### DIFF
--- a/src/app/dashboard/dashboard-home-client.tsx
+++ b/src/app/dashboard/dashboard-home-client.tsx
@@ -563,14 +563,6 @@ export function DashboardHomeClient({
                     <RefreshCw size={16} />
                   )}
                 </button>
-                <button
-                  type="button"
-                  onClick={() => router.refresh()}
-                  className="p-2 rounded-md bg-[#1a1a1a] border border-white/[0.08] text-gray-400 hover:text-white hover:bg-white/[0.06] transition-colors"
-                  title="Refresh Dashboard"
-                >
-                  <RefreshCw size={16} className="rotate-90 opacity-60" />
-                </button>
                 <a
                   href={siteUrl}
                   target="_blank"


### PR DESCRIPTION
## Summary
- remove the separate dashboard refresh icon from the project action row
- keep the GitHub sync refresh action as the single refresh affordance

## Verification
- npm run lint
- npm run typecheck
- npm run build