### PR TITLE
Fail closed for docs access token secrets

### DIFF
--- a/src/app/api/docs/[subdomain]/auth/route.ts
+++ b/src/app/api/docs/[subdomain]/auth/route.ts
@@ -43,17 +43,27 @@ export async function POST(
     return NextResponse.redirect(url);
   }
 
-  const response = NextResponse.redirect(new URL(returnTo, request.url));
-  response.cookies.set({
-    name: getDocsAccessCookieName(subdomain),
-    value: createDocsAccessToken(
+  let accessToken: string;
+  try {
+    accessToken = createDocsAccessToken(
       subdomain,
       (
         project.settings as {
           authentication?: { passwordHash?: string; password?: string };
         }
       )?.authentication?.passwordHash || password,
-    ),
+    );
+  } catch {
+    return NextResponse.json(
+      { error: "Docs access tokens are not configured" },
+      { status: 503 },
+    );
+  }
+
+  const response = NextResponse.redirect(new URL(returnTo, request.url));
+  response.cookies.set({
+    name: getDocsAccessCookieName(subdomain),
+    value: accessToken,
     httpOnly: true,
     sameSite: "lax",
     secure: process.env.NODE_ENV === "production",

--- a/src/lib/project-docs-access.ts
+++ b/src/lib/project-docs-access.ts
@@ -11,11 +11,18 @@ export function getDocsAccessCookieName(subdomain: string) {
 }
 
 function getSigningSecret() {
-  return process.env.BETTER_AUTH_SECRET || "development-docs-access-secret";
+  const secret = process.env.BETTER_AUTH_SECRET;
+  if (secret) return secret;
+  if (process.env.NODE_ENV === "production") return null;
+  return "development-docs-access-secret";
 }
 
 export function createDocsAccessToken(subdomain: string, credential: string) {
-  return createHmac("sha256", getSigningSecret())
+  const secret = getSigningSecret();
+  if (!secret) {
+    throw new Error("BETTER_AUTH_SECRET is required for docs access tokens");
+  }
+  return createHmac("sha256", secret)
     .update(`${subdomain}:${credential}`)
     .digest("hex");
 }
@@ -58,5 +65,9 @@ export function hasValidDocsAccess(
   const credential = getStoredCredential(settings);
   if (!credential) return true;
   if (!token) return false;
-  return safeEqual(token, createDocsAccessToken(subdomain, credential));
+  try {
+    return safeEqual(token, createDocsAccessToken(subdomain, credential));
+  } catch {
+    return false;
+  }
 }

--- a/tests/project-authentication-settings.test.ts
+++ b/tests/project-authentication-settings.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   mergeProjectAuthenticationSettings,
@@ -105,5 +105,27 @@ describe("project authentication settings", () => {
       }),
     ).toBe(false);
     expect(isProjectPasswordProtected({ requireAuth: true })).toBe(false);
+  });
+});
+
+describe("docs access token production secret", () => {
+  it("fails closed in production when BETTER_AUTH_SECRET is missing", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("BETTER_AUTH_SECRET", "");
+
+    try {
+      expect(() => createDocsAccessToken("docs", "secret")).toThrow(
+        "BETTER_AUTH_SECRET is required",
+      );
+      expect(
+        hasValidDocsAccess(
+          { authentication: { mode: "password", password: "secret" } },
+          "docs",
+          "forged-token",
+        ),
+      ).toBe(false);
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- require BETTER_AUTH_SECRET for docs access token signing in production
- fail docs access validation closed when token signing is not configured
- return a clear 503 from the docs auth route instead of minting weak tokens
- add regression coverage for production missing-secret behavior

## Verification
- npm run lint
- npm run typecheck
- npm test -- --run tests/project-authentication-settings.test.ts tests/docs-auth-route.test.ts