### PR TITLE
Require public app URL in production

### DIFF
--- a/src/app/api/docs/[subdomain]/sitemap/route.ts
+++ b/src/app/api/docs/[subdomain]/sitemap/route.ts
@@ -1,9 +1,10 @@
+import { getPublicAppUrl } from "@/lib/app-url";
 import { db } from "@/lib/db";
 import { pages, projects } from "@/lib/db/schema";
 import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
-const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3015";
+const APP_URL = getPublicAppUrl();
 
 /**
  * GET /api/docs/[subdomain]/sitemap

--- a/src/app/docs/[subdomain]/[...slug]/page.tsx
+++ b/src/app/docs/[subdomain]/[...slug]/page.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/docs/page-chrome";
 import { SearchModal } from "@/components/docs/search-modal";
 import { renderApiReferencePage } from "@/lib/api-reference";
+import { getPublicAppUrl } from "@/lib/app-url";
 import { db } from "@/lib/db";
 import { pages, projects } from "@/lib/db/schema";
 import { findRedirect, mergeDocsConfig } from "@/lib/docs-config";
@@ -74,7 +75,7 @@ interface DocsPageProps {
   searchParams?: Promise<{ auth?: string }>;
 }
 
-const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3015";
+const APP_URL = getPublicAppUrl();
 
 export async function generateMetadata({
   params,

--- a/src/app/docs/[subdomain]/robots.txt/route.ts
+++ b/src/app/docs/[subdomain]/robots.txt/route.ts
@@ -1,10 +1,11 @@
+import { getPublicAppUrl } from "@/lib/app-url";
 import { db } from "@/lib/db";
 import { projects } from "@/lib/db/schema";
 import { isProjectPasswordProtected } from "@/lib/project-publication-auth";
 import { generateRobotsTxt } from "@/lib/seo";
 import { eq } from "drizzle-orm";
 
-const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3015";
+const APP_URL = getPublicAppUrl();
 
 export async function GET(
   _request: Request,

--- a/src/app/docs/[subdomain]/sitemap.xml/route.ts
+++ b/src/app/docs/[subdomain]/sitemap.xml/route.ts
@@ -1,10 +1,11 @@
+import { getPublicAppUrl } from "@/lib/app-url";
 import { db } from "@/lib/db";
 import { pages, projects } from "@/lib/db/schema";
 import { isProjectPasswordProtected } from "@/lib/project-publication-auth";
 import { generateSitemapEntries, renderSitemapXml } from "@/lib/seo";
 import { and, eq } from "drizzle-orm";
 
-const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3015";
+const APP_URL = getPublicAppUrl();
 
 export async function GET(
   _request: Request,

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,10 +1,11 @@
+import { getPublicAppUrl } from "@/lib/app-url";
 import { db } from "@/lib/db";
 import { projects } from "@/lib/db/schema";
 import type { MetadataRoute } from "next";
 
 export const dynamic = "force-dynamic";
 
-const APP_URL = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3015";
+const APP_URL = getPublicAppUrl();
 
 /**
  * GET /robots.txt

--- a/src/lib/app-url.ts
+++ b/src/lib/app-url.ts
@@ -1,0 +1,8 @@
+export function getPublicAppUrl() {
+  const url = process.env.NEXT_PUBLIC_APP_URL?.trim();
+  if (url) return url.replace(/\/+$/, "");
+  if (process.env.NODE_ENV === "production") {
+    throw new Error("NEXT_PUBLIC_APP_URL is required in production");
+  }
+  return "http://localhost:3015";
+}

--- a/src/lib/deploy.ts
+++ b/src/lib/deploy.ts
@@ -72,6 +72,7 @@ export function validateDeployConfig(config: Partial<DeployConfig>): {
       "DATABASE_URL",
       "BETTER_AUTH_SECRET",
       "BETTER_AUTH_URL",
+      "NEXT_PUBLIC_APP_URL",
     ]) {
       if (!config.envVars[key]) errors.push(`${key} is required in production`);
     }

--- a/tests/app-url.test.ts
+++ b/tests/app-url.test.ts
@@ -1,0 +1,30 @@
+import { getPublicAppUrl } from "@/lib/app-url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("getPublicAppUrl", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("normalizes a configured public app URL", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://opendocs.namuh.co///");
+
+    expect(getPublicAppUrl()).toBe("https://opendocs.namuh.co");
+  });
+
+  it("requires NEXT_PUBLIC_APP_URL in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "");
+
+    expect(() => getPublicAppUrl()).toThrow(
+      "NEXT_PUBLIC_APP_URL is required in production",
+    );
+  });
+
+  it("keeps localhost fallback outside production", () => {
+    vi.stubEnv("NODE_ENV", "test");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "");
+
+    expect(getPublicAppUrl()).toBe("http://localhost:3015");
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared public app URL helper that fails closed when NEXT_PUBLIC_APP_URL is missing in production
- use the helper for server-generated robots/sitemap/docs metadata URLs
- require NEXT_PUBLIC_APP_URL in production deploy config validation
- add regression coverage for URL normalization and production missing-env behavior

## Verification
- npm run lint
- npm run typecheck
- npm test -- --run tests/app-url.test.ts tests/deploy.test.ts