### PR TITLE
chore: migrate middleware convention to proxy

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,7 +8,7 @@ const PROTECTED_PREFIXES = [
   "/analytics",
 ];
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   const start = Date.now();
   const sessionCookie = getSessionCookie(request);
   const { pathname, search } = request.nextUrl;
@@ -28,7 +28,7 @@ export async function middleware(request: NextRequest) {
   const duration = Date.now() - start;
 
   // Set Server-Timing header for performance monitoring
-  response.headers.set("Server-Timing", `middleware;dur=${duration}`);
+  response.headers.set("Server-Timing", `proxy;dur=${duration}`);
 
   return response;
 }

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -1,4 +1,4 @@
-import { type NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
 import { describe, expect, it, vi } from "vitest";
 
 const getSessionCookieMock = vi.fn();
@@ -16,13 +16,11 @@ function makeNextRequest(url: string): NextRequest {
   return request;
 }
 
-describe("Middleware", () => {
+describe("Proxy", () => {
   it("redirects unauthenticated users to login for protected routes", async () => {
     getSessionCookieMock.mockReturnValue(null);
-    const { middleware } = await import("@/middleware");
-    const response = await middleware(
-      makeNextRequest("http://localhost/dashboard"),
-    );
+    const { proxy } = await import("@/proxy");
+    const response = await proxy(makeNextRequest("http://localhost/dashboard"));
 
     expect(response?.status).toBe(307);
     expect(response?.headers.get("location")).toContain("/login");
@@ -30,18 +28,16 @@ describe("Middleware", () => {
 
   it("adds Server-Timing header for performance monitoring", async () => {
     getSessionCookieMock.mockReturnValue({ session: { id: "session-1" } });
-    const { middleware } = await import("@/middleware");
-    const response = await middleware(
-      makeNextRequest("http://localhost/dashboard"),
-    );
+    const { proxy } = await import("@/proxy");
+    const response = await proxy(makeNextRequest("http://localhost/dashboard"));
 
-    expect(response?.headers.get("Server-Timing")).toContain("middleware;dur=");
+    expect(response?.headers.get("Server-Timing")).toContain("proxy;dur=");
   });
 
   it("allows access to unprotected routes", async () => {
     getSessionCookieMock.mockReturnValue(null);
-    const { middleware } = await import("@/middleware");
-    const response = await middleware(makeNextRequest("http://localhost/"));
+    const { proxy } = await import("@/proxy");
+    const response = await proxy(makeNextRequest("http://localhost/"));
 
     // NextResponse.next() in tests returns a response with status 200 or similar
     expect(response?.status).toBe(200);


### PR DESCRIPTION
## Summary
- move the protected-route middleware implementation to the Next.js proxy convention
- update route guard tests to import proxy
- keep Server-Timing coverage and remove the deprecated middleware build warning

## Verification
- npx biome check --write src/proxy.ts tests/middleware.test.ts
- npm test -- --run tests/middleware.test.ts
- npm run typecheck
- npm run lint
- npm run build
- confirmed build output no longer includes the deprecated middleware file convention warning