### PR TITLE
Use scrypt for docs password hashes

### DIFF
--- a/src/lib/project-authentication-settings.ts
+++ b/src/lib/project-authentication-settings.ts
@@ -1,10 +1,17 @@
+import {
+  randomBytes,
+  scrypt as scryptCallback,
+  timingSafeEqual,
+} from "node:crypto";
+import { promisify } from "node:util";
+
 export type ProjectAuthenticationMode = "public" | "password";
 
 export interface ProjectAuthenticationSettings {
   mode: ProjectAuthenticationMode;
   /** Deprecated legacy plaintext value. Only read for backward compatibility. */
   password: string;
-  /** SHA-256 hash of the shared docs password. */
+  /** Slow password hash for the shared docs password. */
   passwordHash?: string;
 }
 
@@ -19,16 +26,51 @@ interface ProjectSettingsWithAuthentication {
   authentication?: Partial<ProjectAuthenticationSettings> | null;
 }
 
-export function isPasswordHash(value: string) {
+const scrypt = promisify(scryptCallback);
+const SCRYPT_PREFIX = "scrypt:v1";
+const SCRYPT_KEY_LENGTH = 64;
+
+export function isLegacySha256PasswordHash(value: string) {
   return /^[a-f0-9]{64}$/i.test(value);
 }
 
-export async function hashDocsPassword(password: string) {
+export function isDocsPasswordHash(value: string) {
+  return (
+    isLegacySha256PasswordHash(value) ||
+    new RegExp(`^${SCRYPT_PREFIX}:[a-f0-9]{32}:[a-f0-9]{128}$`, "i").test(value)
+  );
+}
+
+async function hashLegacySha256Password(password: string) {
   const data = new TextEncoder().encode(password);
   const digest = await crypto.subtle.digest("SHA-256", data);
   return Array.from(new Uint8Array(digest))
     .map((byte) => byte.toString(16).padStart(2, "0"))
     .join("");
+}
+
+export async function hashDocsPassword(password: string) {
+  const salt = randomBytes(16).toString("hex");
+  const key = (await scrypt(password, salt, SCRYPT_KEY_LENGTH)) as Buffer;
+  return `${SCRYPT_PREFIX}:${salt}:${key.toString("hex")}`;
+}
+
+function safeEqual(a: string, b: string) {
+  const left = Buffer.from(a, "hex");
+  const right = Buffer.from(b, "hex");
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+export async function verifyDocsPasswordHash(hash: string, password: string) {
+  if (isLegacySha256PasswordHash(hash)) {
+    return safeEqual(hash, await hashLegacySha256Password(password));
+  }
+
+  const [prefix, version, salt, key] = hash.split(":");
+  if (`${prefix}:${version}` !== SCRYPT_PREFIX || !salt || !key) return false;
+
+  const derived = (await scrypt(password, salt, SCRYPT_KEY_LENGTH)) as Buffer;
+  return safeEqual(key, derived.toString("hex"));
 }
 
 export function readProjectAuthenticationSettings(
@@ -41,7 +83,7 @@ export function readProjectAuthenticationSettings(
   const passwordHash =
     typeof authSettings?.passwordHash === "string"
       ? authSettings.passwordHash
-      : isPasswordHash(password)
+      : isDocsPasswordHash(password)
         ? password
         : "";
 

--- a/src/lib/project-docs-access.ts
+++ b/src/lib/project-docs-access.ts
@@ -1,7 +1,7 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import {
-  hashDocsPassword,
   readProjectAuthenticationSettings,
+  verifyDocsPasswordHash,
 } from "@/lib/project-authentication-settings";
 
 const COOKIE_PREFIX = "docs_access";
@@ -52,7 +52,7 @@ export async function isValidDocsPassword(
   const auth = readProjectAuthenticationSettings(settings);
   if (auth.mode !== "password") return false;
   if (auth.passwordHash) {
-    return safeEqual(auth.passwordHash, await hashDocsPassword(password));
+    return verifyDocsPasswordHash(auth.passwordHash, password);
   }
   return safeEqual(auth.password, password);
 }

--- a/tests/project-authentication-settings.test.ts
+++ b/tests/project-authentication-settings.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  hashDocsPassword,
   mergeProjectAuthenticationSettings,
   readProjectAuthenticationSettings,
   validateProjectAuthenticationSettings,
+  verifyDocsPasswordHash,
 } from "@/lib/project-authentication-settings";
 import {
   createDocsAccessToken,
@@ -70,9 +72,29 @@ describe("project authentication settings", () => {
     ).toBe("Password protection requires a password.");
   });
 
+  it("hashes docs passwords with scrypt and verifies them", async () => {
+    const hash = await hashDocsPassword("secret");
+
+    expect(hash).toMatch(/^scrypt:v1:[a-f0-9]{32}:[a-f0-9]{128}$/);
+    expect(await verifyDocsPasswordHash(hash, "secret")).toBe(true);
+    expect(await verifyDocsPasswordHash(hash, "wrong")).toBe(false);
+  });
+
+  it("keeps legacy SHA-256 password hashes verifiable", async () => {
+    const legacyHash =
+      "2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b";
+
+    expect(await verifyDocsPasswordHash(legacyHash, "secret")).toBe(true);
+    expect(await verifyDocsPasswordHash(legacyHash, "wrong")).toBe(false);
+  });
+
   it("validates docs access passwords and cookies", async () => {
     const settings = {
-      authentication: { mode: "password", password: "secret" },
+      authentication: {
+        mode: "password",
+        password: "",
+        passwordHash: await hashDocsPassword("secret"),
+      },
     };
     expect(await isValidDocsPassword(settings, "secret")).toBe(true);
     expect(await isValidDocsPassword(settings, "wrong")).toBe(false);
@@ -81,7 +103,10 @@ describe("project authentication settings", () => {
       hasValidDocsAccess(
         settings,
         "docs",
-        createDocsAccessToken("docs", "secret"),
+        createDocsAccessToken(
+          "docs",
+          readProjectAuthenticationSettings(settings).passwordHash ?? "",
+        ),
       ),
     ).toBe(true);
     expect(


### PR DESCRIPTION
## Summary
- replace new shared-docs password hashes with scrypt hashes
- keep legacy SHA-256 and plaintext settings verifiable for backward compatibility
- verify docs-access cookies against the stored credential hash
- add regression coverage for scrypt and legacy SHA-256 verification

## Verification
- npm run lint
- npm run typecheck
- npm test -- --run tests/project-authentication-settings.test.ts tests/project-authentication-settings-route.test.ts tests/docs-auth-route.test.ts