### PR TITLE
Fix generated docs dashboard site link status

### DIFF
--- a/src/lib/dashboard.ts
+++ b/src/lib/dashboard.ts
@@ -54,13 +54,13 @@ export function buildSiteUrl(
   return "#";
 }
 
-/** Format a domain for display (strip protocol, trailing slash). */
+/** Format the dashboard site target for display. */
 export function formatDomainDisplay(
   subdomain: string | null,
   customDomain: string | null,
 ): string {
   if (customDomain) return customDomain;
-  if (subdomain) return `${subdomain}.mintlify.app`;
+  if (subdomain) return `/docs/${subdomain}`;
   return "";
 }
 
@@ -77,6 +77,10 @@ export function projectDisplayStatus(params: {
     params.latestDeploymentStatus === "failed"
   ) {
     return "error";
+  }
+
+  if (params.publishedPageCount > 0) {
+    return "active";
   }
 
   if (

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -83,10 +83,8 @@ describe("formatDomainDisplay", () => {
     );
   });
 
-  it("appends .mintlify.app to subdomain", () => {
-    expect(formatDomainDisplay("my-project", null)).toBe(
-      "my-project.mintlify.app",
-    );
+  it("shows the canonical docs route for generated subdomains", () => {
+    expect(formatDomainDisplay("my-project", null)).toBe("/docs/my-project");
   });
 
   it("returns empty string when nothing set", () => {
@@ -141,11 +139,21 @@ describe("projectDisplayStatus", () => {
     ).toBe("active");
   });
 
-  it("keeps queued and running deployments in updating state", () => {
+  it("keeps published projects live even when manual deployment handoff is queued", () => {
     expect(
       projectDisplayStatus({
         projectStatus: "active",
         publishedPageCount: 1,
+        latestDeploymentStatus: "queued",
+      }),
+    ).toBe("active");
+  });
+
+  it("keeps projects without published pages in updating state", () => {
+    expect(
+      projectDisplayStatus({
+        projectStatus: "active",
+        publishedPageCount: 0,
         latestDeploymentStatus: "queued",
       }),
     ).toBe("deploying");


### PR DESCRIPTION
## Summary
- show generated docs projects as live once published pages exist, even if a manual deployment handoff remains queued/in-progress
- display the canonical in-app docs route for generated docs instead of a non-existent mintlify.app host
- update dashboard utility coverage for the generated-site flow

Fixes #63

## Verification
- npm test -- --run tests/dashboard.test.ts
- npm run lint
- npm run typecheck