### PR TITLE
chore: rename app branding to OpenDocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# namuh-mintlify
+# OpenDocs
 
-[![GitHub stars](https://img.shields.io/github/stars/namuh-eng/namuh-mintlify?style=flat-square)](https://github.com/namuh-eng/namuh-mintlify)
+[![GitHub stars](https://img.shields.io/github/stars/namuh-eng/opendocs?style=flat-square)](https://github.com/namuh-eng/opendocs)
 [![License: ELv2](https://img.shields.io/badge/License-Elastic%202.0-blue.svg?style=flat-square)](LICENSE)
 
 **Open source Mintlify alternative — AI-native documentation platform for developer teams.**
@@ -11,7 +11,7 @@ A fully functional clone of [Mintlify](https://mintlify.com) built with Next.js 
 
 ## About
 
-namuh-mintlify is a production-grade documentation platform that gives you the full Mintlify experience on your own infrastructure. Create organizations, manage documentation projects, write content in a dual-mode editor (visual WYSIWYG or markdown), and deploy beautiful docs sites with AI assistant, full-text search, and OpenAPI auto-documentation.
+OpenDocs is a production-grade documentation platform that gives you the full Mintlify experience on your own infrastructure. Create organizations, manage documentation projects, write content in a dual-mode editor (visual WYSIWYG or markdown), and deploy beautiful docs sites with AI assistant, full-text search, and OpenAPI auto-documentation.
 
 ---
 
@@ -58,8 +58,8 @@ namuh-mintlify is a production-grade documentation platform that gives you the f
 
 ```bash
 # Clone the repository
-git clone https://github.com/namuh-eng/namuh-mintlify.git
-cd namuh-mintlify
+git clone https://github.com/namuh-eng/opendocs.git
+cd opendocs
 
 # Install dependencies
 npm install
@@ -78,8 +78,8 @@ npm run dev
 ### Docker (Coming Soon)
 
 ```bash
-git clone https://github.com/namuh-eng/namuh-mintlify.git
-cd namuh-mintlify
+git clone https://github.com/namuh-eng/opendocs.git
+cd opendocs
 docker compose up
 ```
 
@@ -146,7 +146,7 @@ DASHBOARD_KEY=your-dashboard-key
 ## Project Structure
 
 ```
-namuh-mintlify/
+opendocs/
 ├── src/
 │   ├── app/              # Next.js App Router
 │   │   ├── (auth)/       # Login, signup pages
@@ -188,7 +188,7 @@ We welcome contributions! Whether it's bug fixes, new features, or improvements 
 
 ## Support
 
-- **Issues** — Report bugs or request features on [GitHub Issues](https://github.com/namuh-eng/namuh-mintlify/issues)
+- **Issues** — Report bugs or request features on [GitHub Issues](https://github.com/namuh-eng/opendocs/issues)
 
 ---
 

--- a/docs/deployment/opendocs-production.md
+++ b/docs/deployment/opendocs-production.md
@@ -9,7 +9,7 @@ AWS account: `699486076867`
 
 - ECS cluster: `opendocs`
 - ECS service: `opendocs`
-- Task definition family: `opendocs`
+- Task definition family: `opendocs` (current verified revision: `opendocs:3`)
 - ECR repository: `699486076867.dkr.ecr.us-east-1.amazonaws.com/opendocs`
 - Current image tag: `c4c9167`
 - ALB: `opendocs-alb`
@@ -22,6 +22,8 @@ AWS account: `699486076867`
   - `opendocs/db-password`
   - `opendocs/database-url`
   - `opendocs/better-auth-secret`
+  - `opendocs/google-client-id`
+  - `opendocs/google-client-secret`
 
 Secret values must never be committed, printed, or pasted into chat.
 
@@ -44,7 +46,7 @@ Verified health response through the ALB:
 
 `https://opendocs.namuh.co` is live. ACM validation completed through Cloudflare DNS, and the ALB has an HTTPS listener on port 443.
 
-## DNS / certificate blocker
+## DNS / certificate state
 
 `namuh.co` is Cloudflare-authoritative:
 
@@ -86,8 +88,20 @@ aws ecr get-login-password --region us-east-1 \
 ```
 
 - This repo does not currently have generated Drizzle migration files in `./drizzle`; `npm run db:migrate` failed without useful detail. For the initial production database, `npm run db:push -- --force` applied the schema successfully. Future work should add proper migration artifacts before relying on `db:migrate` in production.
-- The app can boot without Google OAuth credentials, but Better Auth logs a warning and Google login will not work until `AUTH_GOOGLE_ID` and `AUTH_GOOGLE_SECRET` are provided.
+- The app can boot without Google OAuth credentials, but Google login will not work unless `AUTH_GOOGLE_ID` and `AUTH_GOOGLE_SECRET` are present in the ECS task definition.
+- This deployment intentionally uses ECS Fargate + ALB. Do not deploy OpenDocs with AWS App Runner.
 - Keep repo changes on agent branches with PRs into `staging`; deployment resource mutations are external operations and should be documented here without secrets.
+
+## Google OAuth production checklist
+
+For `https://opendocs.namuh.co` Google sign-in, the Google Cloud OAuth client must include:
+
+- Authorized JavaScript origin: `https://opendocs.namuh.co`
+- Authorized redirect URI: `https://opendocs.namuh.co/api/auth/callback/google`
+- OAuth consent screen authorized domain: `namuh.co`
+- If the OAuth app is still in testing, the intended login account must be listed as a test user.
+
+Shadowfax can verify AWS/ECS runtime wiring locally, but Google Cloud Console verification requires an authenticated `gcloud` account/project or browser access to the correct Google Cloud project.
 
 ## HTTPS completion update - 2026-04-29
 
@@ -96,3 +110,9 @@ aws ecr get-login-password --region us-east-1 \
 - ALB HTTPS listener: active on port `443`.
 - Verified `https://opendocs.namuh.co` returns HTTP 200.
 - Verified `https://opendocs.namuh.co/api/health` returns `status: ok`, version `c4c9167`, database connected, and storage available.
+
+## OAuth runtime update - 2026-04-30
+
+- `AUTH_GOOGLE_ID` and `AUTH_GOOGLE_SECRET` are now wired into ECS task definition `opendocs:3` from Secrets Manager.
+- Production sign-in smoke check returned a Google OAuth URL with redirect URI `https://opendocs.namuh.co/api/auth/callback/google`, no Better Auth server error.
+- Remaining console-side requirement: Google Cloud OAuth client and consent screen must include the production origin/redirect/domain listed above. This cannot be verified from this machine until `gcloud` is authenticated to the correct Google Cloud project.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "namuh-mintlify",
+  "name": "opendocs",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "namuh-mintlify",
+      "name": "opendocs",
       "version": "0.1.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1036.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "namuh-mintlify",
+  "name": "opendocs",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Deploy: Docker build → ECR push → App Runner deploy
+# Deploy: Docker build -> ECR push -> ECS Fargate service update
 # Usage: bash scripts/deploy.sh [tag]
 #   tag: Docker image tag (default: git SHA or "latest")
 set -euo pipefail
@@ -7,17 +7,20 @@ cd "$(dirname "$0")/.."
 
 APP_NAME="opendocs"
 AWS_REGION="${AWS_REGION:-us-east-1}"
+ECS_CLUSTER="${ECS_CLUSTER:-opendocs}"
+ECS_SERVICE="${ECS_SERVICE:-opendocs}"
+CONTAINER_NAME="${CONTAINER_NAME:-opendocs}"
 IMAGE_TAG="${1:-$(git rev-parse --short HEAD 2>/dev/null || echo 'latest')}"
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 ECR_URI="${ECR_URI:-${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/${APP_NAME}}"
-SERVICE_NAME="${APP_NAME}-prod"
-PORT=3000
+
 
 echo "=== Deploy: ${APP_NAME} ==="
-echo "  ECR:     ${ECR_URI}"
-echo "  Tag:     ${IMAGE_TAG}"
-echo "  Region:  ${AWS_REGION}"
-echo "  Service: ${SERVICE_NAME}"
+echo "  ECR:      ${ECR_URI}"
+echo "  Tag:      ${IMAGE_TAG}"
+echo "  Region:   ${AWS_REGION}"
+echo "  Cluster:  ${ECS_CLUSTER}"
+echo "  Service:  ${ECS_SERVICE}"
 echo ""
 
 # 1. Build Docker image
@@ -31,209 +34,126 @@ docker build \
   .
 echo "Docker build complete ✓"
 
-# 2. Tag for ECR
+# 2. Ensure ECR repository exists
+echo ""
+echo "--- Ensuring ECR repository ---"
+aws ecr describe-repositories \
+  --repository-names "${APP_NAME}" \
+  --region "${AWS_REGION}" >/dev/null 2>&1 || \
+  aws ecr create-repository \
+    --repository-name "${APP_NAME}" \
+    --region "${AWS_REGION}" \
+    --image-scanning-configuration scanOnPush=true \
+    --output text >/dev/null
+echo "ECR repository ready ✓"
+
+# 3. Tag for ECR
 echo ""
 echo "--- Tagging for ECR ---"
 docker tag "${APP_NAME}:${IMAGE_TAG}" "${ECR_URI}:${IMAGE_TAG}"
 docker tag "${APP_NAME}:latest" "${ECR_URI}:latest"
 echo "Tagged ✓"
 
-# 3. Authenticate with ECR
+# 4. Authenticate with ECR
 echo ""
 echo "--- Authenticating with ECR ---"
 aws ecr get-login-password --region "$AWS_REGION" \
   | docker login --username AWS --password-stdin "${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
 echo "ECR login ✓"
 
-# 4. Push to ECR
+# 5. Push to ECR
 echo ""
 echo "--- Pushing to ECR ---"
 docker push "${ECR_URI}:${IMAGE_TAG}"
 docker push "${ECR_URI}:latest"
 echo "ECR push complete ✓"
 
-# 5. Build env vars JSON for App Runner
+# 6. Register a new ECS task definition revision with the new image
 echo ""
-echo "--- Preparing environment ---"
-ENV_VARS='{}'
+echo "--- Registering ECS task definition revision ---"
+CURRENT_TASK_DEF=$(aws ecs describe-services \
+  --cluster "${ECS_CLUSTER}" \
+  --services "${ECS_SERVICE}" \
+  --region "${AWS_REGION}" \
+  --query 'services[0].taskDefinition' \
+  --output text)
 
-# Read allowed env vars from .env
-ALLOWED_VARS=(
-  DATABASE_URL
-  DB_SSL
-  BETTER_AUTH_SECRET
-  BETTER_AUTH_URL
-  AUTH_GOOGLE_ID
-  AUTH_GOOGLE_SECRET
-  S3_BUCKET
-  AWS_REGION
-  NEXT_PUBLIC_APP_URL
-  ANTHROPIC_API_KEY
-  GITHUB_WEBHOOK_SECRET
-  ENABLE_ASYNC_SIMULATION
-  GITHUB_APP_ID
-  GITHUB_APP_PRIVATE_KEY
-)
-
-for VAR in "${ALLOWED_VARS[@]}"; do
-  VALUE=$(grep "^${VAR}=" .env 2>/dev/null | cut -d= -f2- || true)
-  if [ -n "$VALUE" ]; then
-    ENV_VARS=$(echo "$ENV_VARS" | jq --arg k "$VAR" --arg v "$VALUE" '. + {($k): $v}')
-  fi
-done
-
-# Always set NODE_ENV and APP_VERSION
-ENV_VARS=$(echo "$ENV_VARS" | jq \
-  --arg ver "$IMAGE_TAG" \
-  '. + {"NODE_ENV": "production", "APP_VERSION": $ver}')
-
-# 6. Deploy to App Runner
-echo ""
-echo "--- Deploying to App Runner ---"
-
-# Check if service exists
-SERVICE_ARN=$(aws apprunner list-services --region "$AWS_REGION" \
-  --query "ServiceSummaryList[?ServiceName=='${SERVICE_NAME}'].ServiceArn" \
-  --output text 2>/dev/null || echo "")
-
-if [ -n "$SERVICE_ARN" ] && [ "$SERVICE_ARN" != "None" ]; then
-  echo "Updating existing service: ${SERVICE_NAME}"
-
-  # Update service with new image
-  aws apprunner update-service \
-    --service-arn "$SERVICE_ARN" \
-    --source-configuration "{
-      \"ImageRepository\": {
-        \"ImageIdentifier\": \"${ECR_URI}:${IMAGE_TAG}\",
-        \"ImageRepositoryType\": \"ECR\",
-        \"ImageConfiguration\": {
-          \"Port\": \"${PORT}\",
-          \"RuntimeEnvironmentVariables\": ${ENV_VARS}
-        }
-      },
-      \"AutoDeploymentsEnabled\": false,
-      \"AuthenticationConfiguration\": {
-        \"AccessRoleArn\": \"arn:aws:iam::${ACCOUNT_ID}:role/${APP_NAME}-apprunner-ecr-role\"
-      }
-    }" \
-    --region "$AWS_REGION" \
-    --output text > /dev/null
-
-  echo "Service update initiated ✓"
-else
-  echo "Creating new App Runner service: ${SERVICE_NAME}"
-
-  # Create IAM role for App Runner to pull from ECR (if not exists)
-  ROLE_NAME="${APP_NAME}-apprunner-ecr-role"
-  if ! aws iam get-role --role-name "$ROLE_NAME" > /dev/null 2>&1; then
-    echo "Creating IAM role: ${ROLE_NAME}"
-    aws iam create-role \
-      --role-name "$ROLE_NAME" \
-      --assume-role-policy-document '{
-        "Version": "2012-10-17",
-        "Statement": [{
-          "Effect": "Allow",
-          "Principal": {"Service": "build.apprunner.amazonaws.com"},
-          "Action": "sts:AssumeRole"
-        }]
-      }' \
-      --output text > /dev/null
-
-    aws iam attach-role-policy \
-      --role-name "$ROLE_NAME" \
-      --policy-arn "arn:aws:iam::aws:policy/service-role/AWSAppRunnerServicePolicyForECRAccess"
-
-    echo "Waiting for role propagation..."
-    sleep 10
-  fi
-
-  ROLE_ARN=$(aws iam get-role --role-name "$ROLE_NAME" \
-    --query 'Role.Arn' --output text)
-
-  # Create the App Runner service
-  aws apprunner create-service \
-    --service-name "$SERVICE_NAME" \
-    --source-configuration "{
-      \"ImageRepository\": {
-        \"ImageIdentifier\": \"${ECR_URI}:${IMAGE_TAG}\",
-        \"ImageRepositoryType\": \"ECR\",
-        \"ImageConfiguration\": {
-          \"Port\": \"${PORT}\",
-          \"RuntimeEnvironmentVariables\": ${ENV_VARS}
-        }
-      },
-      \"AutoDeploymentsEnabled\": false,
-      \"AuthenticationConfiguration\": {
-        \"AccessRoleArn\": \"${ROLE_ARN}\"
-      }
-    }" \
-    --instance-configuration "{
-      \"Cpu\": \"1024\",
-      \"Memory\": \"2048\"
-    }" \
-    --health-check-configuration "{
-      \"Protocol\": \"TCP\",
-      \"Interval\": 10,
-      \"Timeout\": 5,
-      \"HealthyThreshold\": 1,
-      \"UnhealthyThreshold\": 5
-    }" \
-    --region "$AWS_REGION" \
-    --output text > /dev/null
-
-  echo "Service creation initiated ✓"
+if [ -z "${CURRENT_TASK_DEF}" ] || [ "${CURRENT_TASK_DEF}" = "None" ]; then
+  echo "No active task definition found for ${ECS_CLUSTER}/${ECS_SERVICE}" >&2
+  exit 1
 fi
 
