### PR TITLE
Require Better Auth URL in production

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,6 +2,15 @@ import { db } from "@/lib/db";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 
+export function getBetterAuthUrl() {
+  const url = process.env.BETTER_AUTH_URL?.trim();
+  if (url) return url;
+  if (process.env.NODE_ENV === "production") {
+    throw new Error("BETTER_AUTH_URL is required in production");
+  }
+  return "http://localhost:3015";
+}
+
 export const auth = betterAuth({
   database: drizzleAdapter(db, {
     provider: "pg",
@@ -18,5 +27,5 @@ export const auth = betterAuth({
       maxAge: 5 * 60, // 5 minutes
     },
   },
-  trustedOrigins: [process.env.BETTER_AUTH_URL || "http://localhost:3015"],
+  trustedOrigins: [getBetterAuthUrl()],
 });

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -112,3 +112,34 @@ describe("auth configuration", () => {
     expect(mod.authClient.useSession).toBeDefined();
   });
 });
+
+describe("auth production origin configuration", () => {
+  it("requires BETTER_AUTH_URL in production", async () => {
+    vi.resetModules();
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("BETTER_AUTH_URL", "");
+
+    try {
+      await expect(import("@/lib/auth")).rejects.toThrow(
+        "BETTER_AUTH_URL is required in production",
+      );
+    } finally {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    }
+  });
+
+  it("keeps localhost fallback for non-production development", async () => {
+    vi.resetModules();
+    vi.stubEnv("NODE_ENV", "test");
+    vi.stubEnv("BETTER_AUTH_URL", "");
+
+    try {
+      const { getBetterAuthUrl } = await import("@/lib/auth");
+      expect(getBetterAuthUrl()).toBe("http://localhost:3015");
+    } finally {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- fail closed when BETTER_AUTH_URL is missing in production instead of trusting localhost
- keep localhost fallback for non-production development/test
- add regression coverage for production and development origin behavior

## Verification
- npm run lint
- npm run typecheck
- npm test -- --run tests/auth.test.ts