### PR TITLE
feat: enforce password access for published docs

### DIFF
--- a/src/app/api/docs/[subdomain]/auth/route.ts
+++ b/src/app/api/docs/[subdomain]/auth/route.ts
@@ -1,0 +1,47 @@
+import { db } from "@/lib/db";
+import { projects } from "@/lib/db/schema";
+import {
+  createDocsAccessToken,
+  getDocsAccessCookieName,
+  isValidDocsPassword,
+} from "@/lib/project-docs-access";
+import { eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ subdomain: string }> },
+) {
+  const { subdomain } = await params;
+  const formData = await request.formData();
+  const password = String(formData.get("password") ?? "");
+  const returnTo = String(formData.get("returnTo") ?? `/docs/${subdomain}`);
+
+  const [project] = await db
+    .select({ settings: projects.settings })
+    .from(projects)
+    .where(eq(projects.subdomain, subdomain))
+    .limit(1);
+
+  if (!project) {
+    return NextResponse.redirect(new URL(`/docs/${subdomain}`, request.url));
+  }
+
+  if (!isValidDocsPassword(project.settings, password)) {
+    const url = new URL(`/docs/${subdomain}`, request.url);
+    url.searchParams.set("auth", "failed");
+    return NextResponse.redirect(url);
+  }
+
+  const response = NextResponse.redirect(new URL(returnTo, request.url));
+  response.cookies.set({
+    name: getDocsAccessCookieName(subdomain),
+    value: createDocsAccessToken(subdomain, password),
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 60 * 60 * 24 * 30,
+  });
+  return response;
+}

