### PR TITLE
fix: keep protected docs out of search indexes

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -33,7 +33,8 @@
       "tests/e2e/.auth",
       "drizzle",
       "*.d.ts",
-      "public"
+      "public",
+      "private"
     ]
   }
 }

--- a/src/app/docs/[subdomain]/robots.txt/route.ts
+++ b/src/app/docs/[subdomain]/robots.txt/route.ts
@@ -1,5 +1,6 @@
 import { db } from "@/lib/db";
 import { projects } from "@/lib/db/schema";
+import { isProjectPasswordProtected } from "@/lib/project-publication-auth";
 import { generateRobotsTxt } from "@/lib/seo";
 import { eq } from "drizzle-orm";
 
@@ -21,11 +22,11 @@ export async function GET(
     return new Response("Not found", { status: 404 });
   }
 
-  // If the project has auth-required settings, disallow crawling
-  const settings = (projectResult[0].settings || {}) as Record<string, unknown>;
-  const requiresAuth = settings.requireAuth === true;
-
-  const txt = generateRobotsTxt(APP_URL, subdomain, !requiresAuth);
+  const txt = generateRobotsTxt(
+    APP_URL,
+    subdomain,
+    !isProjectPasswordProtected(projectResult[0].settings),
+  );
 
   return new Response(txt, {
     headers: {

--- a/src/app/docs/[subdomain]/sitemap.xml/route.ts
+++ b/src/app/docs/[subdomain]/sitemap.xml/route.ts
@@ -1,5 +1,6 @@
 import { db } from "@/lib/db";
 import { pages, projects } from "@/lib/db/schema";
+import { isProjectPasswordProtected } from "@/lib/project-publication-auth";
 import { generateSitemapEntries, renderSitemapXml } from "@/lib/seo";
 import { and, eq } from "drizzle-orm";
 
@@ -12,13 +13,22 @@ export async function GET(
   const { subdomain } = await params;
 
   const projectResult = await db
-    .select({ id: projects.id })
+    .select({ id: projects.id, settings: projects.settings })
     .from(projects)
     .where(eq(projects.subdomain, subdomain))
     .limit(1);
 
   if (projectResult.length === 0) {
     return new Response("Not found", { status: 404 });
+  }
+
+  if (isProjectPasswordProtected(projectResult[0].settings)) {
+    return new Response(renderSitemapXml([]), {
+      headers: {
+        "Content-Type": "application/xml; charset=utf-8",
+        "Cache-Control": "private, no-store",
+      },
+    });
   }
 
   const allPages = await db

--- a/src/lib/project-publication-auth.ts
+++ b/src/lib/project-publication-auth.ts
@@ -1,0 +1,7 @@
+import { readProjectAuthenticationSettings } from "@/lib/project-authentication-settings";
+
+export function isProjectPasswordProtected(
+  settings: unknown,
+): settings is Record<string, unknown> {
+  return readProjectAuthenticationSettings(settings).mode === "password";
+}

--- a/tests/project-authentication-settings.test.ts
+++ b/tests/project-authentication-settings.test.ts
@@ -5,6 +5,7 @@ import {
   readProjectAuthenticationSettings,
   validateProjectAuthenticationSettings,
 } from "@/lib/project-authentication-settings";
+import { isProjectPasswordProtected } from "@/lib/project-publication-auth";
 
 describe("project authentication settings", () => {
   it("defaults to public authentication", () => {
@@ -49,5 +50,19 @@ describe("project authentication settings", () => {
     expect(
       validateProjectAuthenticationSettings({ mode: "password", password: "" }),
     ).toBe("Password protection requires a password.");
+  });
+
+  it("detects password-protected published docs settings", () => {
+    expect(
+      isProjectPasswordProtected({
+        authentication: { mode: "password", password: "secret" },
+      }),
+    ).toBe(true);
+    expect(
+      isProjectPasswordProtected({
+        authentication: { mode: "public", password: "" },
+      }),
+    ).toBe(false);
+    expect(isProjectPasswordProtected({ requireAuth: true })).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- use project authentication settings to disallow robots crawling for password-protected docs
- return an empty private/no-store sitemap for password-protected docs
- ignore private deployment scratch files in Biome so runtime-only artifacts do not break lint

## Verification
- npm run lint
- npm test -- tests/project-authentication-settings.test.ts tests/seo.test.ts