### PR TITLE
feat: add project JSON export settings

### DIFF
--- a/src/app/settings/advanced/exports/page.tsx
+++ b/src/app/settings/advanced/exports/page.tsx
@@ -1,10 +1,87 @@
-import { SettingsPlaceholder } from "@/components/settings/settings-placeholder";
+"use client";
+
+import { useActiveProject } from "@/hooks/use-active-project";
+import {
+  type ExportableProject,
+  buildProjectExport,
+  buildProjectExportFilename,
+  downloadJson,
+} from "@/lib/project-export";
+import { Download, FileJson } from "lucide-react";
 
 export default function ExportsSettingsPage() {
+  const { project, loading } = useActiveProject<ExportableProject>();
+
+  if (loading) {
+    return (
+      <div className="p-6 max-w-2xl">
+        <div className="text-gray-400">Loading...</div>
+      </div>
+    );
+  }
+
+  if (!project) {
+    return (
+      <div className="p-6 max-w-2xl">
+        <div className="text-gray-400">No project found.</div>
+      </div>
+    );
+  }
+
+  const handleDownload = () => {
+    downloadJson(
+      buildProjectExportFilename(project),
+      buildProjectExport(project),
+    );
+  };
+
   return (
-    <SettingsPlaceholder
-      title="Exports"
-      breadcrumb="Settings / Advanced / Exports"
-    />
+    <div className="p-6 max-w-2xl">
+      <div className="mb-1 text-sm text-gray-400">
+        Settings / Advanced / Exports
+      </div>
+      <h1 className="mb-2 text-xl font-semibold text-white">Exports</h1>
+      <p className="mb-6 text-sm text-gray-400">
+        Download a portable JSON snapshot of this project&apos;s deployment and
+        configuration metadata.
+      </p>
+
+      <div className="rounded-xl border border-white/[0.08] bg-[#1a1a1a] p-5">
+        <div className="flex items-start gap-4">
+          <div className="rounded-lg bg-emerald-500/10 p-2 text-emerald-400">
+            <FileJson size={20} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h2 className="text-sm font-medium text-white">Project JSON</h2>
+            <p className="mt-1 text-sm text-gray-400">
+              Includes project identity, domains, repository source, and saved
+              settings. Page content exports can be added separately once the
+              docs export format is finalized.
+            </p>
+            <dl className="mt-4 grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+              <div>
+                <dt className="text-gray-500">Project</dt>
+                <dd className="truncate text-gray-200">{project.name}</dd>
+              </div>
+              <div>
+                <dt className="text-gray-500">Repository</dt>
+                <dd className="truncate text-gray-200">
+                  {project.repoUrl ?? "Not connected"}
+                </dd>
+              </div>
+            </dl>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={handleDownload}
+          className="mt-5 inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+        >
+          <Download size={16} />
+          Download JSON
+        </button>
+      </div>
+    </div>
   );
 }

--- a/src/lib/project-export.ts
+++ b/src/lib/project-export.ts
@@ -1,0 +1,49 @@
+export interface ExportableProject {
+  id: string;
+  name: string;
+  slug: string;
+  subdomain: string | null;
+  customDomain: string | null;
+  repoUrl: string | null;
+  repoBranch: string | null;
+  repoPath: string | null;
+  settings: Record<string, unknown> | null;
+}
+
+export function buildProjectExport(project: ExportableProject) {
+  return {
+    exportedAt: new Date().toISOString(),
+    project: {
+      id: project.id,
+      name: project.name,
+      slug: project.slug,
+      subdomain: project.subdomain,
+      customDomain: project.customDomain,
+      repository: {
+        url: project.repoUrl,
+        branch: project.repoBranch ?? "main",
+        path: project.repoPath ?? "/",
+      },
+      settings: project.settings ?? {},
+    },
+  };
+}
+
+export function buildProjectExportFilename(
+  project: Pick<ExportableProject, "slug">,
+) {
+  const safeSlug = project.slug.replace(/[^a-z0-9-_]+/gi, "-").toLowerCase();
+  return `${safeSlug || "project"}-export.json`;
+}
+
+export function downloadJson(filename: string, data: unknown) {
+  const blob = new Blob([JSON.stringify(data, null, 2)], {
+    type: "application/json",
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}

--- a/tests/project-export.test.ts
+++ b/tests/project-export.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildProjectExport,
+  buildProjectExportFilename,
+} from "@/lib/project-export";
+
+describe("project export helpers", () => {
+  it("builds a portable project export payload", () => {
+    vi.setSystemTime(new Date("2026-04-28T12:00:00.000Z"));
+
+    expect(
+      buildProjectExport({
+        id: "project-1",
+        name: "Docs",
+        slug: "docs",
+        subdomain: "docs",
+        customDomain: "docs.example.com",
+        repoUrl: "https://github.com/acme/docs",
+        repoBranch: null,
+        repoPath: null,
+        settings: { theme: "dark" },
+      }),
+    ).toEqual({
+      exportedAt: "2026-04-28T12:00:00.000Z",
+      project: {
+        id: "project-1",
+        name: "Docs",
+        slug: "docs",
+        subdomain: "docs",
+        customDomain: "docs.example.com",
+        repository: {
+          url: "https://github.com/acme/docs",
+          branch: "main",
+          path: "/",
+        },
+        settings: { theme: "dark" },
+      },
+    });
+
+    vi.useRealTimers();
+  });
+
+  it("sanitizes export filenames", () => {
+    expect(buildProjectExportFilename({ slug: "My Docs!" })).toBe(
+      "my-docs--export.json",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- replace the Advanced > Exports placeholder with a functional project JSON export page
- export project identity, domains, repository source, and saved settings
- add focused coverage for export payload and filename helpers

## Verification
- npx biome check --write src/lib/project-export.ts src/app/settings/advanced/exports/page.tsx tests/project-export.test.ts
- npm test -- --run tests/project-export.test.ts
- npm run typecheck
- npm run lint
- npm run build