### PR TITLE
fix: redact auth password from project exports

### DIFF
--- a/src/lib/project-export.ts
+++ b/src/lib/project-export.ts
@@ -10,6 +10,20 @@ export interface ExportableProject {
   settings: Record<string, unknown> | null;
 }
 
+function redactSensitiveSettings(settings: Record<string, unknown> | null) {
+  const safeSettings = { ...(settings ?? {}) };
+  const authentication = safeSettings.authentication;
+
+  if (authentication && typeof authentication === "object") {
+    safeSettings.authentication = {
+      ...(authentication as Record<string, unknown>),
+      password: "",
+    };
+  }
+
+  return safeSettings;
+}
+
 export function buildProjectExport(project: ExportableProject) {
   return {
     exportedAt: new Date().toISOString(),
@@ -24,7 +38,7 @@ export function buildProjectExport(project: ExportableProject) {
         branch: project.repoBranch ?? "main",
         path: project.repoPath ?? "/",
       },
-      settings: project.settings ?? {},
+      settings: redactSensitiveSettings(project.settings),
     },
   };
 }

--- a/tests/project-export.test.ts
+++ b/tests/project-export.test.ts
@@ -41,6 +41,26 @@ describe("project export helpers", () => {
     vi.useRealTimers();
   });
 
+  it("redacts authentication passwords from exported settings", () => {
+    const exported = buildProjectExport({
+      id: "project-1",
+      name: "Docs",
+      slug: "docs",
+      subdomain: "docs",
+      customDomain: null,
+      repoUrl: null,
+      repoBranch: null,
+      repoPath: null,
+      settings: {
+        authentication: { mode: "password", password: "super-secret" },
+      },
+    });
+
+    expect(exported.project.settings).toEqual({
+      authentication: { mode: "password", password: "" },
+    });
+  });
+
   it("sanitizes export filenames", () => {
     expect(buildProjectExportFilename({ slug: "My Docs!" })).toBe(
       "my-docs--export.json",


### PR DESCRIPTION
## Summary
- redact authentication passwords from project JSON exports
- keep non-sensitive auth metadata like mode in the export
- add coverage preventing shared passwords from leaking into downloaded exports

## Verification
- npx biome check --write src/lib/project-export.ts tests/project-export.test.ts
- npm test -- --run tests/project-export.test.ts
- npm run typecheck
- npm run lint
- npm run build