### PR TITLE
Require docs proxy host allowlist in production

### DIFF
--- a/src/lib/deploy.ts
+++ b/src/lib/deploy.ts
@@ -73,6 +73,7 @@ export function validateDeployConfig(config: Partial<DeployConfig>): {
       "BETTER_AUTH_SECRET",
       "BETTER_AUTH_URL",
       "NEXT_PUBLIC_APP_URL",
+      "DOCS_PROXY_ALLOWED_HOSTS",
     ]) {
       if (!config.envVars[key]) errors.push(`${key} is required in production`);
     }
@@ -102,6 +103,7 @@ const DEPLOY_ENV_ALLOWLIST = [
   "ENABLE_ASYNC_SIMULATION",
   "GITHUB_APP_ID",
   "GITHUB_APP_PRIVATE_KEY",
+  "DOCS_PROXY_ALLOWED_HOSTS",
 ] as const;
 
 export function filterEnvForDeploy(

--- a/src/lib/ssrf-protection.ts
+++ b/src/lib/ssrf-protection.ts
@@ -63,6 +63,9 @@ export async function assertSafeProxyUrl(url: URL) {
     .split(",")
     .map((host) => host.trim().toLowerCase())
     .filter(Boolean);
+  if (allowedHosts.length === 0 && process.env.NODE_ENV === "production") {
+    throw new Error("DOCS_PROXY_ALLOWED_HOSTS is required in production");
+  }
   if (allowedHosts.length > 0 && !allowedHosts.includes(hostname)) {
     throw new Error("Requests to this host are not allowed");
   }

--- a/tests/ssrf-protection.test.ts
+++ b/tests/ssrf-protection.test.ts
@@ -29,10 +29,48 @@ describe("SSRF protection", () => {
     ).rejects.toThrow("internal");
   });
 
-  it("allows public HTTP(S) targets", async () => {
-    const { assertSafeProxyUrl } = await import("@/lib/ssrf-protection");
-    await expect(
-      assertSafeProxyUrl(new URL("https://public.example.com/resource")),
-    ).resolves.toBeUndefined();
+  it("allows public HTTP(S) targets outside production", async () => {
+    vi.stubEnv("NODE_ENV", "test");
+    vi.stubEnv("DOCS_PROXY_ALLOWED_HOSTS", "");
+
+    try {
+      const { assertSafeProxyUrl } = await import("@/lib/ssrf-protection");
+      await expect(
+        assertSafeProxyUrl(new URL("https://public.example.com/resource")),
+      ).resolves.toBeUndefined();
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("requires an explicit host allowlist in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("DOCS_PROXY_ALLOWED_HOSTS", "");
+
+    try {
+      const { assertSafeProxyUrl } = await import("@/lib/ssrf-protection");
+      await expect(
+        assertSafeProxyUrl(new URL("https://public.example.com/resource")),
+      ).rejects.toThrow("DOCS_PROXY_ALLOWED_HOSTS is required in production");
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("allows only configured public hosts in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("DOCS_PROXY_ALLOWED_HOSTS", "public.example.com");
+
+    try {
+      const { assertSafeProxyUrl } = await import("@/lib/ssrf-protection");
+      await expect(
+        assertSafeProxyUrl(new URL("https://public.example.com/resource")),
+      ).resolves.toBeUndefined();
+      await expect(
+        assertSafeProxyUrl(new URL("https://other.example.com/resource")),
+      ).rejects.toThrow("Requests to this host are not allowed");
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- fail closed in production when DOCS_PROXY_ALLOWED_HOSTS is not configured
- keep public HTTP(S) proxying available in non-production for playground/dev use
- include DOCS_PROXY_ALLOWED_HOSTS in deploy env filtering and production deploy validation
- add regression coverage for production allowlist behavior

## Verification
- npm run lint
- npm run typecheck
- npm test -- --run tests/ssrf-protection.test.ts tests/docs-proxy-route.test.ts tests/deploy.test.ts