### PR TITLE
Normalize GitHub README formatting on import

### DIFF
--- a/src/lib/github-docs-import.ts
+++ b/src/lib/github-docs-import.ts
@@ -108,6 +108,63 @@ function toTitle(markdown: string, fallbackPath: string): string {
     .join(" ");
 }
 
+function htmlAttributesToRecord(attrs: string): Record<string, string> {
+  const record: Record<string, string> = {};
+  attrs.replace(
+    /([A-Za-z_:][-A-Za-z0-9_:.]*)\s*=\s*("([^"]*)"|'([^']*)'|([^\s"'>]+))/g,
+    (_match, name, _raw, dquoted, squoted, bare) => {
+      record[name.toLowerCase()] = dquoted ?? squoted ?? bare ?? "";
+      return "";
+    },
+  );
+  return record;
+}
+
+function stripHtmlTags(value: string): string {
+  return value.replace(/<[^>]+>/g, "").trim();
+}
+
+function normalizeGitHubMarkdownContent(content: string): string {
+  let normalized = content.replace(/\r\n?/g, "\n");
+
+  normalized = normalized.replace(/<br\s*\/?\s*>/gi, "\n");
+
+  normalized = normalized.replace(
+    /<h([1-6])\b[^>]*>([\s\S]*?)<\/h\1>/gi,
+    (_match, level: string, inner: string) =>
+      `${"#".repeat(Number(level))} ${stripHtmlTags(inner)}`,
+  );
+
+  normalized = normalized.replace(
+    /<img\b([^>]*)\/?\s*>/gi,
+    (match: string, attrs: string) => {
+      const parsed = htmlAttributesToRecord(attrs);
+      if (!parsed.src) return match;
+      return `![${parsed.alt ?? ""}](${parsed.src})`;
+    },
+  );
+
+  normalized = normalized.replace(
+    /<a\b([^>]*)>([\s\S]*?)<\/a>/gi,
+    (match: string, attrs: string, inner: string) => {
+      const parsed = htmlAttributesToRecord(attrs);
+      const label = stripHtmlTags(inner);
+      if (!parsed.href || !label) return label || match;
+      return `[${label}](${parsed.href})`;
+    },
+  );
+
+  normalized = normalized.replace(/<\/?(?:p|div|span|center)\b[^>]*>/gi, "\n");
+  normalized = normalized.replace(/<!--([\s\S]*?)-->/g, "");
+
+  return normalized
+    .split("\n")
+    .map((line) => line.replace(/[ \t]+$/g, ""))
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
 const EXCLUDED_PATHS = [
   /^agents\.md$/i,
   /^claude\.md$/i,
@@ -193,7 +250,7 @@ export async function importGitHubDocs(
           `GitHub content request failed with status ${response.status} for ${filePath}`,
         );
       }
-      const content = await response.text();
+      const content = normalizeGitHubMarkdownContent(await response.text());
       const pagePath = toPagePath(filePath, basePath);
       if (!pagePath) {
         return null;

--- a/src/lib/mdx-renderer.ts
+++ b/src/lib/mdx-renderer.ts
@@ -415,7 +415,12 @@ export function parseMdxToHtml(content: string): string {
       !/^[-*+]\s+/.test(lines[i]) &&
       !/^\d+\.\s+/.test(lines[i]) &&
       !lines[i].startsWith("> ") &&
-      !/^(-{3,}|\*{3,}|_{3,})\s*$/.test(lines[i])
+      !/^(-{3,}|\*{3,}|_{3,})\s*$/.test(lines[i]) &&
+      !(
+        lines[i].includes("|") &&
+        i + 1 < lines.length &&
+        /^\|?\s*[-:]+[-| :]*$/.test(lines[i + 1])
+      )
     ) {
       paraLines.push(lines[i]);
       i++;

--- a/tests/github-docs-import.test.ts
+++ b/tests/github-docs-import.test.ts
@@ -253,6 +253,52 @@ describe("importPublicGitHubDocs", () => {
     }
   });
 
+  it("normalizes common README HTML wrappers before import", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("/git/trees/")) {
+        return {
+          ok: true,
+          json: async () => ({ tree: [{ path: "README.md", type: "blob" }] }),
+        };
+      }
+      return {
+        ok: true,
+        text: async () => `<p align="center">
+  <h1 align="center">Opensend</h1>
+  <a href="https://example.com/docs"><img alt="Docs" src="docs.png" /></a>
+</p>
+
+Quick start:
+${"```"}bash
+git clone https://github.com/namuh-eng/opensend.git
+${"```"}
+
+| Command | Purpose |
+|---|---|
+| bun test | run tests |
+`,
+      };
+    });
+
+    const { importGitHubDocs } = await import("@/lib/github-docs-import");
+    const result = await importGitHubDocs({
+      repoUrl: "https://github.com/acme/docs",
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.pages[0].title).toBe("Opensend");
+      expect(result.pages[0].content).toContain("# Opensend");
+      expect(result.pages[0].content).toContain(
+        "[![Docs](https://raw.githubusercontent.com/acme/docs/main/docs.png)](https://example.com/docs)",
+      );
+      expect(result.pages[0].content).toContain("```bash");
+      expect(result.pages[0].content).toContain("| Command | Purpose |");
+      expect(result.pages[0].content).not.toContain('<p align="center">');
+    }
+  });
+
   it("handles relative links with titles", async () => {
     const fetchMock = vi.fn(async (url: string) => {
       if (url.includes("/git/trees/")) {


### PR DESCRIPTION
## Summary
- normalize common GitHub README HTML wrappers into markdown before storing imported docs
- preserve badge/image/link readability while still letting relative asset rewriting run
- keep tables from being swallowed by adjacent paragraphs when rendering imported markdown

Fixes #62

## Verification
- npm test -- --run tests/github-docs-import.test.ts tests/mdx-renderer.test.ts tests/dashboard.test.ts
- npm run lint
- npm run typecheck