### PR TITLE
fix: make account deletion cleanup atomic

### DIFF
--- a/src/app/api/users/profile/route.ts
+++ b/src/app/api/users/profile/route.ts
@@ -170,12 +170,16 @@ export async function DELETE() {
   const userId = session.user.id;
 
   try {
-    const deletedOrgIds =
-      await deleteOrganizationsSolelyAdministeredByUser(userId);
+    const deletedOrgIds = await db.transaction(async (tx) => {
+      const deletedOrganizations =
+        await deleteOrganizationsSolelyAdministeredByUser(userId, tx);
 
-    // Delete the user record from the 'user' table (Better Auth).
-    // Cascading deletes in the schema handle memberships, prefs, sessions, accounts.
-    await db.delete(user).where(eq(user.id, userId));
+      // Delete the user record from the 'user' table (Better Auth).
+      // Cascading deletes in the schema handle memberships, prefs, sessions, accounts.
+      await tx.delete(user).where(eq(user.id, userId));
+
+      return deletedOrganizations;
+    });
 
     logger.info("user_delete_completed", {
       requestId,

--- a/src/lib/account-deletion.ts
+++ b/src/lib/account-deletion.ts
@@ -1,6 +1,6 @@
 import { db } from "@/lib/db";
 import { orgMemberships, organizations } from "@/lib/db/schema";
-import { and, eq, ne } from "drizzle-orm";
+import { and, eq, inArray, ne } from "drizzle-orm";
 
 interface MembershipRow {
   orgId: string;
@@ -20,10 +20,13 @@ export function findSoleAdminOrgIdsForDeletion(
     .map((membership) => membership.orgId);
 }
 
+type AccountDeletionDb = Pick<typeof db, "delete" | "select">;
+
 export async function deleteOrganizationsSolelyAdministeredByUser(
   userId: string,
+  database: AccountDeletionDb = db,
 ): Promise<string[]> {
-  const memberships = await db
+  const memberships = await database
     .select({ orgId: orgMemberships.orgId, role: orgMemberships.role })
     .from(orgMemberships)
     .where(eq(orgMemberships.userId, userId));
@@ -36,7 +39,7 @@ export async function deleteOrganizationsSolelyAdministeredByUser(
 
   await Promise.all(
     memberships.map(async ({ orgId }) => {
-      const otherMembers = await db
+      const otherMembers = await database
         .select({ id: orgMemberships.id })
         .from(orgMemberships)
         .where(
@@ -58,11 +61,11 @@ export async function deleteOrganizationsSolelyAdministeredByUser(
     orgIdsWithOtherMembers,
   );
 
-  await Promise.all(
-    orgIdsToDelete.map((orgId) =>
-      db.delete(organizations).where(eq(organizations.id, orgId)),
-    ),
-  );
+  if (orgIdsToDelete.length > 0) {
+    await database
+      .delete(organizations)
+      .where(inArray(organizations.id, orgIdsToDelete));
+  }
 
   return orgIdsToDelete;
 }


### PR DESCRIPTION
## Summary
- run solo-org cleanup and account deletion in a single transaction
- allow the account deletion cleanup helper to operate on a transaction client
- batch organization cleanup into one delete statement

## Verification
- npx biome check --write src/lib/account-deletion.ts src/app/api/users/profile/route.ts
- npm test -- --run tests/account-deletion.test.ts
- npm run typecheck
- npm run lint
- npm run build