### PR TITLE
Harden rate limit client keys

### DIFF
--- a/src/app/api/docs/proxy/route.ts
+++ b/src/app/api/docs/proxy/route.ts
@@ -1,3 +1,4 @@
+import { getClientRateLimitKey } from "@/lib/client-rate-limit-key";
 import { createRequestId, logger } from "@/lib/logger";
 import { applyRateLimit, buildRateLimitHeaders } from "@/lib/rate-limit";
 import { assertSafeProxyUrl } from "@/lib/ssrf-protection";
@@ -9,9 +10,9 @@ import { NextResponse } from "next/server";
  */
 export async function POST(req: Request): Promise<NextResponse> {
   const requestId = createRequestId();
-  const forwardedFor = req.headers.get("x-forwarded-for") ?? "unknown";
+  const rateLimitKey = getClientRateLimitKey(req.headers, "docs-proxy");
   const rateLimit = applyRateLimit({
-    key: `docs-proxy:${forwardedFor}`,
+    key: rateLimitKey,
     limit: 20,
     windowMs: 60_000,
   });
@@ -20,7 +21,7 @@ export async function POST(req: Request): Promise<NextResponse> {
       requestId,
       route: "/api/docs/proxy",
       method: "POST",
-      forwardedFor,
+      rateLimitKey,
     });
     return NextResponse.json(
       { error: "Too many proxy requests" },

--- a/src/app/api/webhooks/github/route.ts
+++ b/src/app/api/webhooks/github/route.ts
@@ -1,4 +1,5 @@
 import { enqueueDeployment } from "@/lib/async-execution";
+import { getClientRateLimitKey } from "@/lib/client-rate-limit-key";
 import { db } from "@/lib/db";
 import {
   auditLogs,
@@ -24,12 +25,12 @@ export async function POST(request: Request) {
   const requestId = createRequestId();
   const eventType = request.headers.get("x-github-event");
   const signature = request.headers.get("x-hub-signature-256");
-  const forwardedFor = request.headers.get("x-forwarded-for") ?? "unknown";
+  const rateLimitKey = getClientRateLimitKey(request.headers, "github-webhook");
   const installationTargetId = request.headers.get(
     "x-github-hook-installation-target-id",
   );
   const rateLimit = applyRateLimit({
-    key: `github-webhook:${forwardedFor}`,
+    key: rateLimitKey,
     limit: 120,
     windowMs: 60_000,
   });
@@ -38,7 +39,7 @@ export async function POST(request: Request) {
       requestId,
       route: "/api/webhooks/github",
       method: "POST",
-      forwardedFor,
+      rateLimitKey,
       eventType: eventType ?? "unknown",
     });
     return NextResponse.json(

--- a/src/lib/client-rate-limit-key.ts
+++ b/src/lib/client-rate-limit-key.ts
@@ -1,0 +1,44 @@
+import { isIP } from "node:net";
+
+function normalizeIp(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const bracketedIpv6 = trimmed.match(/^\[([^\]]+)\](?::\d+)?$/);
+  if (bracketedIpv6?.[1] && isIP(bracketedIpv6[1])) return bracketedIpv6[1];
+
+  const ipv4WithPort = trimmed.match(/^(\d{1,3}(?:\.\d{1,3}){3})(?::\d+)?$/);
+  if (ipv4WithPort?.[1] && isIP(ipv4WithPort[1])) return ipv4WithPort[1];
+
+  return isIP(trimmed) ? trimmed : null;
+}
+
+function firstForwardedFor(value: string) {
+  return value
+    .split(",")
+    .map((part) => normalizeIp(part))
+    .find((part): part is string => Boolean(part));
+}
+
+export function getClientRateLimitKey(
+  headers: Headers,
+  namespace: string,
+  fallback = "unknown",
+) {
+  const candidates = [
+    headers.get("cf-connecting-ip"),
+    headers.get("fly-client-ip"),
+    headers.get("x-real-ip"),
+    headers.get("x-forwarded-for"),
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const normalized = candidate.includes(",")
+      ? firstForwardedFor(candidate)
+      : normalizeIp(candidate);
+    if (normalized) return `${namespace}:ip:${normalized}`;
+  }
+
+  return `${namespace}:ip:${fallback}`;
+}

--- a/tests/client-rate-limit-key.test.ts
+++ b/tests/client-rate-limit-key.test.ts
@@ -1,0 +1,33 @@
+import { getClientRateLimitKey } from "@/lib/client-rate-limit-key";
+import { describe, expect, it } from "vitest";
+
+describe("getClientRateLimitKey", () => {
+  it("normalizes the first valid forwarded IP", () => {
+    const headers = new Headers({
+      "x-forwarded-for": "203.0.113.10, 10.0.0.1",
+    });
+
+    expect(getClientRateLimitKey(headers, "docs-proxy")).toBe(
+      "docs-proxy:ip:203.0.113.10",
+    );
+  });
+
+  it("prefers proxy-provided single client IP headers over forwarded chains", () => {
+    const headers = new Headers({
+      "cf-connecting-ip": "2001:db8::1",
+      "x-forwarded-for": "198.51.100.20",
+    });
+
+    expect(getClientRateLimitKey(headers, "github-webhook")).toBe(
+      "github-webhook:ip:2001:db8::1",
+    );
+  });
+
+  it("falls back for malformed forwarded headers", () => {
+    const headers = new Headers({ "x-forwarded-for": "not an ip" });
+
+    expect(getClientRateLimitKey(headers, "docs-proxy")).toBe(
+      "docs-proxy:ip:unknown",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- normalize client IPs before using them as rate-limit keys
- prefer proxy-provided single-IP headers before forwarded chains
- avoid logging raw x-forwarded-for values in webhook/proxy rate-limit warnings
- add regression coverage for normalized/fallback rate-limit keys

## Verification
- npm run lint
- npm run typecheck
- npm test -- --run tests/client-rate-limit-key.test.ts tests/docs-proxy-route.test.ts tests/github-webhook-route.test.ts