### PR TITLE
Fix stale dashboard deployment activity status

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,9 @@
 import { ACTIVE_PROJECT_COOKIE, findActiveProject } from "@/lib/active-project";
 import { getBetterAuthUrl } from "@/lib/auth";
-import { projectDisplayStatus } from "@/lib/dashboard";
+import {
+  effectiveDeploymentStatus,
+  projectDisplayStatus,
+} from "@/lib/dashboard";
 import { db } from "@/lib/db";
 import {
   deployments,
@@ -201,6 +204,25 @@ export default async function DashboardPage() {
     }
   }
 
+  const isPublishedProjectLive =
+    project?.status === "active" && publishedPageCount > 0;
+  const visibleManualHandoffs = manualHandoffs.filter((handoff) => {
+    const detailsProjectId = handoff.details.projectId;
+    if (
+      isPublishedProjectLive &&
+      detailsProjectId === project?.id &&
+      (handoff.action === "deployment_manual_handoff_required" ||
+        handoff.action === "project_initial_deployment_manual_handoff_required")
+    ) {
+      return false;
+    }
+    return true;
+  });
+  const visibleManualHandoffStats =
+    visibleManualHandoffs.length === 0
+      ? { ...manualHandoffStats, oldestUnresolvedMs: null }
+      : manualHandoffStats;
+
   return (
     <DashboardHomeClient
       greeting={greeting}
@@ -222,6 +244,13 @@ export default async function DashboardPage() {
       }
       deployments={projectDeployments.map((d) => ({
         ...d,
+        status: project
+          ? effectiveDeploymentStatus({
+              status: d.status,
+              projectStatus: project.status,
+              publishedPageCount,
+            })
+          : d.status,
         startedAt: d.startedAt?.toISOString() ?? null,
         endedAt: d.endedAt?.toISOString() ?? null,
         createdAt: d.createdAt.toISOString(),
@@ -232,9 +261,9 @@ export default async function DashboardPage() {
         endedAt: d.endedAt?.toISOString() ?? null,
         createdAt: d.createdAt.toISOString(),
       }))}
-      manualHandoffs={manualHandoffs}
+      manualHandoffs={visibleManualHandoffs}
       resolvedManualHandoffs={resolvedManualHandoffs}
-      manualHandoffStats={manualHandoffStats}
+      manualHandoffStats={visibleManualHandoffStats}
       resolvedManualHandoffStats={resolvedManualHandoffStats}
       publishedPages={publishedPages}
     />

--- a/src/lib/dashboard.ts
+++ b/src/lib/dashboard.ts
@@ -66,6 +66,31 @@ export function formatDomainDisplay(
 
 export type ProjectDisplayStatus = "active" | "deploying" | "error";
 
+type DeploymentStatus = "queued" | "in_progress" | "succeeded" | "failed";
+
+/**
+ * Normalize deployment rows for dashboard display.
+ *
+ * In manual execution mode, deployment rows can remain queued/in_progress even
+ * after the project has published pages. For the user's dashboard, published
+ * live content is the stronger source of truth, so show those stale rows as
+ * successful instead of leaving the activity feed stuck on Updating.
+ */
+export function effectiveDeploymentStatus(params: {
+  status: string;
+  projectStatus: string;
+  publishedPageCount: number;
+}): DeploymentStatus {
+  if (params.status === "failed") return "failed";
+  if (params.status === "succeeded") return "succeeded";
+
+  if (params.projectStatus === "active" && params.publishedPageCount > 0) {
+    return "succeeded";
+  }
+
+  return params.status === "in_progress" ? "in_progress" : "queued";
+}
+
 /** Determine the dashboard status from deploy state and published content. */
 export function projectDisplayStatus(params: {
   projectStatus: string;

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -1,6 +1,7 @@
 import {
   buildQuickActionCards,
   buildSiteUrl,
+  effectiveDeploymentStatus,
   formatDomainDisplay,
   projectDisplayStatus,
   projectStatusSummary,
@@ -115,6 +116,48 @@ describe("projectStatusSummary", () => {
     expect(projectStatusSummary("active", "Something", null)).toBe(
       "No deployments yet",
     );
+  });
+});
+
+describe("effectiveDeploymentStatus", () => {
+  it("shows stale queued deployment rows as successful once published docs are live", () => {
+    expect(
+      effectiveDeploymentStatus({
+        status: "queued",
+        projectStatus: "active",
+        publishedPageCount: 3,
+      }),
+    ).toBe("succeeded");
+  });
+
+  it("shows stale in-progress deployment rows as successful once published docs are live", () => {
+    expect(
+      effectiveDeploymentStatus({
+        status: "in_progress",
+        projectStatus: "active",
+        publishedPageCount: 3,
+      }),
+    ).toBe("succeeded");
+  });
+
+  it("preserves failed deployment rows", () => {
+    expect(
+      effectiveDeploymentStatus({
+        status: "failed",
+        projectStatus: "active",
+        publishedPageCount: 3,
+      }),
+    ).toBe("failed");
+  });
+
+  it("keeps deployments pending while no pages are published", () => {
+    expect(
+      effectiveDeploymentStatus({
+        status: "in_progress",
+        projectStatus: "active",
+        publishedPageCount: 0,
+      }),
+    ).toBe("in_progress");
   });
 });
 


### PR DESCRIPTION
## Summary
- show queued/in-progress deployment rows as successful once published pages prove the docs are live
- hide stale deployment manual-handoff rows for live projects from the active follow-up queue
- add coverage for stale deployment status normalization

## Verification
- npm test -- --run tests/dashboard.test.ts tests/deployments.test.ts
- npm run lint
- npm run typecheck