### PR TITLE
fix: constrain docs auth return paths

### DIFF
--- a/src/app/api/docs/[subdomain]/auth/route.ts
+++ b/src/app/api/docs/[subdomain]/auth/route.ts
@@ -8,6 +8,13 @@ import {
 import { eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
+export function normalizeDocsReturnTo(returnTo: string, subdomain: string) {
+  const fallback = `/docs/${subdomain}`;
+  if (!returnTo.startsWith(fallback)) return fallback;
+  if (returnTo.startsWith("//") || returnTo.includes("://")) return fallback;
+  return returnTo;
+}
+
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ subdomain: string }> },
@@ -15,7 +22,10 @@ export async function POST(
   const { subdomain } = await params;
   const formData = await request.formData();
   const password = String(formData.get("password") ?? "");
-  const returnTo = String(formData.get("returnTo") ?? `/docs/${subdomain}`);
+  const returnTo = normalizeDocsReturnTo(
+    String(formData.get("returnTo") ?? ""),
+    subdomain,
+  );
 
   const [project] = await db
     .select({ settings: projects.settings })

--- a/tests/docs-auth-route.test.ts
+++ b/tests/docs-auth-route.test.ts
@@ -1,0 +1,18 @@
+import { normalizeDocsReturnTo } from "@/app/api/docs/[subdomain]/auth/route";
+import { describe, expect, it } from "vitest";
+
+describe("docs auth route", () => {
+  it("allows same-site docs return paths", () => {
+    expect(normalizeDocsReturnTo("/docs/acme/intro", "acme")).toBe(
+      "/docs/acme/intro",
+    );
+  });
+
+  it("falls back when returnTo points outside the docs site", () => {
+    expect(normalizeDocsReturnTo("/settings", "acme")).toBe("/docs/acme");
+    expect(normalizeDocsReturnTo("https://evil.test", "acme")).toBe(
+      "/docs/acme",
+    );
+    expect(normalizeDocsReturnTo("//evil.test", "acme")).toBe("/docs/acme");
+  });
+});


### PR DESCRIPTION
## Summary
- normalize docs password return paths to same-site docs URLs
- prevent external or unrelated return targets after password submission
- add route helper coverage

## Verification
- npm run lint
- npm test -- tests/docs-auth-route.test.ts tests/project-authentication-settings.test.ts
- npx tsc --noEmit --pretty false