### PR TITLE
Provide auth URL during Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 ARG NEXT_PUBLIC_APP_URL=http://localhost:3015
+ARG BETTER_AUTH_URL=http://localhost:3015
 ENV NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL
+ENV BETTER_AUTH_URL=$BETTER_AUTH_URL
 RUN npm run build
 
 FROM base AS runner


### PR DESCRIPTION
## Summary
- add BETTER_AUTH_URL as a Docker build arg/env alongside NEXT_PUBLIC_APP_URL
- keeps production fail-closed auth URL validation while allowing container builds to use the configured public auth URL

## Verification
- npm run lint
- npm run typecheck
- npm test -- --run tests/auth.test.ts tests/deploy.test.ts