--- a/src/app/api/docs/[subdomain]/chat/route.ts
+++ b/src/app/api/docs/[subdomain]/chat/route.ts
@@ -17,6 +17,10 @@ import {
 import { db } from "@/lib/db";
 import { assistantConversations, pages, projects } from "@/lib/db/schema";
 import {
+  getDocsAccessCookieName,
+  hasValidDocsAccess,
+} from "@/lib/project-docs-access";
+import {
   BedrockRuntimeClient,
   ConverseStreamCommand,
 } from "@aws-sdk/client-bedrock-runtime";
@@ -34,7 +38,11 @@ export async function POST(
 
   // ── Find project by subdomain ──────────────────────────────────────────────
   const projectResult = await db
-    .select({ id: projects.id, name: projects.name })
+    .select({
+      id: projects.id,
+      name: projects.name,
+      settings: projects.settings,
+    })
     .from(projects)
     .where(eq(projects.subdomain, subdomain))
     .limit(1);
@@ -44,6 +52,18 @@ export async function POST(
   }
 
   const project = projectResult[0];
+  if (
+    !hasValidDocsAccess(
+      project.settings,
+      subdomain,
+      request.cookies.get(getDocsAccessCookieName(subdomain))?.value,
+    )
+  ) {
+    return NextResponse.json(
+      { message: "Docs password required" },
+      { status: 401 },
+    );
+  }
 
   // ── Parse body ─────────────────────────────────────────────────────────────
   let body: unknown;

--- a/src/app/api/docs/[subdomain]/feedback/route.ts
+++ b/src/app/api/docs/[subdomain]/feedback/route.ts
@@ -1,8 +1,12 @@
 import { db } from "@/lib/db";
 import { analyticsEvents, projects } from "@/lib/db/schema";
 import { validateFeedbackPayload } from "@/lib/feedback";
+import {
+  getDocsAccessCookieName,
+  hasValidDocsAccess,
+} from "@/lib/project-docs-access";
 import { eq } from "drizzle-orm";
-import { NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 
 /**
  * POST /api/docs/[subdomain]/feedback
@@ -11,14 +15,14 @@ import { NextResponse } from "next/server";
  * Body: { page: string, rating: "helpful" | "not_helpful", comment?: string }
  */
 export async function POST(
-  request: Request,
+  request: NextRequest,
   { params }: { params: Promise<{ subdomain: string }> },
 ) {
   const { subdomain } = await params;
 
   // Find project by subdomain
   const [project] = await db
-    .select({ id: projects.id })
+    .select({ id: projects.id, settings: projects.settings })
     .from(projects)
     .where(eq(projects.subdomain, subdomain))
     .limit(1);
@@ -27,6 +31,19 @@ export async function POST(
     return NextResponse.json(
       { error: "Documentation site not found" },
       { status: 404 },
+    );
+  }
+
+  if (
+    !hasValidDocsAccess(
+      project.settings,
+      subdomain,
+      request.cookies.get(getDocsAccessCookieName(subdomain))?.value,
+    )
+  ) {
+    return NextResponse.json(
+      { error: "Docs password required" },
+      { status: 401 },
     );
   }
 

--- a/src/app/api/docs/[subdomain]/route.ts
+++ b/src/app/api/docs/[subdomain]/route.ts
@@ -1,11 +1,15 @@
 import { db } from "@/lib/db";
 import { pages, projects } from "@/lib/db/schema";
+import {
+  getDocsAccessCookieName,
+  hasValidDocsAccess,
+} from "@/lib/project-docs-access";
 import { and, eq } from "drizzle-orm";
-import { NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 
 /** GET /api/docs/[subdomain] — public endpoint to fetch all published pages for a docs site */
 export async function GET(
-  _request: Request,
+  request: NextRequest,
   { params }: { params: Promise<{ subdomain: string }> },
 ) {
   const { subdomain } = await params;
@@ -30,6 +34,18 @@ export async function GET(
   }
 
   const projectData = project[0];
+  if (
+    !hasValidDocsAccess(
+      projectData.settings,
+      subdomain,
+      request.cookies.get(getDocsAccessCookieName(subdomain))?.value,
+    )
+  ) {
+    return NextResponse.json(
+      { error: "Docs password required" },
+      { status: 401 },
+    );
+  }
 
   // Fetch all published pages for this project
   const publishedPages = await db

--- a/src/app/api/docs/[subdomain]/search/route.ts
+++ b/src/app/api/docs/[subdomain]/search/route.ts
@@ -15,6 +15,10 @@
 import { buildSearchQuery } from "@/lib/assistant";
 import { db } from "@/lib/db";
 import { pages, projects } from "@/lib/db/schema";
+import {
+  getDocsAccessCookieName,
+  hasValidDocsAccess,
+} from "@/lib/project-docs-access";
 import { extractSnippet, getBreadcrumb } from "@/lib/search";
 import { and, eq, ilike, or, sql } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
@@ -46,13 +50,26 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
   // Find the project by subdomain
   const projectResult = await db
-    .select({ id: projects.id })
+    .select({ id: projects.id, settings: projects.settings })
     .from(projects)
     .where(eq(projects.subdomain, subdomain))
     .limit(1);
 
   if (projectResult.length === 0) {
     return NextResponse.json({ message: "Project not found" }, { status: 404 });
+  }
+
+  if (
+    !hasValidDocsAccess(
+      projectResult[0].settings,
+      subdomain,
+      request.cookies.get(getDocsAccessCookieName(subdomain))?.value,
+    )
+  ) {
+    return NextResponse.json(
+      { message: "Docs password required" },
+      { status: 401 },
+    );
   }
 
   const projectId = projectResult[0].id;

--- a/src/app/docs/[subdomain]/[...slug]/page.tsx
+++ b/src/app/docs/[subdomain]/[...slug]/page.tsx
@@ -4,6 +4,7 @@ import { ChatWidget } from "@/components/docs/chat-widget";
 import { CustomCodeInjection } from "@/components/docs/custom-code-injection";
 import { DocsFooter } from "@/components/docs/docs-footer";
 import { DocsPagination } from "@/components/docs/docs-pagination";
+import { DocsPasswordGate } from "@/components/docs/docs-password-gate";
 import { DocsSidebar } from "@/components/docs/docs-sidebar";
 import { DocsToc } from "@/components/docs/docs-toc";
 import { DocsTopbar } from "@/components/docs/docs-topbar";
@@ -46,6 +47,10 @@ import {
   renderApiPlaygroundHtml,
 } from "@/lib/openapi-parser";
 import { getGroupName } from "@/lib/page-chrome";
+import {
+  getDocsAccessCookieName,
+  hasValidDocsAccess,
+} from "@/lib/project-docs-access";
 import { buildPageMetadata } from "@/lib/seo";
 import {
   buildVariablesMap,
@@ -61,10 +66,12 @@ import {
 } from "@/lib/versions";
 import { and, eq } from "drizzle-orm";
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import { notFound, permanentRedirect } from "next/navigation";
 
 interface DocsPageProps {
   params: Promise<{ subdomain: string; slug: string[] }>;
+  searchParams?: Promise<{ auth?: string }>;
 }
 
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3015";
@@ -199,8 +206,12 @@ export async function generateMetadata({
   return metadata;
 }
 
-export default async function DocsPage({ params }: DocsPageProps) {
+export default async function DocsPage({
+  params,
+  searchParams,
+}: DocsPageProps) {
   const { subdomain, slug } = await params;
+  const query = await searchParams;
 
   // Find project
   const projectResult = await db
@@ -219,6 +230,21 @@ export default async function DocsPage({ params }: DocsPageProps) {
   }
 
   const project = projectResult[0];
+  const cookieStore = await cookies();
+  if (
+    !hasValidDocsAccess(
+      project.settings,
+      subdomain,
+      cookieStore.get(getDocsAccessCookieName(subdomain))?.value,
+    )
+  ) {
+    return (
+      <DocsPasswordGate
+        subdomain={subdomain}
+        error={query?.auth === "failed" ? "Incorrect password." : undefined}
+      />
+    );
+  }
 
   // Parse i18n + versions configuration
   const docsSettings = (project.settings || {}) as Record<string, unknown>;

--- a/src/app/docs/[subdomain]/page.tsx
+++ b/src/app/docs/[subdomain]/page.tsx
@@ -1,24 +1,51 @@
+import { DocsPasswordGate } from "@/components/docs/docs-password-gate";
 import { db } from "@/lib/db";
 import { pages, projects } from "@/lib/db/schema";
+import {
+  getDocsAccessCookieName,
+  hasValidDocsAccess,
+} from "@/lib/project-docs-access";
 import { and, eq } from "drizzle-orm";
+import { cookies } from "next/headers";
 import { notFound, redirect } from "next/navigation";
 
 interface DocsIndexProps {
   params: Promise<{ subdomain: string }>;
+  searchParams?: Promise<{ auth?: string }>;
 }
 
 /** Docs site index: redirects to the first published page or shows a 404 */
-export default async function DocsIndex({ params }: DocsIndexProps) {
+export default async function DocsIndex({
+  params,
+  searchParams,
+}: DocsIndexProps) {
   const { subdomain } = await params;
+  const query = await searchParams;
 
   const projectResult = await db
-    .select({ id: projects.id })
+    .select({ id: projects.id, settings: projects.settings })
     .from(projects)
     .where(eq(projects.subdomain, subdomain))
     .limit(1);
 
   if (projectResult.length === 0) {
     notFound();
+  }
+
+  const cookieStore = await cookies();
+  if (
+    !hasValidDocsAccess(
+      projectResult[0].settings,
+      subdomain,
+      cookieStore.get(getDocsAccessCookieName(subdomain))?.value,
+    )
+  ) {
+    return (
+      <DocsPasswordGate
+        subdomain={subdomain}
+        error={query?.auth === "failed" ? "Incorrect password." : undefined}
+      />
+    );
   }
 
   // 1. Try to find 'introduction' first

--- a/src/components/docs/docs-password-gate.tsx
+++ b/src/components/docs/docs-password-gate.tsx
@@ -1,0 +1,43 @@
+interface DocsPasswordGateProps {
+  subdomain: string;
+  error?: string;
+}
+
+export function DocsPasswordGate({ subdomain, error }: DocsPasswordGateProps) {
+  return (
+    <main className="min-h-screen bg-[#0b0b0b] text-white flex items-center justify-center px-6">
+      <form
+        action={`/api/docs/${subdomain}/auth`}
+        method="post"
+        className="w-full max-w-sm rounded-2xl border border-white/10 bg-white/[0.03] p-6 shadow-2xl"
+      >
+        <div className="mb-5">
+          <p className="text-xs uppercase tracking-[0.25em] text-emerald-300/80">
+            Protected docs
+          </p>
+          <h1 className="mt-2 text-2xl font-semibold">Enter password</h1>
+          <p className="mt-2 text-sm text-gray-400">
+            This documentation site is password-protected.
+          </p>
+        </div>
+        <input type="hidden" name="returnTo" value={`/docs/${subdomain}`} />
+        <label className="block text-sm font-medium text-gray-200">
+          Password
+          <input
+            className="mt-2 w-full rounded-lg border border-white/10 bg-[#151515] px-3 py-2 text-white outline-none focus:border-emerald-400"
+            name="password"
+            type="password"
+            required
+          />
+        </label>
+        {error && <p className="mt-3 text-sm text-red-300">{error}</p>}
+        <button
+          className="mt-5 w-full rounded-lg bg-emerald-500 px-4 py-2 font-medium text-black hover:bg-emerald-400"
+          type="submit"
+        >
+          Continue
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/src/lib/project-docs-access.ts
+++ b/src/lib/project-docs-access.ts
@@ -1,0 +1,49 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { readProjectAuthenticationSettings } from "@/lib/project-authentication-settings";
+
+const COOKIE_PREFIX = "docs_access";
+
+export function getDocsAccessCookieName(subdomain: string) {
+  return `${COOKIE_PREFIX}_${subdomain.replace(/[^a-zA-Z0-9_-]/g, "_")}`;
+}
+
+function getSigningSecret() {
+  return process.env.BETTER_AUTH_SECRET || "development-docs-access-secret";
+}
+
+export function createDocsAccessToken(subdomain: string, password: string) {
+  return createHmac("sha256", getSigningSecret())
+    .update(`${subdomain}:${password}`)
+    .digest("hex");
+}
+
+function safeEqual(a: string, b: string) {
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+type ProjectSettings = Record<string, unknown> | null | undefined;
+
+export function isDocsAccessRequired(settings: ProjectSettings) {
+  return readProjectAuthenticationSettings(settings).mode === "password";
+}
+
+export function isValidDocsPassword(
+  settings: ProjectSettings,
+  password: string,
+) {
+  const auth = readProjectAuthenticationSettings(settings);
+  return auth.mode === "password" && safeEqual(auth.password, password);
+}
+
+export function hasValidDocsAccess(
+  settings: ProjectSettings,
+  subdomain: string,
+  token: string | undefined,
+) {
+  const auth = readProjectAuthenticationSettings(settings);
+  if (auth.mode !== "password") return true;
+  if (!token) return false;
+  return safeEqual(token, createDocsAccessToken(subdomain, auth.password));
+}

--- a/src/lib/project-publication-auth.ts
+++ b/src/lib/project-publication-auth.ts
@@ -1,7 +1,7 @@
 import { readProjectAuthenticationSettings } from "@/lib/project-authentication-settings";
 
 export function isProjectPasswordProtected(
-  settings: unknown,
+  settings: Record<string, unknown> | null | undefined,
 ): settings is Record<string, unknown> {
   return readProjectAuthenticationSettings(settings).mode === "password";
 }

--- a/tests/project-authentication-settings.test.ts
+++ b/tests/project-authentication-settings.test.ts
@@ -5,6 +5,11 @@ import {
   readProjectAuthenticationSettings,
   validateProjectAuthenticationSettings,
 } from "@/lib/project-authentication-settings";
+import {
+  createDocsAccessToken,
+  hasValidDocsAccess,
+  isValidDocsPassword,
+} from "@/lib/project-docs-access";
 import { isProjectPasswordProtected } from "@/lib/project-publication-auth";
 
 describe("project authentication settings", () => {
@@ -50,6 +55,29 @@ describe("project authentication settings", () => {
     expect(
       validateProjectAuthenticationSettings({ mode: "password", password: "" }),
     ).toBe("Password protection requires a password.");
+  });
+
+  it("validates docs access passwords and cookies", () => {
+    const settings = {
+      authentication: { mode: "password", password: "secret" },
+    };
+    expect(isValidDocsPassword(settings, "secret")).toBe(true);
+    expect(isValidDocsPassword(settings, "wrong")).toBe(false);
+    expect(hasValidDocsAccess(settings, "docs", undefined)).toBe(false);
+    expect(
+      hasValidDocsAccess(
+        settings,
+        "docs",
+        createDocsAccessToken("docs", "secret"),
+      ),
+    ).toBe(true);
+    expect(
+      hasValidDocsAccess(
+        { authentication: { mode: "public" } },
+        "docs",
+        undefined,
+      ),
+    ).toBe(true);
   });
 
   it("detects password-protected published docs settings", () => {


### PR DESCRIPTION
## Summary
- add a password gate for password-protected docs sites
- issue an HttpOnly docs access cookie after successful password submission
- block published docs APIs (page payload, search, chat, feedback) unless the docs access cookie is valid

## Verification
- npm run lint
- npm test -- tests/project-authentication-settings.test.ts tests/seo.test.ts
- npx tsc --noEmit --pretty false