### PR TITLE
chore: ignore clawhip runtime state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ test.txt
 .inspect-complete
 .ralph_to_ralph_source/
 tests/e2e/.auth/
+
+# clawhip runtime state
+.clawhip/state/


### PR DESCRIPTION
## Summary
- ignore generated clawhip runtime state so repo checks stay clean after notification activity

## Verification
- git status --short --branch