### PR TITLE
fix: clean up solo orgs on account deletion

### DIFF
--- a/src/app/api/users/profile/route.ts
+++ b/src/app/api/users/profile/route.ts
@@ -1,3 +1,4 @@
+import { deleteOrganizationsSolelyAdministeredByUser } from "@/lib/account-deletion";
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { user } from "@/lib/db/auth-schema";
@@ -169,7 +170,10 @@ export async function DELETE() {
   const userId = session.user.id;
 
   try {
-    // Delete the user record from the 'user' table (Better Auth)
+    const deletedOrgIds =
+      await deleteOrganizationsSolelyAdministeredByUser(userId);
+
+    // Delete the user record from the 'user' table (Better Auth).
     // Cascading deletes in the schema handle memberships, prefs, sessions, accounts.
     await db.delete(user).where(eq(user.id, userId));
 
@@ -177,6 +181,7 @@ export async function DELETE() {
       requestId,
       userId,
       email: session.user.email,
+      deletedOrgCount: deletedOrgIds.length,
     });
 
     return NextResponse.json({ success: true, requestId });

--- a/src/lib/account-deletion.ts
+++ b/src/lib/account-deletion.ts
@@ -1,0 +1,68 @@
+import { db } from "@/lib/db";
+import { orgMemberships, organizations } from "@/lib/db/schema";
+import { and, eq, ne } from "drizzle-orm";
+
+interface MembershipRow {
+  orgId: string;
+  role: string;
+}
+
+export function findSoleAdminOrgIdsForDeletion(
+  memberships: MembershipRow[],
+  orgIdsWithOtherMembers: Set<string>,
+): string[] {
+  return memberships
+    .filter(
+      (membership) =>
+        membership.role === "admin" &&
+        !orgIdsWithOtherMembers.has(membership.orgId),
+    )
+    .map((membership) => membership.orgId);
+}
+
+export async function deleteOrganizationsSolelyAdministeredByUser(
+  userId: string,
+): Promise<string[]> {
+  const memberships = await db
+    .select({ orgId: orgMemberships.orgId, role: orgMemberships.role })
+    .from(orgMemberships)
+    .where(eq(orgMemberships.userId, userId));
+
+  if (memberships.length === 0) {
+    return [];
+  }
+
+  const orgIdsWithOtherMembers = new Set<string>();
+
+  await Promise.all(
+    memberships.map(async ({ orgId }) => {
+      const otherMembers = await db
+        .select({ id: orgMemberships.id })
+        .from(orgMemberships)
+        .where(
+          and(
+            eq(orgMemberships.orgId, orgId),
+            ne(orgMemberships.userId, userId),
+          ),
+        )
+        .limit(1);
+
+      if (otherMembers.length > 0) {
+        orgIdsWithOtherMembers.add(orgId);
+      }
+    }),
+  );
+
+  const orgIdsToDelete = findSoleAdminOrgIdsForDeletion(
+    memberships,
+    orgIdsWithOtherMembers,
+  );
+
+  await Promise.all(
+    orgIdsToDelete.map((orgId) =>
+      db.delete(organizations).where(eq(organizations.id, orgId)),
+    ),
+  );
+
+  return orgIdsToDelete;
+}

--- a/tests/account-deletion.test.ts
+++ b/tests/account-deletion.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { findSoleAdminOrgIdsForDeletion } from "@/lib/account-deletion";
+
+describe("account deletion organization cleanup", () => {
+  it("deletes organizations where the user is the only admin/member", () => {
+    expect(
+      findSoleAdminOrgIdsForDeletion(
+        [
+          { orgId: "solo-admin-org", role: "admin" },
+          { orgId: "shared-admin-org", role: "admin" },
+        ],
+        new Set(["shared-admin-org"]),
+      ),
+    ).toEqual(["solo-admin-org"]);
+  });
+
+  it("does not delete organizations where the user is not an admin", () => {
+    expect(
+      findSoleAdminOrgIdsForDeletion(
+        [
+          { orgId: "viewer-org", role: "viewer" },
+          { orgId: "editor-org", role: "editor" },
+        ],
+        new Set(),
+      ),
+    ).toEqual([]);
+  });
+
+  it("does not delete organizations that still have other members", () => {
+    expect(
+      findSoleAdminOrgIdsForDeletion(
+        [{ orgId: "shared-admin-org", role: "admin" }],
+        new Set(["shared-admin-org"]),
+      ),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- clean up organizations solely administered by a user before deleting their account
- keep shared organizations intact when other members remain
- add focused coverage for the account deletion cleanup decision logic

## Verification
- npx biome check --write src/lib/account-deletion.ts src/app/api/users/profile/route.ts tests/account-deletion.test.ts
- npm test -- --run tests/account-deletion.test.ts
- npm run typecheck
- npm run lint
- npm run build