### PR TITLE
Block unsafe docs proxy redirects

### DIFF
--- a/src/app/api/docs/proxy/route.ts
+++ b/src/app/api/docs/proxy/route.ts
@@ -102,6 +102,7 @@ export async function POST(req: Request): Promise<NextResponse> {
     const fetchOptions: RequestInit = {
       method,
       headers: fetchHeaders,
+      redirect: "manual",
       signal: controller.signal,
     };
 
@@ -111,6 +112,29 @@ export async function POST(req: Request): Promise<NextResponse> {
 
     const response = await fetch(parsedUrl.toString(), fetchOptions);
     clearTimeout(timeoutId);
+
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get("location");
+      if (location) {
+        const redirectUrl = new URL(location, parsedUrl);
+        try {
+          await assertSafeProxyUrl(redirectUrl);
+        } catch (error) {
+          logger.warn("docs_proxy_blocked_unsafe_redirect", {
+            requestId,
+            route: "/api/docs/proxy",
+            method: "POST",
+            hostname: redirectUrl.hostname,
+            error: error instanceof Error ? error.message : "unsafe redirect",
+          });
+          return NextResponse.json(
+            { error: "Redirect target is not allowed" },
+            { status: 403, headers: buildRateLimitHeaders(rateLimit) },
+          );
+        }
+      }
+    }
+
     const responseBody = await response.text();
 
     // Collect response headers

--- a/tests/docs-proxy-route.test.ts
+++ b/tests/docs-proxy-route.test.ts
@@ -155,6 +155,7 @@ describe("POST /api/docs/proxy", () => {
         Accept: "application/json",
       },
       body: '{"hello":"world"}',
+      redirect: "manual",
       signal: expect.any(AbortSignal),
     });
 
@@ -211,8 +212,33 @@ describe("POST /api/docs/proxy", () => {
     expect(fetchMock).toHaveBeenCalledWith("https://example.com/docs.json", {
       method: "GET",
       headers: {},
+      redirect: "manual",
       signal: expect.any(AbortSignal),
     });
     expect(response.status).toBe(200);
+  });
+
+  it("blocks redirects to internal addresses", async () => {
+    fetchMock.mockResolvedValue(
+      new Response("", {
+        status: 302,
+        headers: {
+          location: "http://169.254.169.254/latest/meta-data",
+        },
+      }),
+    );
+
+    const { POST } = await import("@/app/api/docs/proxy/route");
+    const response = await POST(
+      makeRequest({
+        method: "GET",
+        url: "https://example.com/redirect",
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      error: "Redirect target is not allowed",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- fetch docs proxy requests with manual redirect handling
- validate redirect locations with the same SSRF guard before returning them
- block redirects to internal metadata/private addresses

## Verification
- npm run lint
- npm run typecheck
- npm test -- --run tests/docs-proxy-route.test.ts tests/ssrf-protection.test.ts