-# 7. Wait for deployment and get URL
+TASK_DEF_JSON=$(aws ecs describe-task-definition \
+  --task-definition "${CURRENT_TASK_DEF}" \
+  --region "${AWS_REGION}" \
+  --query 'taskDefinition')
+
+NEW_TASK_DEF=$(echo "${TASK_DEF_JSON}" | jq \
+  --arg image "${ECR_URI}:${IMAGE_TAG}" \
+  --arg container "${CONTAINER_NAME}" \
+  --arg version "${IMAGE_TAG}" \
+  'del(
+      .taskDefinitionArn,
+      .revision,
+      .status,
+      .requiresAttributes,
+      .compatibilities,
+      .registeredAt,
+      .registeredBy
+    )
+    | .containerDefinitions = (.containerDefinitions | map(
+        if .name == $container then
+          .image = $image
+          | .environment = ((.environment // [])
+              | map(if .name == "APP_VERSION" then .value = $version else . end))
+        else . end
+      ))')
+
+NEW_TASK_DEF_ARN=$(aws ecs register-task-definition \
+  --region "${AWS_REGION}" \
+  --cli-input-json "${NEW_TASK_DEF}" \
+  --query 'taskDefinition.taskDefinitionArn' \
+  --output text)
+echo "Registered ${NEW_TASK_DEF_ARN} ✓"
+
+# 7. Update ECS service
 echo ""
-echo "--- Waiting for deployment ---"
-echo "(This may take 3-5 minutes for first deploy...)"
+echo "--- Updating ECS service ---"
+aws ecs update-service \
+  --cluster "${ECS_CLUSTER}" \
+  --service "${ECS_SERVICE}" \
+  --task-definition "${NEW_TASK_DEF_ARN}" \
+  --force-new-deployment \
+  --region "${AWS_REGION}" \
+  --output text >/dev/null
+echo "Service update initiated ✓"
 
-# Poll for service status
-for i in $(seq 1 60); do
-  STATUS=$(aws apprunner describe-service \
-    --service-arn "$(aws apprunner list-services --region "$AWS_REGION" \
-      --query "ServiceSummaryList[?ServiceName=='${SERVICE_NAME}'].ServiceArn" \
-      --output text)" \
-    --region "$AWS_REGION" \
-    --query 'Service.Status' --output text 2>/dev/null || echo "UNKNOWN")
+# 8. Wait for stability
+echo ""
+echo "--- Waiting for ECS service stability ---"
+aws ecs wait services-stable \
+  --cluster "${ECS_CLUSTER}" \
+  --services "${ECS_SERVICE}" \
+  --region "${AWS_REGION}"
+echo "Service stable ✓"
 
-  if [ "$STATUS" = "RUNNING" ]; then
-    break
-  fi
-  echo "  Status: ${STATUS} (attempt ${i}/60)"
-  sleep 10
-done
-
-# Get the service URL
-SERVICE_URL=$(aws apprunner describe-service \
-  --service-arn "$(aws apprunner list-services --region "$AWS_REGION" \
-    --query "ServiceSummaryList[?ServiceName=='${SERVICE_NAME}'].ServiceArn" \
-    --output text)" \
-  --region "$AWS_REGION" \
-  --query 'Service.ServiceUrl' --output text 2>/dev/null || echo "")
+# 9. Verify health check
+echo ""
+echo "--- Verifying production health ---"
+HEALTH_URL="${HEALTH_URL:-https://opendocs.namuh.co/api/health}"
+HEALTH=$(curl -fsS "${HEALTH_URL}")
+echo "${HEALTH}" | jq .
+STATUS=$(echo "${HEALTH}" | jq -r '.status')
+VERSION=$(echo "${HEALTH}" | jq -r '.version')
+if [ "${STATUS}" != "ok" ]; then
+  echo "Health check failed: ${STATUS}" >&2
+  exit 1
+fi
+if [ "${VERSION}" != "${IMAGE_TAG}" ]; then
+  echo "Warning: health version is ${VERSION}, expected ${IMAGE_TAG}. The ALB may still be draining old tasks." >&2
+fi
 
 echo ""
 echo "=== Deploy Complete ==="
-if [ -n "$SERVICE_URL" ] && [ "$SERVICE_URL" != "None" ]; then
-  echo "  URL:    https://${SERVICE_URL}"
-  echo "  Health: https://${SERVICE_URL}/api/health"
-  echo ""
-
-  # 8. Verify health check
-  echo "--- Verifying health check ---"
-  HEALTH=$(curl -s "https://${SERVICE_URL}/api/health" 2>/dev/null || echo '{"status":"unreachable"}')
-  echo "  Response: ${HEALTH}"
-
-  STATUS=$(echo "$HEALTH" | jq -r '.status' 2>/dev/null || echo "unknown")
-  if [ "$STATUS" = "ok" ]; then
-    echo "  Health check: PASSED ✓"
-  else
-    echo "  Health check: ${STATUS} (may need a moment to warm up)"
-  fi
-else
-  echo "  Service URL not yet available — check AWS console"
-fi
-
-echo ""
-echo "Done."
+echo "  URL:    https://opendocs.namuh.co"
+echo "  Health: ${HEALTH_URL}"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-APP_NAME="namuh-mintlify"
+APP_NAME="opendocs"
 AWS_REGION="${AWS_REGION:-us-east-1}"
 IMAGE_TAG="${1:-$(git rev-parse --short HEAD 2>/dev/null || echo 'latest')}"
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -4,10 +4,10 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-APP_NAME="namuh-mintlify"
+APP_NAME="opendocs"
 AWS_REGION="${AWS_REGION:-us-east-1}"
-DB_NAME="namuh_mintlify"
-DB_USER="mintlify_admin"
+DB_NAME="opendocs"
+DB_USER="opendocs_admin"
 DB_INSTANCE_CLASS="${DB_INSTANCE_CLASS:-db.t3.micro}"
 
 echo "=== Pre-flight Setup (AWS Full Stack) ==="

--- a/src/app/api/admin/canary/route.ts
+++ b/src/app/api/admin/canary/route.ts
@@ -10,7 +10,7 @@ import { type NextRequest, NextResponse } from "next/server";
  * POST /api/admin/canary
  *
  * Mock canary/rollback control endpoint. Admins only.
- * In a real environment, this would interface with App Runner/ECS/CloudWatch.
+ * In a real environment, this would interface with ECS/CloudWatch.
  */
 export async function POST(request: NextRequest) {
   const requestId = createRequestId();

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -55,7 +55,7 @@ export async function GET() {
     storageAvailable,
   });
 
-  // Always return 200 for container liveness checks (App Runner, ECS, K8s).
+  // Always return 200 for container liveness checks (ECS, K8s).
   // Degraded status is reported in the response body for monitoring dashboards.
   return NextResponse.json(response, { status: 200 });
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "Namuh Mintlify",
+  title: "OpenDocs",
   description:
     "AI-native documentation platform for teams shipping docs, APIs, and product knowledge.",
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,7 +25,7 @@ export default function Home() {
       <div className="mx-auto flex min-h-screen max-w-6xl flex-col justify-center px-6 py-20">
         <div className="max-w-3xl">
           <div className="mb-6 inline-flex items-center rounded-full border border-white/10 bg-white/[0.03] px-3 py-1 text-xs text-white/70">
-            Namuh Mintlify
+            OpenDocs
           </div>
 
           <h1 className="text-4xl font-semibold tracking-tight sm:text-6xl">

--- a/src/components/auth/google-auth-card.tsx
+++ b/src/components/auth/google-auth-card.tsx
@@ -82,9 +82,7 @@ export function GoogleAuthCard({ callbackURL, mode }: GoogleAuthCardProps) {
       </button>
 
       <p className="text-center text-xs text-gray-500">
-        {isSignup
-          ? "Already have an account? "
-          : "Don&apos;t have an account? "}
+        {isSignup ? "Already have an account? " : "Don't have an account? "}
         <a
           href={isSignup ? "/login" : "/signup"}
           className="text-green-500 hover:text-green-400"

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -14,7 +14,7 @@ export type LogContext = Record<string, LogValue> & {
   event?: string;
 };
 
-const APP_NAME = "namuh-mintlify";
+const APP_NAME = "opendocs";
 
 function safeSerializeError(error: unknown) {
   if (error instanceof Error) {

--- a/tests/deploy.test.ts
+++ b/tests/deploy.test.ts
@@ -87,9 +87,9 @@ describe("Health check response", () => {
 
 describe("Deploy config validation", () => {
   const validConfig: DeployConfig = {
-    ecrUri: "699486076867.dkr.ecr.us-east-1.amazonaws.com/namuh-mintlify",
+    ecrUri: "699486076867.dkr.ecr.us-east-1.amazonaws.com/opendocs",
     region: "us-east-1",
-    serviceName: "namuh-mintlify-prod",
+    serviceName: "opendocs-prod",
     imageTag: "latest",
     port: 3000,
     envVars: {},
@@ -143,17 +143,17 @@ describe("Deploy config validation", () => {
 describe("Image URI builder", () => {
   it("appends tag to ECR URI", () => {
     const uri = buildImageUri(
-      "699486076867.dkr.ecr.us-east-1.amazonaws.com/namuh-mintlify",
+      "699486076867.dkr.ecr.us-east-1.amazonaws.com/opendocs",
       "v1.0.0",
     );
     expect(uri).toBe(
-      "699486076867.dkr.ecr.us-east-1.amazonaws.com/namuh-mintlify:v1.0.0",
+      "699486076867.dkr.ecr.us-east-1.amazonaws.com/opendocs:v1.0.0",
     );
   });
 
   it("handles latest tag", () => {
     const uri = buildImageUri(
-      "699486076867.dkr.ecr.us-east-1.amazonaws.com/namuh-mintlify",
+      "699486076867.dkr.ecr.us-east-1.amazonaws.com/opendocs",
       "latest",
     );
     expect(uri).toContain(":latest");
@@ -162,15 +162,11 @@ describe("Image URI builder", () => {
 
 describe("Service name generator", () => {
   it("creates service name from app name and env", () => {
-    expect(generateServiceName("namuh-mintlify", "prod")).toBe(
-      "namuh-mintlify-prod",
-    );
+    expect(generateServiceName("opendocs", "prod")).toBe("opendocs-prod");
   });
 
   it("handles staging env", () => {
-    expect(generateServiceName("namuh-mintlify", "staging")).toBe(
-      "namuh-mintlify-staging",
-    );
+    expect(generateServiceName("opendocs", "staging")).toBe("opendocs-staging");
   });
 });
 

--- a/tests/github-connections-route.test.ts
+++ b/tests/github-connections-route.test.ts
@@ -188,7 +188,7 @@ describe("/api/github-connections", () => {
           installationId: "123",
           repos: [
             {
-              fullName: "namuh-eng/namuh-mintlify",
+              fullName: "namuh-eng/opendocs",
               branch: "main",
               permissions: "admin",
             },
@@ -257,7 +257,7 @@ describe("/api/github-connections", () => {
         installationId: "123",
         repos: [
           {
-            fullName: "namuh-eng/namuh-mintlify",
+            fullName: "namuh-eng/opendocs",
             branch: "main",
             permissions: "admin",
           },
@@ -277,7 +277,7 @@ describe("/api/github-connections", () => {
           installationId: "123",
           repos: [
             {
-              fullName: "namuh-eng/namuh-mintlify",
+              fullName: "namuh-eng/opendocs",
               branch: "main",
               permissions: "admin",
             },
@@ -292,7 +292,7 @@ describe("/api/github-connections", () => {
       installationId: "123",
       repos: [
         {
-          fullName: "namuh-eng/namuh-mintlify",
+          fullName: "namuh-eng/opendocs",
           branch: "main",
           permissions: "admin",
         },
@@ -307,7 +307,7 @@ describe("/api/github-connections", () => {
         installationId: "123",
         repos: [
           {
-            fullName: "namuh-eng/namuh-mintlify",
+            fullName: "namuh-eng/opendocs",
             branch: "main",
             permissions: "admin",
           },
@@ -359,7 +359,7 @@ describe("/api/github-connections", () => {
         installationId: "123",
         repos: [
           {
-            fullName: "namuh-eng/namuh-mintlify",
+            fullName: "namuh-eng/opendocs",
             branch: "main",
             permissions: "admin",
           },
@@ -381,7 +381,7 @@ describe("/api/github-connections", () => {
           installationId: "123",
           repos: [
             {
-              fullName: "namuh-eng/namuh-mintlify",
+              fullName: "namuh-eng/opendocs",
               branch: "main",
               permissions: "admin",
             },
@@ -394,7 +394,7 @@ describe("/api/github-connections", () => {
     expect(setMock).toHaveBeenCalledWith({
       repos: [
         {
-          fullName: "namuh-eng/namuh-mintlify",
+          fullName: "namuh-eng/opendocs",
           branch: "main",
           permissions: "admin",
         },
@@ -409,7 +409,7 @@ describe("/api/github-connections", () => {
         installationId: "123",
         repos: [
           {
-            fullName: "namuh-eng/namuh-mintlify",
+            fullName: "namuh-eng/opendocs",
             branch: "main",
             permissions: "admin",
           },

--- a/tests/github-import.test.ts
+++ b/tests/github-import.test.ts
@@ -21,7 +21,7 @@ describe("github-import helpers", () => {
           installationId: "inst_123",
           repos: [
             {
-              fullName: "namuh-eng/namuh-mintlify",
+              fullName: "namuh-eng/opendocs",
               branch: "main",
               permissions: "admin",
             },
@@ -33,7 +33,7 @@ describe("github-import helpers", () => {
     const mod = await import("@/lib/github-import");
     await expect(mod.listConnectedGitHubRepos("org-1")).resolves.toEqual([
       {
-        fullName: "namuh-eng/namuh-mintlify",
+        fullName: "namuh-eng/opendocs",
         branch: "main",
         permissions: "admin",
         installationId: "inst_123",
@@ -49,7 +49,7 @@ describe("github-import helpers", () => {
           installationId: "inst_123",
           repos: [
             {
-              fullName: "namuh-eng/namuh-mintlify",
+              fullName: "namuh-eng/opendocs",
               branch: "main",
               permissions: "admin",
             },
@@ -62,11 +62,11 @@ describe("github-import helpers", () => {
     await expect(
       mod.resolveGitHubImportAccessForRepoUrl({
         orgId: "org-1",
-        repoUrl: "https://github.com/namuh-eng/namuh-mintlify",
+        repoUrl: "https://github.com/namuh-eng/opendocs",
       }),
     ).resolves.toMatchObject({
       status: "private_connected",
-      repoFullName: "namuh-eng/namuh-mintlify",
+      repoFullName: "namuh-eng/opendocs",
     });
   });
 
@@ -91,7 +91,7 @@ describe("github-import helpers", () => {
     await expect(
       mod.resolveGitHubImportAccessForRepoUrl({
         orgId: "org-1",
-        repoUrl: "https://github.com/namuh-eng/namuh-mintlify?private=true",
+        repoUrl: "https://github.com/namuh-eng/opendocs?private=true",
       }),
     ).resolves.toMatchObject({
       status: "repo_not_connected",
@@ -108,7 +108,7 @@ describe("github-import helpers", () => {
           installationId: "inst_other",
           repos: [
             {
-              fullName: "namuh-eng/namuh-mintlify",
+              fullName: "namuh-eng/opendocs",
               branch: "main",
               permissions: "admin",
             },
@@ -121,14 +121,14 @@ describe("github-import helpers", () => {
     await expect(
       mod.resolveGitHubImportAccess({
         orgId: "org-1",
-        repoUrl: "https://github.com/namuh-eng/namuh-mintlify",
+        repoUrl: "https://github.com/namuh-eng/opendocs",
         repoBranch: "main",
         repoPath: "/",
         settings: {
           githubSource: {
-            repoFullName: "namuh-eng/namuh-mintlify",
+            repoFullName: "namuh-eng/opendocs",
             owner: "namuh-eng",
-            repo: "namuh-mintlify",
+            repo: "opendocs",
             installationId: "inst_123",
             branch: "main",
             path: "/",

--- a/tests/github-source-readers.test.ts
+++ b/tests/github-source-readers.test.ts
@@ -10,9 +10,9 @@ describe("github-source readers", () => {
         repoPath: "/guides",
         settings: {
           githubSource: {
-            repoFullName: "namuh-eng/namuh-mintlify",
+            repoFullName: "namuh-eng/opendocs",
             owner: "namuh-eng",
-            repo: "namuh-mintlify",
+            repo: "opendocs",
             installationId: "inst_123",
             branch: "main",
             path: "/docs",
@@ -21,9 +21,9 @@ describe("github-source readers", () => {
         },
       }),
     ).toEqual({
-      repoFullName: "namuh-eng/namuh-mintlify",
+      repoFullName: "namuh-eng/opendocs",
       owner: "namuh-eng",
-      repo: "namuh-mintlify",
+      repo: "opendocs",
       installationId: "inst_123",
       branch: "develop",
       path: "/guides",

--- a/tests/github-source.test.ts
+++ b/tests/github-source.test.ts
@@ -8,15 +8,15 @@ describe("github-source helpers", () => {
   it("builds connected repo source metadata", () => {
     expect(
       buildGitHubSourceSelection({
-        repoUrl: "https://github.com/namuh-eng/namuh-mintlify",
+        repoUrl: "https://github.com/namuh-eng/opendocs",
         installationId: "inst_123",
         repoBranch: "main",
         repoPath: "/docs",
       }),
     ).toEqual({
-      repoFullName: "namuh-eng/namuh-mintlify",
+      repoFullName: "namuh-eng/opendocs",
       owner: "namuh-eng",
-      repo: "namuh-mintlify",
+      repo: "opendocs",
       installationId: "inst_123",
       branch: "main",
       path: "/docs",

--- a/tests/github-webhook-route.test.ts
+++ b/tests/github-webhook-route.test.ts
@@ -52,7 +52,7 @@ describe("POST /api/webhooks/github", () => {
             installationId: "inst_123",
             repos: [
               {
-                fullName: "namuh-eng/namuh-mintlify",
+                fullName: "namuh-eng/opendocs",
                 branch: "main",
                 permissions: "admin",
               },
@@ -67,14 +67,14 @@ describe("POST /api/webhooks/github", () => {
         where: vi.fn().mockResolvedValue([
           {
             id: "project-1",
-            repoUrl: "https://github.com/namuh-eng/namuh-mintlify",
+            repoUrl: "https://github.com/namuh-eng/opendocs",
             repoBranch: "main",
             repoPath: "/",
             settings: {
               githubSource: {
-                repoFullName: "namuh-eng/namuh-mintlify",
+                repoFullName: "namuh-eng/opendocs",
                 owner: "namuh-eng",
-                repo: "namuh-mintlify",
+                repo: "opendocs",
                 installationId: "inst_123",
                 branch: "main",
                 path: "/",
@@ -84,14 +84,14 @@ describe("POST /api/webhooks/github", () => {
           },
           {
             id: "project-2",
-            repoUrl: "https://github.com/namuh-eng/namuh-mintlify",
+            repoUrl: "https://github.com/namuh-eng/opendocs",
             repoBranch: "main",
             repoPath: "/",
             settings: {
               githubSource: {
-                repoFullName: "namuh-eng/namuh-mintlify",
+                repoFullName: "namuh-eng/opendocs",
                 owner: "namuh-eng",
-                repo: "namuh-mintlify",
+                repo: "opendocs",
                 installationId: "inst_other",
                 branch: "main",
                 path: "/",
@@ -120,7 +120,7 @@ describe("POST /api/webhooks/github", () => {
         {
           ref: "refs/heads/main",
           after: "abc123def456",
-          repository: { full_name: "namuh-eng/namuh-mintlify" },
+          repository: { full_name: "namuh-eng/opendocs" },
           head_commit: { message: "Update docs", id: "abc123def456" },
           installation: { id: 123 },
         },


### PR DESCRIPTION
## Summary
- rename visible app/package branding from Namuh Mintlify to OpenDocs/opendocs
- fix the escaped login footer copy so it renders "Don't have an account? Sign up"
- update deployment/preflight identifiers and affected tests/log app name

## Verification
- npm run lint
- npm run typecheck
- npm test -- --run tests/auth.test.ts tests/deploy.test.ts tests/github-source.test.ts tests/github-import.test.ts tests/github-webhook-route.test.ts tests/github-connections-route.test.ts tests/github-source-readers.test.ts
- npm run build
- ever start --url http://localhost:3015/login --title opendocs-login-test, ever snapshot verified the footer renders as "Don't have an account?"

## Login test note
A full Google OAuth login test is not complete yet because gcloud is not installed in this environment, so I could not add/confirm an OAuth test user from CLI. Ever also reported the extension disconnected after the initial login-page snapshot.