### PR TITLE
Promote dashboard deployment activity fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,3 +80,54 @@ Test the SDK manually: import it, call the API, verify response.
 - Commit fixes: `git commit -m "fix: <description>"`
 - Push after every commit: `git push`
 - **NEVER weaken or delete tests to make them pass.** Fix the code, not the test.
+
+## Recovery Rules (autonomous loop — DO NOT pause)
+
+Ashley is building a closed-loop environment. You must keep working autonomously and never halt for human input unless every recovery path is exhausted. Optional human intervention is fine; mandatory waiting is not.
+
+### Detection signals (any of these means you are blocked)
+
+- HTTP 429 / "rate limit" / "too many requests" from Anthropic, OpenAI, GitHub, Vercel, AWS, or any external API
+- Build or test hangs > 5 min with no output
+- `make check` / `make test` / `make test-e2e` failing in a way you cannot diagnose in 2 attempts
+- Merge conflict on rebase or PR
+- Codex / agent stops to ask "approval required" / "needs review"
+- Tooling auth failed (gh CLI, AWS, npm registry)
+
+### Recovery procedure (in order — do not skip)
+
+1. **Print a clearly-keyworded line** so clawhip catches it. Use one of: `rate limit`, `merge conflict`, `tests failed`, `error TS`, `approval required`, `blocked`, `needs review`, `auth failed` — verbatim.
+2. **Log the blocker** to `private/recovery-log.jsonl` (gitignored) with timestamp, signal type, and one-line context.
+3. **Backoff schedule for rate limits**: 1 min → 5 min → 15 min → 30 min → 60 min → 2 h. Never sleep longer than 2 h in one stretch.
+4. **Do not pause the whole agent**. Switch to fallback work (see below) and emit a heartbeat every 4 min so clawhip stale-detection does not fire.
+5. **For merge conflicts**: rebase on `staging` (never `main`), resolve in favor of the more recent semantically-correct change, run `make check && make test`, force-push the agent branch. Never abandon the PR.
+6. **For test failures you cannot fix in 2 attempts**: emit `tests failed: <one-line>`, switch to fallback work, retry the failing test set later with a fresh shell.
+7. **After 4 failed retry rounds** (≈3.75 h cumulative blocked on the same task): emit `blocked: <task> exceeded all retries — needs human review`, stop attempting that task for the day, continue all other work.
+
+### Fallback work while blocked (always available, never empty)
+
+In priority order — if the current task is stuck, pick the next available item:
+
+1. Review other open PRs labeled `agent:shadowfax` and finish anything ready to merge into `staging`.
+2. Run `make check && make test` on a clean checkout of `staging` and report any drift.
+3. Pick another open issue labeled `agent:shadowfax` and start it (claim per the GitHub Claim Labels section).
+4. Lint/format pass: `make check` then commit any auto-fix output.
+5. Documentation polish in `docs/` or inline comments where coverage is thin.
+6. Tidy `private/recovery-log.jsonl` and reconcile with closed issues.
+
+### Hard rules
+
+- Never wait silently. clawhip's stale-detection fires after 5 minutes of no pane output — emit at least one line per 4 minutes.
+- Never weaken or delete tests to make them pass.
+- Never push to `main`. Always branch -> PR into `staging` -> verify -> merge into `staging` only.
+- Never use `--no-verify` / `--no-gpg-sign` / `git push --force` to main.
+- If you discover a blocker that genuinely requires human judgment (security, payment, account access), emit `needs human: <one-line>` and continue with fallback work.
+
+### Heartbeat format
+
+Every 4 minutes minimum during long-running work, print one line:
+```
+[heartbeat] <iso8601> | task=<short> | status=<running|sleeping|fallback> | next=<one-line>
+```
+
+This keeps the autonomous loop alive and gives clawhip a clean trail.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,20 +30,22 @@ An autonomously-built clone of a SaaS product. It has its own backend (AWS servi
 ## Commands
 - `make check` — typecheck + Biome lint/format. Run after every code change.
 - `make test` — run unit tests (Vitest). Must all pass.
-- `make test-e2e` — run Playwright E2E tests. Run FIRST before manual testing.
 - `make all` — check + test
 - `npm run dev` — start dev server (if not already running)
+- Do not run Playwright or `make test-e2e` for OpenDocs browser QA. Use Ever CLI/browser instead.
 
 ## How To Test
 
-### Step 1: Automated regression (fast)
-Run `make test-e2e` first. This catches obvious breakage in seconds.
+### Step 1: Browser verification (Ever CLI)
+Ever CLI/browser is the only approved E2E and parity surface for OpenDocs.
+- Read `/Users/ashleyha/dev/ever-skills/ever-browser/SKILL.md` before browser QA.
+- When Ever behavior is unclear or broken, inspect `/Users/ashleyha/dev/forever-agent/packages/cli` and fix/recover the Ever path instead of switching tools.
+- In the `shadowfax-opendocs` tmux lane, use the Shadowfax-scoped Ever profile (`ever` in-lane or `ever-shadowfax` outside it).
+- Use `ever snapshot` / `ever click` / `ever input` / `ever eval` with snapshot -> act -> snapshot evidence.
+- For Mintlify parity work, compare the reference page against `https://opendocs.namuh.co` through Ever browser evidence before deciding what to build.
 
-### Step 2: Manual verification (Ever CLI)
-- `ever snapshot` — see current page state
-- `ever click <id>` — click elements
-- `ever input <id> <text>` — fill inputs
-- Use the local Ever CLI docs available in your environment for full command reference
+### Step 2: Automated regression
+Run `make check` and `make test` after code changes. Do not use Playwright as a fallback for browser verification.
 
 ### Step 3: Real API testing
 Test the clone's API directly:
@@ -66,7 +68,7 @@ Test the SDK manually: import it, call the API, verify response.
 - `src/components/` — React components
 - `src/lib/` — Backend clients (db.ts, ses.ts, s3.ts, etc.)
 - `tests/` — unit tests (Vitest)
-- `tests/e2e/` — E2E tests (Playwright)
+- `tests/e2e/` — legacy browser tests; do not use for OpenDocs browser QA
 - `packages/sdk/` — TypeScript SDK package
 
 ## Environment

--- a/public/docs-search-shortcut.js
+++ b/public/docs-search-shortcut.js
@@ -1,0 +1,16 @@
+(function () {
+  if (window.__docsSearchBootstrapInstalled) return;
+  window.__docsSearchBootstrapInstalled = true;
+  window.__docsSearchRequested = false;
+
+  document.addEventListener("keydown", function (event) {
+    if (
+      String(event.key).toLowerCase() === "k" &&
+      (event.metaKey || event.ctrlKey)
+    ) {
+      event.preventDefault();
+      window.__docsSearchRequested = true;
+      document.dispatchEvent(new CustomEvent("open-search"));
+    }
+  });
+})();

--- a/src/app/[orgSlug]/[projectSlug]/home/page.tsx
+++ b/src/app/[orgSlug]/[projectSlug]/home/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/app/dashboard/page";

--- a/src/app/[orgSlug]/[projectSlug]/layout.tsx
+++ b/src/app/[orgSlug]/[projectSlug]/layout.tsx
@@ -1,0 +1,9 @@
+import { DashboardShell } from "@/components/layout/dashboard-shell";
+
+export default function MintlifyWorkspaceLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <DashboardShell>{children}</DashboardShell>;
+}

--- a/src/app/api/docs/[subdomain]/markdown/[...slug]/route.ts
+++ b/src/app/api/docs/[subdomain]/markdown/[...slug]/route.ts
@@ -1,0 +1,68 @@
+import { db } from "@/lib/db";
+import { pages, projects } from "@/lib/db/schema";
+import { pageToMarkdown } from "@/lib/page-chrome";
+import {
+  getDocsAccessCookieName,
+  hasValidDocsAccess,
+} from "@/lib/project-docs-access";
+import { and, eq } from "drizzle-orm";
+import { type NextRequest, NextResponse } from "next/server";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ subdomain: string; slug: string[] }> },
+) {
+  const { subdomain, slug } = await params;
+  const pagePath = slug.join("/").trim();
+
+  if (!pagePath) {
+    return new NextResponse("Page path required", { status: 400 });
+  }
+
+  const [project] = await db
+    .select({
+      id: projects.id,
+      settings: projects.settings,
+    })
+    .from(projects)
+    .where(eq(projects.subdomain, subdomain))
+    .limit(1);
+
+  if (!project) {
+    return new NextResponse("Documentation site not found", { status: 404 });
+  }
+
+  if (
+    !hasValidDocsAccess(
+      project.settings,
+      subdomain,
+      request.cookies.get(getDocsAccessCookieName(subdomain))?.value,
+    )
+  ) {
+    return new NextResponse("Docs password required", { status: 401 });
+  }
+
+  const [page] = await db
+    .select({ title: pages.title, content: pages.content })
+    .from(pages)
+    .where(
+      and(
+        eq(pages.projectId, project.id),
+        eq(pages.path, pagePath),
+        eq(pages.isPublished, true),
+      ),
+    )
+    .limit(1);
+
+  if (!page) {
+    return new NextResponse("Page not found", { status: 404 });
+  }
+
+  return new NextResponse(pageToMarkdown(page.title, page.content ?? ""), {
+    status: 200,
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+    },
+  });
+}

--- a/src/app/api/docs/[subdomain]/search/route.ts
+++ b/src/app/api/docs/[subdomain]/search/route.ts
@@ -16,6 +16,11 @@ import { buildSearchQuery } from "@/lib/assistant";
 import { db } from "@/lib/db";
 import { pages, projects } from "@/lib/db/schema";
 import {
+  generateAsyncApiPages,
+  generateVirtualPages,
+  isAsyncApiSpec,
+} from "@/lib/openapi";
+import {
   getDocsAccessCookieName,
   hasValidDocsAccess,
 } from "@/lib/project-docs-access";
@@ -25,6 +30,101 @@ import { type NextRequest, NextResponse } from "next/server";
 
 interface RouteContext {
   params: Promise<{ subdomain: string }>;
+}
+
+interface RankedSearchResult {
+  path: string;
+  title: string;
+  description: string | null;
+  snippet: string;
+  breadcrumb: string[];
+  rank: number;
+}
+
+function matchesQuery(query: string, values: Array<string | null | undefined>) {
+  const haystack = values.filter(Boolean).join(" ").toLowerCase();
+  const tokens = query.toLowerCase().split(/\s+/).filter(Boolean);
+  return tokens.every((token) => haystack.includes(token));
+}
+
+function rankMatch(
+  query: string,
+  fields: {
+    title: string;
+    path: string;
+    description?: string | null;
+    content?: string | null;
+  },
+) {
+  const q = query.toLowerCase();
+  if (fields.title.toLowerCase().includes(q)) return 0;
+  if (fields.path.toLowerCase().includes(q)) return 1;
+  if (fields.description?.toLowerCase().includes(q)) return 2;
+  if (fields.content?.toLowerCase().includes(q)) return 3;
+  return 4;
+}
+
+function getGeneratedApiSearchResults(
+  spec: Record<string, unknown> | undefined,
+  query: string,
+): RankedSearchResult[] {
+  if (!spec || typeof spec !== "object") return [];
+
+  if (isAsyncApiSpec(spec)) {
+    return generateAsyncApiPages(spec)
+      .filter((page) =>
+        matchesQuery(query, [
+          page.title,
+          page.path,
+          page.description,
+          page.channel.name,
+          page.group,
+        ]),
+      )
+      .map((page) => ({
+        path: page.path,
+        title: page.title,
+        description: page.description || null,
+        snippet: page.description,
+        breadcrumb: getBreadcrumb(page.path),
+        rank: rankMatch(query, {
+          title: page.title,
+          path: page.path,
+          description: page.description,
+        }),
+      }));
+  }
+
+  return generateVirtualPages(spec)
+    .filter((page) =>
+      matchesQuery(query, [
+        page.title,
+        page.path,
+        page.description,
+        page.method,
+        page.endpoint.path,
+        page.endpoint.operationId,
+        page.group,
+      ]),
+    )
+    .map((page) => {
+      const endpointLabel = `${page.method} ${page.endpoint.path}`;
+      return {
+        path: page.path,
+        title: page.title,
+        description: page.description || null,
+        snippet: page.description
+          ? `${endpointLabel} — ${page.description}`
+          : endpointLabel,
+        breadcrumb: getBreadcrumb(page.path),
+        rank: rankMatch(query, {
+          title: page.title,
+          path: page.path,
+          description: page.description,
+          content: endpointLabel,
+        }),
+      };
+    });
 }
 
 export async function GET(request: NextRequest, context: RouteContext) {
@@ -73,6 +173,10 @@ export async function GET(request: NextRequest, context: RouteContext) {
   }
 
   const projectId = projectResult[0].id;
+  const docsSettings = (projectResult[0].settings || {}) as Record<
+    string,
+    unknown
+  >;
   const pattern = buildSearchQuery(query);
 
   // Search with relevance ordering: title > description > content
@@ -107,13 +211,39 @@ export async function GET(request: NextRequest, context: RouteContext) {
     )
     .limit(limit);
 
-  const formatted = results.map((r) => ({
+  const formatted: RankedSearchResult[] = results.map((r) => ({
     path: r.path,
     title: r.title,
     description: r.description,
     snippet: extractSnippet(r.content, query),
     breadcrumb: getBreadcrumb(r.path),
+    rank: rankMatch(query, {
+      title: r.title,
+      path: r.path,
+      description: r.description,
+      content: r.content,
+    }),
   }));
 
-  return NextResponse.json(formatted, { status: 200 });
+  const generatedResults = getGeneratedApiSearchResults(
+    docsSettings.openApiSpec as Record<string, unknown> | undefined,
+    query,
+  );
+  const seenPaths = new Set<string>();
+  const combined = [...formatted, ...generatedResults]
+    .filter((result) => {
+      if (seenPaths.has(result.path)) return false;
+      seenPaths.add(result.path);
+      return true;
+    })
+    .sort(
+      (a, b) =>
+        a.rank - b.rank ||
+        a.title.localeCompare(b.title) ||
+        a.path.localeCompare(b.path),
+    )
+    .slice(0, limit)
+    .map(({ rank: _rank, ...result }) => result);
+
+  return NextResponse.json(combined, { status: 200 });
 }

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -201,6 +201,10 @@ export async function PUT(
     )?.installationId ??
     null;
 
+  const settingsUpdate = validation.fields.settings as
+    | Record<string, unknown>
+    | undefined;
+
   const mergedSettings = mergeProjectSettingsWithGitHubSource(
     existing[0].settings,
     buildGitHubSourceSelection({
@@ -209,6 +213,7 @@ export async function PUT(
       repoBranch: resolvedRepoBranch,
       repoPath: resolvedRepoPath,
     }),
+    settingsUpdate,
   );
 
   const updateFields = {

--- a/src/app/api/test/create-session/route.ts
+++ b/src/app/api/test/create-session/route.ts
@@ -5,12 +5,267 @@ import {
   session as authSessions,
   user as authUsers,
 } from "@/lib/db/auth-schema";
-import { orgMemberships, organizations, projects } from "@/lib/db/schema";
+import {
+  orgMemberships,
+  organizations,
+  pages,
+  projects,
+} from "@/lib/db/schema";
 import { slugify } from "@/lib/orgs";
 import { generateSubdomain, slugifyProject } from "@/lib/projects";
 import { serializeSignedCookie } from "better-call";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
+
+const FIXTURE_ORG_SLUG = "playwright-docs-fixtures";
+const FIXTURE_PROJECT_SLUG = "test-project";
+const FIXTURE_SUBDOMAIN = "test-project";
+
+const FIXTURE_OPENAPI_SPEC = {
+  openapi: "3.0.3",
+  info: { title: "Fixture API", version: "1.0.0" },
+  servers: [{ url: "https://api.example.com" }],
+  paths: {
+    "/plants": {
+      get: {
+        operationId: "getPlants",
+        summary: "Get Plants",
+        description: "Returns a list of plants.",
+        tags: ["Plants"],
+        parameters: [
+          {
+            name: "limit",
+            in: "query",
+            required: false,
+            description: "Maximum number of plants to return.",
+            schema: { type: "integer", default: 10 },
+          },
+        ],
+        responses: {
+          "200": { description: "A list of plants." },
+          "400": { description: "Invalid request." },
+        },
+      },
+    },
+  },
+};
+
+const FIXTURE_PROJECT_SETTINGS = {
+  supportEmail: "support@example.com",
+  githubUrl: "https://github.com/namuh-eng/opendocs",
+  docsConfig: {
+    footer: {
+      brandName: "OpenDocs",
+      brandUrl: "https://example.com",
+      socialLinks: [
+        { type: "github", url: "https://github.com/namuh-eng/opendocs" },
+      ],
+    },
+    apiDocs: {
+      playgroundEnabled: true,
+      baseApiUrl: "https://api.example.com",
+    },
+    assistantSearch: {
+      assistantEnabled: true,
+      searchEnabled: true,
+      searchPrompt: "Search the fixture docs...",
+    },
+  },
+  languages: {
+    enabled: true,
+    defaultLanguage: "en",
+    supportedLanguages: ["en", "fr"],
+  },
+  versions: {
+    enabled: true,
+    versions: [
+      { tag: "v2", name: "Version 2.0", isDefault: true },
+      { tag: "v1", name: "Version 1.0", isDefault: false },
+    ],
+  },
+  openApiSpec: FIXTURE_OPENAPI_SPEC,
+};
+
+const FIXTURE_PAGES = [
+  {
+    path: "introduction",
+    title: "Introduction",
+    description: "Welcome to the Playwright docs fixture.",
+    content: `# Introduction
+
+This stable fixture powers public docs route E2E coverage.
+
+## Getting started
+
+Use the quickstart to make your first request.
+
+### Install the package
+
+Install the SDK before continuing.
+
+## Configure navigation
+
+Navigation, pagination, and table of contents are verified from this page.
+`,
+  },
+  {
+    path: "quickstart",
+    title: "Quickstart",
+    description: "Get running quickly with the fixture docs.",
+    content: `# Quickstart
+
+This quickstart contains enough sections for layout, search, and TOC tests.
+
+## Create a project
+
+Create a docs project and publish your first page.
+
+## Install the SDK
+
+Install dependencies and configure authentication.
+
+## Make your first request
+
+Call the Plants API and inspect the response.
+`,
+  },
+  {
+    path: "getting-started",
+    title: "Getting Started",
+    description: "Searchable getting started content.",
+    content: `# Getting Started
+
+Search tests query this page for getting started and install guidance.
+
+## Install
+
+Install the package and configure your environment.
+`,
+  },
+  {
+    path: "guides/quickstart",
+    title: "Guide Quickstart",
+    description: "Nested guide page for breadcrumb coverage.",
+    content: `# Guide Quickstart
+
+Nested guide content for page chrome tests.
+
+## Guide section
+
+This heading appears in the table of contents.
+`,
+  },
+  {
+    path: "fr/introduction",
+    title: "Introduction",
+    description: "Page d’introduction en français.",
+    content: `# Introduction
+
+Contenu de test en français.
+`,
+  },
+  {
+    path: "v1/introduction",
+    title: "Introduction",
+    description: "Version 1 introduction page.",
+    content: `# Introduction
+
+Version 1 fixture content.
+`,
+  },
+  {
+    path: "v1/fr/introduction",
+    title: "Introduction",
+    description: "Version 1 French introduction page.",
+    content: `# Introduction
+
+Contenu français pour la version 1.
+`,
+  },
+];
+
+async function ensureDocsFixtureProject() {
+  let [org] = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(eq(organizations.slug, FIXTURE_ORG_SLUG))
+    .limit(1);
+
+  if (!org) {
+    [org] = await db
+      .insert(organizations)
+      .values({
+        name: "Playwright Docs Fixtures",
+        slug: FIXTURE_ORG_SLUG,
+      })
+      .returning({ id: organizations.id });
+  }
+
+  if (!org) return;
+
+  let [project] = await db
+    .select({ id: projects.id })
+    .from(projects)
+    .where(eq(projects.subdomain, FIXTURE_SUBDOMAIN))
+    .limit(1);
+
+  if (!project) {
+    [project] = await db
+      .insert(projects)
+      .values({
+        orgId: org.id,
+        name: "Test Project",
+        slug: FIXTURE_PROJECT_SLUG,
+        subdomain: FIXTURE_SUBDOMAIN,
+        status: "active",
+        settings: FIXTURE_PROJECT_SETTINGS,
+      })
+      .returning({ id: projects.id });
+  } else {
+    await db
+      .update(projects)
+      .set({
+        name: "Test Project",
+        subdomain: FIXTURE_SUBDOMAIN,
+        status: "active",
+        settings: FIXTURE_PROJECT_SETTINGS,
+      })
+      .where(eq(projects.id, project.id));
+  }
+
+  if (!project) return;
+
+  for (const fixturePage of FIXTURE_PAGES) {
+    const [existingPage] = await db
+      .select({ id: pages.id })
+      .from(pages)
+      .where(
+        and(eq(pages.projectId, project.id), eq(pages.path, fixturePage.path)),
+      )
+      .limit(1);
+
+    const pageValues = {
+      title: fixturePage.title,
+      description: fixturePage.description,
+      content: fixturePage.content,
+      frontmatter: {},
+      isPublished: true,
+    };
+
+    if (existingPage) {
+      await db
+        .update(pages)
+        .set(pageValues)
+        .where(eq(pages.id, existingPage.id));
+    } else {
+      await db.insert(pages).values({
+        projectId: project.id,
+        path: fixturePage.path,
+        ...pageValues,
+      });
+    }
+  }
+}
 
 // Test-only route for creating sessions in E2E tests.
 // Only available in dedicated test environments.
@@ -142,6 +397,8 @@ export async function POST(request: Request) {
       });
     }
   }
+
+  await ensureDocsFixtureProject();
 
   await db.delete(authSessions).where(eq(authSessions.userId, existingUser.id));
 

--- a/src/app/dashboard/dashboard-home-client.tsx
+++ b/src/app/dashboard/dashboard-home-client.tsx
@@ -54,6 +54,9 @@ interface ProjectInfo {
   subdomain: string | null;
   status: string;
   customDomain: string | null;
+  repoUrl: string | null;
+  repoBranch: string | null;
+  repoPath: string | null;
 }
 
 interface ManualHandoffRow {
@@ -132,6 +135,18 @@ const ICON_MAP = {
   settings: Settings,
   "bar-chart": BarChart3,
 } as const;
+
+function parseRepoOwner(repoUrl: string | null) {
+  if (!repoUrl) return null;
+
+  const match = repoUrl.match(/github\.com[:/]([^/]+)\//i);
+  return match?.[1] ?? null;
+}
+
+function formatRepoPath(repoPath: string | null) {
+  if (!repoPath || repoPath === "/") return null;
+  return repoPath.replace(/^\//, "");
+}
 
 function ProjectStatusBadge({ status }: { status: string }) {
   const isLive = status === "active";
@@ -363,6 +378,9 @@ export function DashboardHomeClient({
   const domainDisplay = project
     ? formatDomainDisplay(project.subdomain, project.customDomain)
     : "";
+  const repoOwner = project ? parseRepoOwner(project.repoUrl) : null;
+  const repoPath = project ? formatRepoPath(project.repoPath) : null;
+  const repoBranch = project?.repoBranch ?? null;
 
   const quickActions = project ? buildQuickActionCards(project.id) : [];
   // Fill in the view-site href dynamically
@@ -580,6 +598,26 @@ export function DashboardHomeClient({
                 </a>
               </div>
 
+              {(repoOwner || repoPath || repoBranch) && (
+                <div className="flex items-center gap-2 rounded-lg border border-white/[0.08] bg-[#1a1a1a] px-3 py-2 text-xs text-gray-400">
+                  {repoOwner && (
+                    <span className="text-gray-300">{repoOwner}</span>
+                  )}
+                  {repoPath && (
+                    <>
+                      <span className="text-gray-600">/</span>
+                      <span className="text-gray-300">{repoPath}</span>
+                    </>
+                  )}
+                  {repoBranch && (
+                    <>
+                      <span className="text-gray-600">branch</span>
+                      <span className="text-white">{repoBranch}</span>
+                    </>
+                  )}
+                </div>
+              )}
+
               {/* Domain info */}
               <div className="pt-2 space-y-1">
                 <p className="text-xs font-medium text-gray-500">Domain</p>
@@ -663,210 +701,215 @@ export function DashboardHomeClient({
           </div>
 
           {/* Manual follow-up queue */}
-          <div className="mb-6 rounded-xl border border-amber-400/20 bg-amber-400/[0.06] p-4">
-            <div className="flex items-start justify-between gap-4 mb-3">
-              <div>
-                <h3 className="text-sm font-medium text-white">
-                  Manual follow-up queue
-                </h3>
-                <p className="text-xs text-gray-400 mt-1">
-                  Recent async work that was recorded without a live executor.
-                </p>
+          {(unresolvedCount > 0 || resolvedCount > 0) && (
+            <div className="mb-6 rounded-xl border border-amber-400/20 bg-amber-400/[0.06] p-4">
+              <div className="flex items-start justify-between gap-4 mb-3">
+                <div>
+                  <h3 className="text-sm font-medium text-white">
+                    Manual follow-up queue
+                  </h3>
+                  <p className="text-xs text-gray-400 mt-1">
+                    Recent async work that was recorded without a live executor.
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-amber-300">
+                    {displayedManualHandoffs.length} shown
+                  </span>
+                  {sortedManualHandoffs.length > 5 ? (
+                    <button
+                      type="button"
+                      onClick={() => setShowAllHandoffs((current) => !current)}
+                      className="text-xs text-gray-400 hover:text-white transition-colors"
+                    >
+                      {showAllHandoffs ? "Show less" : "View all"}
+                    </button>
+                  ) : null}
+                </div>
               </div>
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-amber-300">
-                  {displayedManualHandoffs.length} shown
-                </span>
-                {sortedManualHandoffs.length > 5 ? (
+
+              {handoffNotice ? (
+                <div className="mb-3 rounded-md border border-emerald-400/20 bg-emerald-400/10 px-3 py-2 text-xs text-emerald-200 flex items-center justify-between">
+                  <span>{handoffNotice}</span>
                   <button
                     type="button"
-                    onClick={() => setShowAllHandoffs((current) => !current)}
-                    className="text-xs text-gray-400 hover:text-white transition-colors"
+                    onClick={() => setHandoffNotice(null)}
+                    className="text-emerald-400 hover:text-emerald-300"
                   >
-                    {showAllHandoffs ? "Show less" : "View all"}
+                    <Plus size={14} className="rotate-45" />
                   </button>
-                ) : null}
-              </div>
-            </div>
+                </div>
+              ) : null}
 
-            {handoffNotice ? (
-              <div className="mb-3 rounded-md border border-emerald-400/20 bg-emerald-400/10 px-3 py-2 text-xs text-emerald-200 flex items-center justify-between">
-                <span>{handoffNotice}</span>
-                <button
-                  type="button"
-                  onClick={() => setHandoffNotice(null)}
-                  className="text-emerald-400 hover:text-emerald-300"
-                >
-                  <Plus size={14} className="rotate-45" />
-                </button>
-              </div>
-            ) : null}
-
-            <div className="mb-3 grid grid-cols-4 gap-2 text-xs">
-              <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-gray-300">
-                <span className="block text-gray-500">Unresolved</span>
-                <span className="text-white">{unresolvedCount}</span>
-              </div>
-              <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-gray-300">
-                <span className="block text-gray-500">Resolved</span>
-                <span className="text-white">{resolvedCount}</span>
-              </div>
-              <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-gray-300">
-                <span className="block text-gray-500">Avg resolve time</span>
-                <span className="text-white">
-                  {averageResolvedDuration ?? "—"}
-                </span>
-              </div>
-              <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-gray-300">
-                <span className="block text-gray-500">Oldest unresolved</span>
-                <span className="text-white">{oldestUnresolvedAge ?? "—"}</span>
-              </div>
-            </div>
-
-            <div className="flex items-center justify-between gap-3 mb-3">
-              <div className="flex items-center gap-2">
-                <button
-                  type="button"
-                  onClick={() => setHandoffView("active")}
-                  className={clsx(
-                    "px-2.5 py-1 rounded-md text-xs transition-colors",
-                    handoffView === "active"
-                      ? "bg-white/[0.12] text-white"
-                      : "text-gray-400 hover:text-white hover:bg-white/[0.06]",
-                  )}
-                >
-                  Active
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setHandoffView("resolved")}
-                  className={clsx(
-                    "px-2.5 py-1 rounded-md text-xs transition-colors",
-                    handoffView === "resolved"
-                      ? "bg-white/[0.12] text-white"
-                      : "text-gray-400 hover:text-white hover:bg-white/[0.06]",
-                  )}
-                >
-                  Resolved
-                </button>
+              <div className="mb-3 grid grid-cols-4 gap-2 text-xs">
+                <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-gray-300">
+                  <span className="block text-gray-500">Unresolved</span>
+                  <span className="text-white">{unresolvedCount}</span>
+                </div>
+                <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-gray-300">
+                  <span className="block text-gray-500">Resolved</span>
+                  <span className="text-white">{resolvedCount}</span>
+                </div>
+                <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-gray-300">
+                  <span className="block text-gray-500">Avg resolve time</span>
+                  <span className="text-white">
+                    {averageResolvedDuration ?? "—"}
+                  </span>
+                </div>
+                <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-gray-300">
+                  <span className="block text-gray-500">Oldest unresolved</span>
+                  <span className="text-white">
+                    {oldestUnresolvedAge ?? "—"}
+                  </span>
+                </div>
               </div>
 
-              <div className="flex items-center gap-2">
-                {HANDOFF_FILTERS.map((filter) => (
+              <div className="flex items-center justify-between gap-3 mb-3">
+                <div className="flex items-center gap-2">
                   <button
-                    key={filter.key}
                     type="button"
-                    onClick={() => setHandoffFilter(filter.key)}
+                    onClick={() => setHandoffView("active")}
                     className={clsx(
                       "px-2.5 py-1 rounded-md text-xs transition-colors",
-                      handoffFilter === filter.key
+                      handoffView === "active"
                         ? "bg-white/[0.12] text-white"
                         : "text-gray-400 hover:text-white hover:bg-white/[0.06]",
                     )}
                   >
-                    {filter.label}
+                    Active
                   </button>
-                ))}
-                <select
-                  value={handoffSort}
-                  onChange={(event) =>
-                    setHandoffSort(
-                      event.target.value as
-                        | "newest"
-                        | "oldest"
-                        | "longest-open",
-                    )
-                  }
-                  className="rounded-md border border-white/[0.08] bg-black/20 px-2 py-1 text-xs text-gray-300 focus:outline-none"
-                >
-                  <option value="newest">Newest</option>
-                  <option value="oldest">Oldest</option>
-                  <option value="longest-open">Longest open</option>
-                </select>
-              </div>
-            </div>
-
-            {filteredManualHandoffs.length === 0 ? (
-              <p className="text-sm text-gray-500">
-                No manual handoffs recorded recently.
-              </p>
-            ) : (
-              <div className="space-y-2">
-                {displayedManualHandoffs.map((handoff) => (
-                  <div
-                    key={handoff.id}
-                    className="flex items-center justify-between gap-3 rounded-lg border border-white/[0.06] bg-black/20 px-3 py-2"
+                  <button
+                    type="button"
+                    onClick={() => setHandoffView("resolved")}
+                    className={clsx(
+                      "px-2.5 py-1 rounded-md text-xs transition-colors",
+                      handoffView === "resolved"
+                        ? "bg-white/[0.12] text-white"
+                        : "text-gray-400 hover:text-white hover:bg-white/[0.06]",
+                    )}
                   >
-                    <div className="min-w-0">
-                      <p className="text-sm text-white truncate">
-                        {handoff.action}
-                      </p>
-                      <p className="text-xs text-gray-500 truncate">
-                        {String(
-                          handoff.details.projectId ??
-                            handoff.details.deploymentId ??
-                            handoff.details.jobId ??
-                            "manual follow-up required",
-                        )}
-                      </p>
-                      {handoffView === "resolved" &&
-                      handoff.details.resolution ? (
-                        <>
-                          <p className="text-xs text-gray-500 truncate mt-1">
-                            Created {timeAgo(handoff.createdAt)}
-                            {handoff.details.resolution.resolvedAt
-                              ? ` • Resolved ${timeAgo(handoff.details.resolution.resolvedAt)}`
-                              : ""}
-                            {handoff.details.resolution.resolvedAt
-                              ? ` • ${formatDuration(handoff.createdAt, handoff.details.resolution.resolvedAt) ?? ""}`
-                              : ""}
-                          </p>
-                          <p className="text-xs text-gray-500 truncate mt-1">
-                            Resolved by{" "}
-                            {handoff.details.resolution.resolvedByName ??
-                              handoff.details.resolution.resolvedByUserId ??
-                              "unknown"}
-                          </p>
-                          {handoff.details.resolution.resolutionNote ? (
-                            <p className="text-xs text-gray-400 mt-1 line-clamp-2">
-                              Note: {handoff.details.resolution.resolutionNote}
-                            </p>
-                          ) : null}
-                        </>
-                      ) : null}
-                    </div>
-                    <div className="flex items-center gap-3 shrink-0">
-                      <span className="text-xs text-gray-400">
-                        {timeAgo(handoff.createdAt)}
-                      </span>
-                      {handoffView === "active" ? (
-                        <div className="flex items-center gap-2">
-                          <button
-                            type="button"
-                            onClick={() => deleteHandoff(handoff.id)}
-                            className="p-1.5 rounded-md text-gray-500 hover:text-red-400 hover:bg-red-400/10 transition-colors"
-                            title="Delete record"
-                          >
-                            <Trash2 size={14} />
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => resolveHandoff(handoff.id)}
-                            disabled={resolvingHandoffId === handoff.id}
-                            className="px-2 py-1 rounded-md text-xs bg-emerald-500/15 text-emerald-300 hover:bg-emerald-500/25 disabled:opacity-50 transition-colors"
-                          >
-                            {resolvingHandoffId === handoff.id
-                              ? "Resolving..."
-                              : "Resolve"}
-                          </button>
-                        </div>
-                      ) : null}
-                    </div>
-                  </div>
-                ))}
+                    Resolved
+                  </button>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  {HANDOFF_FILTERS.map((filter) => (
+                    <button
+                      key={filter.key}
+                      type="button"
+                      onClick={() => setHandoffFilter(filter.key)}
+                      className={clsx(
+                        "px-2.5 py-1 rounded-md text-xs transition-colors",
+                        handoffFilter === filter.key
+                          ? "bg-white/[0.12] text-white"
+                          : "text-gray-400 hover:text-white hover:bg-white/[0.06]",
+                      )}
+                    >
+                      {filter.label}
+                    </button>
+                  ))}
+                  <select
+                    value={handoffSort}
+                    onChange={(event) =>
+                      setHandoffSort(
+                        event.target.value as
+                          | "newest"
+                          | "oldest"
+                          | "longest-open",
+                      )
+                    }
+                    className="rounded-md border border-white/[0.08] bg-black/20 px-2 py-1 text-xs text-gray-300 focus:outline-none"
+                  >
+                    <option value="newest">Newest</option>
+                    <option value="oldest">Oldest</option>
+                    <option value="longest-open">Longest open</option>
+                  </select>
+                </div>
               </div>
-            )}
-          </div>
+
+              {filteredManualHandoffs.length === 0 ? (
+                <p className="text-sm text-gray-500">
+                  No manual handoffs recorded recently.
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {displayedManualHandoffs.map((handoff) => (
+                    <div
+                      key={handoff.id}
+                      className="flex items-center justify-between gap-3 rounded-lg border border-white/[0.06] bg-black/20 px-3 py-2"
+                    >
+                      <div className="min-w-0">
+                        <p className="text-sm text-white truncate">
+                          {handoff.action}
+                        </p>
+                        <p className="text-xs text-gray-500 truncate">
+                          {String(
+                            handoff.details.projectId ??
+                              handoff.details.deploymentId ??
+                              handoff.details.jobId ??
+                              "manual follow-up required",
+                          )}
+                        </p>
+                        {handoffView === "resolved" &&
+                        handoff.details.resolution ? (
+                          <>
+                            <p className="text-xs text-gray-500 truncate mt-1">
+                              Created {timeAgo(handoff.createdAt)}
+                              {handoff.details.resolution.resolvedAt
+                                ? ` • Resolved ${timeAgo(handoff.details.resolution.resolvedAt)}`
+                                : ""}
+                              {handoff.details.resolution.resolvedAt
+                                ? ` • ${formatDuration(handoff.createdAt, handoff.details.resolution.resolvedAt) ?? ""}`
+                                : ""}
+                            </p>
+                            <p className="text-xs text-gray-500 truncate mt-1">
+                              Resolved by{" "}
+                              {handoff.details.resolution.resolvedByName ??
+                                handoff.details.resolution.resolvedByUserId ??
+                                "unknown"}
+                            </p>
+                            {handoff.details.resolution.resolutionNote ? (
+                              <p className="text-xs text-gray-400 mt-1 line-clamp-2">
+                                Note:{" "}
+                                {handoff.details.resolution.resolutionNote}
+                              </p>
+                            ) : null}
+                          </>
+                        ) : null}
+                      </div>
+                      <div className="flex items-center gap-3 shrink-0">
+                        <span className="text-xs text-gray-400">
+                          {timeAgo(handoff.createdAt)}
+                        </span>
+                        {handoffView === "active" ? (
+                          <div className="flex items-center gap-2">
+                            <button
+                              type="button"
+                              onClick={() => deleteHandoff(handoff.id)}
+                              className="p-1.5 rounded-md text-gray-500 hover:text-red-400 hover:bg-red-400/10 transition-colors"
+                              title="Delete record"
+                            >
+                              <Trash2 size={14} />
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => resolveHandoff(handoff.id)}
+                              disabled={resolvingHandoffId === handoff.id}
+                              className="px-2 py-1 rounded-md text-xs bg-emerald-500/15 text-emerald-300 hover:bg-emerald-500/25 disabled:opacity-50 transition-colors"
+                            >
+                              {resolvingHandoffId === handoff.id
+                                ? "Resolving..."
+                                : "Resolve"}
+                            </button>
+                          </div>
+                        ) : null}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
 
           {/* Activity section */}
           <div>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -18,7 +18,14 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { DashboardHomeClient } from "./dashboard-home-client";
 
-export default async function DashboardPage() {
+interface DashboardPageProps {
+  params?: Promise<{ orgSlug?: string; projectSlug?: string }>;
+}
+
+export default async function DashboardPage({
+  params,
+}: DashboardPageProps = {}) {
+  const routeParams = await params;
   const session = await getServerSession();
   if (!session) redirect("/login");
 
@@ -35,7 +42,14 @@ export default async function DashboardPage() {
     })
     .from(orgMemberships)
     .innerJoin(organizations, eq(orgMemberships.orgId, organizations.id))
-    .where(eq(orgMemberships.userId, session.user.id))
+    .where(
+      routeParams?.orgSlug
+        ? and(
+            eq(orgMemberships.userId, session.user.id),
+            eq(organizations.slug, routeParams.orgSlug),
+          )
+        : eq(orgMemberships.userId, session.user.id),
+    )
     .limit(1);
 
   if (membership.length === 0) redirect("/onboarding");
@@ -49,7 +63,11 @@ export default async function DashboardPage() {
     .orderBy(projects.createdAt);
 
   const activeProjectId = (await cookies()).get(ACTIVE_PROJECT_COOKIE)?.value;
-  const project = findActiveProject(orgProjects, activeProjectId);
+  const project = routeParams?.projectSlug
+    ? (orgProjects.find(
+        (candidate) => candidate.slug === routeParams.projectSlug,
+      ) ?? findActiveProject(orgProjects, activeProjectId))
+    : findActiveProject(orgProjects, activeProjectId);
 
   type DeploymentRow = {
     id: string;
@@ -204,8 +222,7 @@ export default async function DashboardPage() {
     }
   }
 
-  const isPublishedProjectLive =
-    project?.status === "active" && publishedPageCount > 0;
+  const isPublishedProjectLive = project?.status === "active";
   const visibleManualHandoffs = manualHandoffs.filter((handoff) => {
     const detailsProjectId = handoff.details.projectId;
     if (
@@ -233,6 +250,9 @@ export default async function DashboardPage() {
               id: project.id,
               name: project.name,
               subdomain: project.subdomain,
+              repoUrl: project.repoUrl,
+              repoBranch: project.repoBranch,
+              repoPath: project.repoPath,
               status: projectDisplayStatus({
                 projectStatus: project.status,
                 publishedPageCount,

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,9 @@
 import { ACTIVE_PROJECT_COOKIE, findActiveProject } from "@/lib/active-project";
 import { getBetterAuthUrl } from "@/lib/auth";
-import { projectDisplayStatus } from "@/lib/dashboard";
+import {
+  effectiveDeploymentStatus,
+  projectDisplayStatus,
+} from "@/lib/dashboard";
 import { db } from "@/lib/db";
 import {
   deployments,
@@ -201,6 +204,25 @@ export default async function DashboardPage() {
     }
   }
 
+  const isPublishedProjectLive =
+    project?.status === "active" && publishedPageCount > 0;
+  const visibleManualHandoffs = manualHandoffs.filter((handoff) => {
+    const detailsProjectId = handoff.details.projectId;
+    if (
+      isPublishedProjectLive &&
+      detailsProjectId === project?.id &&
+      (handoff.action === "deployment_manual_handoff_required" ||
+        handoff.action === "project_initial_deployment_manual_handoff_required")
+    ) {
+      return false;
+    }
+    return true;
+  });
+  const visibleManualHandoffStats =
+    visibleManualHandoffs.length === 0
+      ? { ...manualHandoffStats, oldestUnresolvedMs: null }
+      : manualHandoffStats;
+
   return (
     <DashboardHomeClient
       greeting={greeting}
@@ -222,6 +244,13 @@ export default async function DashboardPage() {
       }
       deployments={projectDeployments.map((d) => ({
         ...d,
+        status: project
+          ? effectiveDeploymentStatus({
+              status: d.status,
+              projectStatus: project.status,
+              publishedPageCount,
+            })
+          : d.status,
         startedAt: d.startedAt?.toISOString() ?? null,
         endedAt: d.endedAt?.toISOString() ?? null,
         createdAt: d.createdAt.toISOString(),
@@ -232,9 +261,9 @@ export default async function DashboardPage() {
         endedAt: d.endedAt?.toISOString() ?? null,
         createdAt: d.createdAt.toISOString(),
       }))}
-      manualHandoffs={manualHandoffs}
+      manualHandoffs={visibleManualHandoffs}
       resolvedManualHandoffs={resolvedManualHandoffs}
-      manualHandoffStats={manualHandoffStats}
+      manualHandoffStats={visibleManualHandoffStats}
       resolvedManualHandoffStats={resolvedManualHandoffStats}
       publishedPages={publishedPages}
     />

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -42,14 +42,7 @@ export default async function DashboardPage({
     })
     .from(orgMemberships)
     .innerJoin(organizations, eq(orgMemberships.orgId, organizations.id))
-    .where(
-      routeParams?.orgSlug
-        ? and(
-            eq(orgMemberships.userId, session.user.id),
-            eq(organizations.slug, routeParams.orgSlug),
-          )
-        : eq(orgMemberships.userId, session.user.id),
-    )
+    .where(eq(orgMemberships.userId, session.user.id))
     .limit(1);
 
   if (membership.length === 0) redirect("/onboarding");

--- a/src/app/docs/[subdomain]/[...slug]/page.tsx
+++ b/src/app/docs/[subdomain]/[...slug]/page.tsx
@@ -492,12 +492,14 @@ export default async function DocsPage({
 
   // Build searchable pages list (DB + virtual)
   const searchablePages = allNavPaths;
+  const hasGeneratedApiRoute = Boolean(virtualPage || asyncPage);
 
   // Compute available locales for the language switcher
   const availableLocales = getAvailableLocalesForPage(
     allPagesRaw,
     pagePath,
     langConfig,
+    { includeConfiguredRoutes: hasGeneratedApiRoute },
   );
 
   // Compute available versions for the version switcher
@@ -505,6 +507,7 @@ export default async function DocsPage({
     allPagesRaw,
     pagePath,
     versionConfig,
+    { includeConfiguredRoutes: hasGeneratedApiRoute },
   );
 
   return (

--- a/src/app/docs/[subdomain]/[...slug]/page.tsx
+++ b/src/app/docs/[subdomain]/[...slug]/page.tsx
@@ -105,22 +105,6 @@ function applyProjectBrandCasing(title: string, projectName: string): string {
     : title;
 }
 
-function applyProjectBrandCasingToContent(
-  content: string,
-  projectName: string,
-): string {
-  const brandName = projectName.replace(/\s+docs$/i, "").trim();
-  if (!brandName || !/^[a-z0-9]+$/i.test(brandName)) return content;
-
-  return content.replace(
-    new RegExp(
-      `\\b${brandName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`,
-      "gi",
-    ),
-    brandName,
-  );
-}
-
 export async function generateMetadata({
   params,
 }: DocsPageProps): Promise<Metadata> {
@@ -455,10 +439,7 @@ export default async function DocsPage({
     // Render DB page (existing behavior)
     pageTitle = applyProjectBrandCasing(currentPage.title, project.name);
     pageDescription = currentPage.description || "";
-    pageContent = applyProjectBrandCasingToContent(
-      currentPage.content || "",
-      project.name,
-    );
+    pageContent = currentPage.content || "";
 
     // Resolve snippets and variables before rendering
     const snippetPages = allPages

--- a/src/app/docs/[subdomain]/[...slug]/page.tsx
+++ b/src/app/docs/[subdomain]/[...slug]/page.tsx
@@ -77,6 +77,50 @@ interface DocsPageProps {
 
 const APP_URL = getPublicAppUrl();
 
+function normalizeHeadingText(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[`*_~]/g, "")
+    .replace(/<[^>]+>/g, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function stripLeadingDuplicateH1(content: string, title: string): string {
+  const match = content.match(/^\s*#\s+(.+?)\s*(?:\r?\n|$)/);
+  if (!match) return content;
+
+  return normalizeHeadingText(match[1] ?? "") === normalizeHeadingText(title)
+    ? content.slice(match[0].length).replace(/^\s*\r?\n/, "")
+    : content;
+}
+
+function applyProjectBrandCasing(title: string, projectName: string): string {
+  const brandName = projectName.replace(/\s+docs$/i, "").trim();
+  if (!brandName) return title;
+
+  return normalizeHeadingText(title).replace(/\s+/g, "") ===
+    normalizeHeadingText(brandName).replace(/\s+/g, "")
+    ? brandName
+    : title;
+}
+
+function applyProjectBrandCasingToContent(
+  content: string,
+  projectName: string,
+): string {
+  const brandName = projectName.replace(/\s+docs$/i, "").trim();
+  if (!brandName || !/^[a-z0-9]+$/i.test(brandName)) return content;
+
+  return content.replace(
+    new RegExp(
+      `\\b${brandName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`,
+      "gi",
+    ),
+    brandName,
+  );
+}
+
 export async function generateMetadata({
   params,
 }: DocsPageProps): Promise<Metadata> {
@@ -356,7 +400,7 @@ export default async function DocsPage({
   const navPages = allPages.map((p) => ({
     id: p.id,
     path: p.path,
-    title: p.title,
+    title: applyProjectBrandCasing(p.title, project.name),
     frontmatter: p.frontmatter as Record<string, unknown> | null,
   }));
 
@@ -409,9 +453,12 @@ export default async function DocsPage({
     }
   } else if (currentPage) {
     // Render DB page (existing behavior)
-    pageTitle = currentPage.title;
+    pageTitle = applyProjectBrandCasing(currentPage.title, project.name);
     pageDescription = currentPage.description || "";
-    pageContent = currentPage.content || "";
+    pageContent = applyProjectBrandCasingToContent(
+      currentPage.content || "",
+      project.name,
+    );
 
     // Resolve snippets and variables before rendering
     const snippetPages = allPages
@@ -425,7 +472,8 @@ export default async function DocsPage({
       projectVars,
     );
 
-    let contentToRender = pageContent;
+    let contentToRender = stripLeadingDuplicateH1(pageContent, pageTitle);
+    pageContent = contentToRender;
     contentToRender = resolveSnippets(contentToRender, snippetPages);
     contentToRender = resolveVariables(contentToRender, variables);
     renderedHtml = renderMdxContent(contentToRender);

--- a/src/app/docs/[subdomain]/[...slug]/page.tsx
+++ b/src/app/docs/[subdomain]/[...slug]/page.tsx
@@ -81,6 +81,11 @@ interface DocsPageProps {
 }
 
 const APP_URL = getPublicAppUrl();
+const DOCS_NOT_FOUND_TITLE = "404: This page could not be found.";
+
+function getDocsNotFoundMetadata(): Metadata {
+  return { title: DOCS_NOT_FOUND_TITLE };
+}
 
 function normalizeHeadingText(value: string): string {
   return value
@@ -125,7 +130,7 @@ export async function generateMetadata({
     .where(eq(projects.subdomain, subdomain))
     .limit(1);
 
-  if (projectResult.length === 0) return {};
+  if (projectResult.length === 0) return getDocsNotFoundMetadata();
 
   const project = projectResult[0];
   const docsSettings = (project.settings || {}) as Record<string, unknown>;
@@ -179,7 +184,27 @@ export async function generateMetadata({
     )
     .limit(1);
 
-  if (pageResult.length === 0) return {};
+  if (pageResult.length === 0) {
+    if (findRedirect(docsConfig.advanced.redirects, pagePath)) return {};
+
+    const spec = docsSettings.openApiSpec as
+      | Record<string, unknown>
+      | undefined;
+    if (spec && typeof spec === "object") {
+      const generatedPage = isAsyncApiSpec(spec)
+        ? findVirtualAsyncApiPage(generateAsyncApiPages(spec), pagePath)
+        : findVirtualPage(generateVirtualPages(spec), pagePath);
+
+      if (generatedPage) {
+        return {
+          title: generatedPage.title,
+          description: generatedPage.description,
+        };
+      }
+    }
+
+    return getDocsNotFoundMetadata();
+  }
 
   const page = pageResult[0];
   const meta = buildPageMetadata(

--- a/src/app/docs/[subdomain]/[...slug]/page.tsx
+++ b/src/app/docs/[subdomain]/[...slug]/page.tsx
@@ -20,7 +20,11 @@ import { renderApiReferencePage } from "@/lib/api-reference";
 import { getPublicAppUrl } from "@/lib/app-url";
 import { db } from "@/lib/db";
 import { pages, projects } from "@/lib/db/schema";
-import { findRedirect, mergeDocsConfig } from "@/lib/docs-config";
+import {
+  findRedirect,
+  getDocsThemeCssVars,
+  mergeDocsConfig,
+} from "@/lib/docs-config";
 import { getFooterSettings } from "@/lib/docs-footer";
 import { extractToc } from "@/lib/editor";
 import {
@@ -69,6 +73,7 @@ import { and, eq } from "drizzle-orm";
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import { notFound, permanentRedirect } from "next/navigation";
+import type { CSSProperties } from "react";
 
 interface DocsPageProps {
   params: Promise<{ subdomain: string; slug: string[] }>;
@@ -539,8 +544,10 @@ export default async function DocsPage({
     { includeConfiguredRoutes: hasGeneratedApiRoute },
   );
 
+  const docsThemeStyle = getDocsThemeCssVars(docsConfig) as CSSProperties;
+
   return (
-    <div className="docs-layout">
+    <div className="docs-layout" style={docsThemeStyle}>
       <DocsTopbar
         projectName={project.name}
         subdomain={subdomain}

--- a/src/app/docs/[subdomain]/[...slug]/page.tsx
+++ b/src/app/docs/[subdomain]/[...slug]/page.tsx
@@ -197,7 +197,7 @@ export async function generateMetadata({
 
       if (generatedPage) {
         return {
-          title: generatedPage.title,
+          title: "Documentation",
           description: generatedPage.description,
         };
       }

--- a/src/app/docs/[subdomain]/[...slug]/page.tsx
+++ b/src/app/docs/[subdomain]/[...slug]/page.tsx
@@ -568,6 +568,8 @@ export default async function DocsPage({
         }
       />
 
+      {/* Capture Cmd/Ctrl+K before React hydration so fast navigations still open search. */}
+      <script src="/docs-search-shortcut.js" />
       <SearchModal pages={searchablePages} subdomain={subdomain} />
       <MobileSidebar
         nav={nav}

--- a/src/app/docs/[subdomain]/[...slug]/page.tsx
+++ b/src/app/docs/[subdomain]/[...slug]/page.tsx
@@ -555,7 +555,7 @@ export default async function DocsPage({
           projectName={project.name}
         />
 
-        <main className="docs-main">
+        <main id="main-content" className="docs-main" tabIndex={-1}>
           {groupName && (
             <div className="docs-breadcrumb" data-testid="breadcrumb-group">
               {groupName}

--- a/src/app/docs/[subdomain]/llms-full.txt/route.ts
+++ b/src/app/docs/[subdomain]/llms-full.txt/route.ts
@@ -1,0 +1,9 @@
+import { getPublicDocsLlmsResponse } from "@/lib/public-docs-llms";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ subdomain: string }> },
+) {
+  const { subdomain } = await params;
+  return getPublicDocsLlmsResponse(request, subdomain, "full");
+}

--- a/src/app/docs/[subdomain]/llms.txt/route.ts
+++ b/src/app/docs/[subdomain]/llms.txt/route.ts
@@ -1,0 +1,9 @@
+import { getPublicDocsLlmsResponse } from "@/lib/public-docs-llms";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ subdomain: string }> },
+) {
+  const { subdomain } = await params;
+  return getPublicDocsLlmsResponse(request, subdomain, "index");
+}

--- a/src/app/docs/[subdomain]/mcp/route.ts
+++ b/src/app/docs/[subdomain]/mcp/route.ts
@@ -1,0 +1,57 @@
+import { db } from "@/lib/db";
+import { projects } from "@/lib/db/schema";
+import {
+  getDocsAccessCookieName,
+  hasValidDocsAccess,
+} from "@/lib/project-docs-access";
+import { buildPublicMcpDescriptor } from "@/lib/public-mcp";
+import { eq } from "drizzle-orm";
+import { type NextRequest, NextResponse } from "next/server";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ subdomain: string }> },
+) {
+  const { subdomain } = await params;
+  const [project] = await db
+    .select({
+      name: projects.name,
+      subdomain: projects.subdomain,
+      settings: projects.settings,
+    })
+    .from(projects)
+    .where(eq(projects.subdomain, subdomain))
+    .limit(1);
+
+  if (!project?.subdomain) {
+    return NextResponse.json(
+      { error: "Documentation site not found" },
+      { status: 404 },
+    );
+  }
+
+  if (
+    !hasValidDocsAccess(
+      project.settings,
+      subdomain,
+      request.cookies.get(getDocsAccessCookieName(subdomain))?.value,
+    )
+  ) {
+    return NextResponse.json(
+      { error: "Docs password required" },
+      { status: 401 },
+    );
+  }
+
+  return NextResponse.json(
+    buildPublicMcpDescriptor(
+      { name: project.name, subdomain: project.subdomain },
+      new URL(request.url).origin,
+    ),
+    {
+      headers: {
+        "Cache-Control": "public, max-age=3600, s-maxage=3600",
+      },
+    },
+  );
+}

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,0 +1,159 @@
+import { db } from "@/lib/db";
+import { pages, projects } from "@/lib/db/schema";
+import { buildDocsEntryProjects } from "@/lib/docs-entry";
+import { and, asc, eq, isNotNull } from "drizzle-orm";
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Docs - OpenDocs",
+  description: "Browse published OpenDocs documentation and API references.",
+};
+
+async function getPublishedDocsProjects() {
+  try {
+    const rows = await db
+      .select({
+        projectId: projects.id,
+        projectName: projects.name,
+        subdomain: projects.subdomain,
+        pagePath: pages.path,
+        pageTitle: pages.title,
+        pageDescription: pages.description,
+      })
+      .from(projects)
+      .innerJoin(pages, eq(pages.projectId, projects.id))
+      .where(and(isNotNull(projects.subdomain), eq(pages.isPublished, true)))
+      .orderBy(asc(projects.name), asc(pages.path));
+
+    return buildDocsEntryProjects(rows).slice(0, 6);
+  } catch {
+    return [];
+  }
+}
+
+const featureCards = [
+  {
+    title: "Searchable docs",
+    description:
+      "Publish MDX content with navigation, table of contents, keyboard search, and reader feedback.",
+  },
+  {
+    title: "API references",
+    description:
+      "Turn OpenAPI definitions into interactive endpoint pages with request examples and playgrounds.",
+  },
+  {
+    title: "AI-native help",
+    description:
+      "Give readers assistant workflows that can answer questions from your documentation.",
+  },
+];
+
+export default async function DocsLandingPage() {
+  const publishedProjects = await getPublishedDocsProjects();
+
+  return (
+    <main className="min-h-screen bg-[#0b0b0d] text-white">
+      <div className="mx-auto flex min-h-screen max-w-6xl flex-col px-6 py-10">
+        <header className="flex items-center justify-between gap-4">
+          <Link href="/" className="text-sm font-semibold tracking-tight">
+            OpenDocs
+          </Link>
+          <nav className="flex items-center gap-3 text-sm text-white/70">
+            <Link className="transition hover:text-white" href="/onboarding">
+              Start onboarding
+            </Link>
+            <Link className="transition hover:text-white" href="/dashboard">
+              Dashboard
+            </Link>
+          </nav>
+        </header>
+
+        <section className="grid flex-1 items-center gap-12 py-20 lg:grid-cols-[1fr_0.85fr]">
+          <div>
+            <div className="mb-6 inline-flex items-center rounded-full border border-white/10 bg-white/[0.03] px-3 py-1 text-xs text-white/70">
+              Documentation
+            </div>
+            <h1 className="text-4xl font-semibold tracking-tight sm:text-6xl">
+              Browse published docs and API references
+            </h1>
+            <p className="mt-6 max-w-2xl text-base leading-7 text-white/70 sm:text-lg">
+              OpenDocs gives every project a Mintlify-style public docs surface
+              with structured navigation, search, API playgrounds, and AI-ready
+              content.
+            </p>
+            <div className="mt-10 flex flex-wrap gap-3">
+              <Link
+                href={publishedProjects[0]?.href ?? "/onboarding"}
+                className="rounded-lg bg-emerald-500 px-4 py-2.5 text-sm font-medium text-black transition hover:bg-emerald-400"
+              >
+                Explore docs
+              </Link>
+              <Link
+                href="/dashboard"
+                className="rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-sm font-medium text-white transition hover:bg-white/10"
+              >
+                Open dashboard
+              </Link>
+            </div>
+          </div>
+
+          <div className="rounded-3xl border border-white/10 bg-white/[0.03] p-5 shadow-2xl shadow-black/30">
+            <h2 className="text-sm font-medium text-white/80">
+              Published documentation
+            </h2>
+            <div className="mt-4 space-y-3">
+              {publishedProjects.length > 0 ? (
+                publishedProjects.map((project) => (
+                  <Link
+                    key={project.id}
+                    href={project.href}
+                    className="block rounded-2xl border border-white/10 bg-black/20 p-4 transition hover:border-emerald-400/50 hover:bg-emerald-500/10"
+                  >
+                    <div className="text-sm font-semibold text-white">
+                      {project.name}
+                    </div>
+                    <div className="mt-1 text-xs text-emerald-300">
+                      /docs/{project.subdomain}
+                    </div>
+                    <p className="mt-3 text-sm leading-6 text-white/65">
+                      {project.pageDescription ??
+                        `Start with ${project.pageTitle}.`}
+                    </p>
+                  </Link>
+                ))
+              ) : (
+                <div className="rounded-2xl border border-dashed border-white/15 bg-black/20 p-4">
+                  <div className="text-sm font-semibold text-white">
+                    No published docs yet
+                  </div>
+                  <p className="mt-2 text-sm leading-6 text-white/65">
+                    Create a project or publish a page to make it available from
+                    this docs entry point.
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+        </section>
+
+        <section className="grid gap-4 pb-16 md:grid-cols-3">
+          {featureCards.map((card) => (
+            <div
+              key={card.title}
+              className="rounded-2xl border border-white/10 bg-white/[0.03] p-5"
+            >
+              <h2 className="text-sm font-medium text-white">{card.title}</h2>
+              <p className="mt-2 text-sm leading-6 text-white/65">
+                {card.description}
+              </p>
+            </div>
+          ))}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -65,7 +65,7 @@ body {
   z-index: 100;
   transform: translateY(-150%);
   border-radius: 8px;
-  background: #16a34a;
+  background: var(--docs-primary, #16a34a);
   color: #ffffff;
   padding: 8px 12px;
   font-size: 13px;
@@ -172,7 +172,7 @@ body {
   gap: 4px;
   padding: 6px 14px;
   border-radius: 8px;
-  background: #16a34a;
+  background: var(--docs-primary, #16a34a);
   color: #fff;
   font-size: 13px;
   font-weight: 500;
@@ -328,7 +328,7 @@ body {
 
 .docs-breadcrumb {
   font-size: 13px;
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
   margin-bottom: 8px;
   font-weight: 500;
 }
@@ -338,7 +338,7 @@ body {
 }
 
 .docs-breadcrumb-active {
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
 }
 
 .docs-title-row {
@@ -611,7 +611,7 @@ body {
 }
 
 .docs-content blockquote {
-  border-left: 3px solid #16a34a;
+  border-left: 3px solid var(--docs-primary, #16a34a);
   padding: 8px 16px;
   margin: 16px 0;
   color: #9ca3af;
@@ -707,7 +707,7 @@ body {
 }
 
 .code-ask-ai {
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
 }
 
 .code-ask-ai:hover {
@@ -782,7 +782,7 @@ body {
 }
 
 .callout-tip .callout-icon {
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
 }
 
 .callout-icon {
@@ -907,7 +907,7 @@ body {
   height: 32px;
   border-radius: 50%;
   background: rgba(22, 163, 74, 0.15);
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -996,8 +996,8 @@ body {
 }
 
 .tab-button.active {
-  color: #16a34a;
-  border-bottom-color: #16a34a;
+  color: var(--docs-primary, #16a34a);
+  border-bottom-color: var(--docs-primary, #16a34a);
 }
 
 .tab-panel {
@@ -1217,7 +1217,7 @@ pre.mermaid svg {
 
 .update-date {
   font-size: 13px;
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
   font-weight: 500;
   margin-bottom: 4px;
 }
@@ -1678,6 +1678,16 @@ pre.mermaid svg {
   color: #f9fafb;
 }
 
+.docs-topbar-logo-icon {
+  color: var(--docs-primary, #16a34a);
+}
+
+.docs-topbar-logo-image {
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
+}
+
 /* ── Search Modal ─────────────────────────────────────────────────────────── */
 
 .search-modal-overlay {
@@ -2057,11 +2067,11 @@ pre.mermaid svg {
 }
 
 .lang-switcher-option-active {
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
 }
 
 .lang-switcher-option-active:hover {
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
 }
 
 .lang-switcher-option-code {
@@ -2154,11 +2164,11 @@ pre.mermaid svg {
 }
 
 .version-switcher-option-active {
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
 }
 
 .version-switcher-option-active:hover {
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
 }
 
 .version-switcher-option-name {
@@ -2173,7 +2183,7 @@ pre.mermaid svg {
   padding: 2px 6px;
   border-radius: 4px;
   background: rgba(22, 163, 74, 0.15);
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
 }
 
 /* ── Light Theme ──────────────────────────────────────────────────────────── */
@@ -2276,7 +2286,7 @@ pre.mermaid svg {
 }
 
 [data-theme="light"] .lang-switcher-option-active {
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
 }
 
 [data-theme="light"] .version-switcher-btn {
@@ -2306,7 +2316,7 @@ pre.mermaid svg {
 }
 
 [data-theme="light"] .version-switcher-option-active {
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
 }
 
 [data-theme="light"] .version-switcher-default-badge {
@@ -2335,7 +2345,7 @@ pre.mermaid svg {
 }
 
 [data-theme="light"] .docs-nav-item.active {
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
   background: rgba(22, 163, 74, 0.06);
 }
 
@@ -2352,7 +2362,7 @@ pre.mermaid svg {
 }
 
 [data-theme="light"] .docs-breadcrumb {
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
 }
 
 [data-theme="light"] .page-action-btn {
@@ -2759,7 +2769,7 @@ pre.mermaid svg {
 }
 
 .chat-message-user .chat-message-avatar {
-  background: #16a34a;
+  background: var(--docs-primary, #16a34a);
   color: white;
 }
 
@@ -2786,7 +2796,7 @@ pre.mermaid svg {
 }
 
 .chat-message-user .chat-message-content {
-  background: #16a34a;
+  background: var(--docs-primary, #16a34a);
   color: white;
   border-bottom-right-radius: 4px;
 }
@@ -2936,7 +2946,7 @@ pre.mermaid svg {
 }
 
 .chat-widget-textarea:focus {
-  border-color: #16a34a;
+  border-color: var(--docs-primary, #16a34a);
 }
 
 .chat-widget-textarea::placeholder {
@@ -2955,7 +2965,7 @@ pre.mermaid svg {
   width: 36px;
   height: 36px;
   border-radius: 8px;
-  background: #16a34a;
+  background: var(--docs-primary, #16a34a);
   border: none;
   color: white;
   cursor: pointer;
@@ -3112,8 +3122,8 @@ pre.mermaid svg {
 }
 
 .method-get {
-  background: #16a34a22;
-  color: #16a34a;
+  background: var(--docs-primary-soft, #16a34a22);
+  color: var(--docs-primary, #16a34a);
 }
 .method-post {
   background: #2563eb22;
@@ -3202,7 +3212,7 @@ pre.mermaid svg {
 }
 
 .api-param-input:focus {
-  border-color: #16a34a;
+  border-color: var(--docs-primary, #16a34a);
 }
 
 .api-param-input::placeholder {
@@ -3229,7 +3239,7 @@ pre.mermaid svg {
 }
 
 .api-body-textarea:focus {
-  border-color: #16a34a;
+  border-color: var(--docs-primary, #16a34a);
 }
 
 .api-send-section {
@@ -3237,7 +3247,7 @@ pre.mermaid svg {
 }
 
 .api-send-btn {
-  background: #16a34a;
+  background: var(--docs-primary, #16a34a);
   color: #fff;
   border: none;
   border-radius: 6px;
@@ -3285,8 +3295,8 @@ pre.mermaid svg {
 }
 
 .status-2xx {
-  background: #16a34a22;
-  color: #16a34a;
+  background: var(--docs-primary-soft, #16a34a22);
+  color: var(--docs-primary, #16a34a);
 }
 .status-3xx {
   background: #2563eb22;
@@ -3325,8 +3335,8 @@ pre.mermaid svg {
 }
 
 .api-resp-tab.active {
-  color: #16a34a;
-  border-bottom-color: #16a34a;
+  color: var(--docs-primary, #16a34a);
+  border-bottom-color: var(--docs-primary, #16a34a);
 }
 
 .api-resp-tab:hover {
@@ -3475,7 +3485,7 @@ pre.mermaid svg {
 }
 
 .api-ref-tryit-btn {
-  background: #16a34a;
+  background: var(--docs-primary, #16a34a);
   color: #fff;
   border: none;
   border-radius: 6px;
@@ -3525,7 +3535,7 @@ pre.mermaid svg {
 
 .api-ref-lang-tab.active {
   color: #fff;
-  border-bottom-color: #16a34a;
+  border-bottom-color: var(--docs-primary, #16a34a);
 }
 
 .api-ref-lang-tab:hover {
@@ -3612,8 +3622,8 @@ pre.mermaid svg {
 }
 
 .api-ref-status-tab.active {
-  color: #16a34a;
-  border-bottom-color: #16a34a;
+  color: var(--docs-primary, #16a34a);
+  border-bottom-color: var(--docs-primary, #16a34a);
 }
 
 .api-ref-status-tab:hover {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,10 +29,32 @@ body {
 /* ── Docs Site Layout ──────────────────────────────────────────────────────── */
 
 .docs-layout {
+  --docs-bg: #080d0c;
+  --docs-bg-deep: #050908;
+  --docs-surface: rgba(255, 255, 255, 0.045);
+  --docs-surface-hover: rgba(255, 255, 255, 0.075);
+  --docs-border: rgba(255, 255, 255, 0.075);
+  --docs-border-strong: rgba(255, 255, 255, 0.13);
+  --docs-text: #f7faf8;
+  --docs-text-muted: #9aa39f;
+  --docs-text-subtle: #6f7874;
+  --docs-green: #00e887;
+  --docs-green-soft: rgba(0, 232, 135, 0.11);
+  --docs-green-border: rgba(0, 232, 135, 0.32);
+  --docs-card: #0b1110;
+}
+
+.docs-layout {
   min-height: 100vh;
-  background: #090d0d;
-  color: #e5e7eb;
-  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  background: radial-gradient(
+      circle at 55% -12%,
+      rgba(0, 232, 135, 0.07),
+      transparent 28rem
+    ), var(--docs-bg);
+  color: var(--docs-text);
+  font-family: "Inter", ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-feature-settings: "cv02", "cv03", "cv04", "cv11";
 }
 
 /* Top bar */
@@ -40,14 +62,14 @@ body {
   position: sticky;
   top: 0;
   z-index: 40;
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) auto minmax(220px, 1fr);
   align-items: center;
-  justify-content: space-between;
-  height: 56px;
-  padding: 0 24px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(9, 13, 13, 0.95);
-  backdrop-filter: blur(8px);
+  height: 52px;
+  padding: 0 28px;
+  border-bottom: 1px solid var(--docs-border);
+  background: color-mix(in srgb, var(--docs-bg-deep) 92%, transparent);
+  backdrop-filter: blur(14px);
 }
 
 .docs-topbar-left {
@@ -65,13 +87,15 @@ body {
 .docs-topbar-center {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 8px;
 }
 
 .docs-topbar-right {
   display: flex;
   align-items: center;
-  gap: 12px;
+  justify-content: flex-end;
+  gap: 10px;
 }
 
 /* Ask AI button */
@@ -141,14 +165,16 @@ body {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 12px;
-  border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(255, 255, 255, 0.04);
-  color: #9ca3af;
+  width: min(30vw, 320px);
+  height: 36px;
+  padding: 0 12px;
+  border-radius: 999px;
+  border: 1px solid var(--docs-border);
+  background: var(--docs-surface);
+  color: var(--docs-text-muted);
   font-size: 13px;
   cursor: pointer;
-  transition: border-color 0.15s;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
 }
 
 .docs-search-btn:hover {
@@ -166,27 +192,33 @@ body {
 
 /* Body: sidebar + main + toc */
 .docs-body {
-  display: flex;
-  max-width: 1440px;
+  display: grid;
+  grid-template-columns: 264px minmax(0, 760px) 236px;
+  gap: 44px;
+  max-width: 1392px;
   margin: 0 auto;
+  padding: 0 28px;
 }
 
 /* Sidebar */
 .docs-sidebar {
   position: sticky;
-  top: 56px;
-  width: 260px;
-  min-width: 260px;
-  height: calc(100vh - 56px);
+  top: 52px;
+  width: 264px;
+  min-width: 0;
+  height: calc(100vh - 52px);
   overflow-y: auto;
-  padding: 16px 0;
-  border-right: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 22px 0 32px;
+  border-right: 0;
+  background: transparent;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.14) transparent;
 }
 
 .docs-sidebar-header {
-  padding: 0 16px 16px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-  margin-bottom: 8px;
+  padding: 0 12px 18px;
+  margin-bottom: 10px;
+  border-bottom: 1px solid var(--docs-border);
 }
 
 .docs-logo {
@@ -211,23 +243,25 @@ body {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 12px;
-  border-radius: 6px;
+  min-height: 32px;
+  padding: 5px 10px;
+  border-radius: 8px;
   font-size: 13px;
-  color: #9ca3af;
+  line-height: 1.35;
+  color: var(--docs-text-muted);
   text-decoration: none;
-  transition: all 0.15s;
+  transition: background 0.15s, color 0.15s;
 }
 
 .docs-nav-item:hover {
-  color: #e5e7eb;
-  background: rgba(255, 255, 255, 0.04);
+  color: var(--docs-text);
+  background: var(--docs-surface);
 }
 
 .docs-nav-item.active {
-  color: #16a34a;
-  background: rgba(22, 163, 74, 0.08);
-  font-weight: 500;
+  color: var(--docs-green);
+  background: var(--docs-green-soft);
+  font-weight: 600;
 }
 
 .docs-nav-group {
@@ -239,12 +273,12 @@ body {
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: 6px 12px;
-  font-size: 12px;
-  font-weight: 600;
-  color: #e5e7eb;
+  padding: 8px 10px 6px;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--docs-text-subtle);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.08em;
   background: none;
   border: none;
   cursor: pointer;
@@ -264,10 +298,9 @@ body {
 
 /* Main content area */
 .docs-main {
-  flex: 1;
   min-width: 0;
-  max-width: 768px;
-  padding: 32px 48px;
+  max-width: 760px;
+  padding: 56px 0 80px;
 }
 
 .docs-breadcrumb {
@@ -293,11 +326,12 @@ body {
 }
 
 .docs-page-title {
-  font-size: 32px;
-  font-weight: 700;
-  color: #f9fafb;
-  margin-bottom: 8px;
-  line-height: 1.2;
+  font-size: clamp(36px, 4vw, 48px);
+  font-weight: 750;
+  letter-spacing: -0.045em;
+  color: var(--docs-text);
+  margin-bottom: 10px;
+  line-height: 1.04;
   flex: 1;
 }
 
@@ -378,22 +412,25 @@ body {
 }
 
 .docs-page-description {
-  font-size: 16px;
-  color: #9ca3af;
-  margin-bottom: 32px;
-  line-height: 1.6;
+  max-width: 660px;
+  font-size: 17px;
+  color: var(--docs-text-muted);
+  margin-bottom: 34px;
+  line-height: 1.65;
 }
 
 /* TOC */
 .docs-toc {
   position: sticky;
-  top: 88px;
-  width: 240px;
-  min-width: 240px;
+  top: 84px;
+  width: 236px;
+  min-width: 0;
   height: fit-content;
-  max-height: calc(100vh - 120px);
+  max-height: calc(100vh - 112px);
   overflow-y: auto;
-  padding: 32px 16px 32px 0;
+  padding: 4px 0 32px;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.14) transparent;
 }
 
 .docs-toc-title {
@@ -405,14 +442,21 @@ body {
   margin-bottom: 12px;
 }
 
+.docs-toc nav {
+  border-left: 1px solid var(--docs-border);
+}
+
 .docs-toc-link {
   display: block;
-  padding: 4px 8px;
-  font-size: 13px;
-  color: #6b7280;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  font-size: 12.5px;
+  line-height: 1.35;
+  color: var(--docs-text-subtle);
   text-decoration: none;
-  border-left: 2px solid transparent;
-  transition: all 0.15s;
+  border-left: 1px solid transparent;
+  transform: translateX(-1px);
+  transition: border-color 0.15s, color 0.15s;
 }
 
 .docs-toc-link:hover {
@@ -420,16 +464,17 @@ body {
 }
 
 .docs-toc-link.active {
-  color: #16a34a;
-  border-left-color: #16a34a;
+  color: var(--docs-green);
+  border-left-color: var(--docs-green);
+  font-weight: 600;
 }
 
 /* ── Docs Content Prose ────────────────────────────────────────────────────── */
 
 .docs-content {
-  font-size: 15px;
-  line-height: 1.7;
-  color: #d1d5db;
+  font-size: 15.5px;
+  line-height: 1.78;
+  color: #c5ccc8;
 }
 
 .docs-content h1,
@@ -449,9 +494,10 @@ body {
   font-size: 28px;
 }
 .docs-content h2 {
-  font-size: 22px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-  padding-bottom: 8px;
+  font-size: 25px;
+  letter-spacing: -0.025em;
+  border-bottom: 1px solid var(--docs-border);
+  padding-bottom: 10px;
 }
 .docs-content h3 {
   font-size: 18px;
@@ -482,12 +528,12 @@ body {
 }
 
 .docs-content p {
-  margin-bottom: 16px;
+  margin-bottom: 18px;
 }
 
 .docs-content a {
-  color: #16a34a;
-  text-decoration: underline;
+  color: var(--docs-green);
+  text-decoration: none;
   text-underline-offset: 3px;
 }
 
@@ -502,12 +548,13 @@ body {
 
 .docs-content code {
   padding: 2px 6px;
-  border-radius: 4px;
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  font-family: "JetBrains Mono", "Fira Code", monospace;
+  border-radius: 6px;
+  background: var(--docs-surface);
+  border: 1px solid var(--docs-border);
+  font-family: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular,
+    Menlo, monospace;
   font-size: 0.875em;
-  color: #e5e7eb;
+  color: var(--docs-text);
 }
 
 .docs-content pre code {
@@ -574,11 +621,12 @@ body {
 
 /* Code blocks */
 .code-block {
-  margin: 16px 0;
-  border-radius: 8px;
-  background: #0f1117;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  margin: 24px 0;
+  border-radius: 16px;
+  background: #08100e;
+  border: 1px solid var(--docs-border);
   overflow: hidden;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.22);
 }
 
 .code-header {
@@ -730,10 +778,11 @@ body {
 
 .card {
   padding: 20px;
-  border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.02);
-  transition: all 0.2s;
+  border-radius: 16px;
+  border: 1px solid var(--docs-border);
+  background: linear-gradient(145deg, rgba(0, 232, 135, 0.055), transparent 48%),
+    var(--docs-card);
+  transition: border-color 0.2s, background 0.2s, transform 0.2s;
 }
 
 .card-link {
@@ -743,8 +792,10 @@ body {
 }
 
 .card-link:hover {
-  border-color: rgba(22, 163, 74, 0.3);
-  background: rgba(22, 163, 74, 0.04);
+  border-color: var(--docs-green-border);
+  background: linear-gradient(145deg, rgba(0, 232, 135, 0.09), transparent 52%),
+    var(--docs-card);
+  transform: translateY(-1px);
 }
 
 .card-icon {
@@ -3621,4 +3672,100 @@ pre.mermaid svg {
 
 [data-theme="light"] .api-ref-param-row {
   border-bottom-color: rgba(0, 0, 0, 0.06);
+}
+
+/* Mintlify-grade docs polish */
+.docs-topbar-ask-ai,
+.docs-theme-toggle,
+.page-action-btn {
+  border-color: var(--docs-border);
+  background: var(--docs-surface);
+  border-radius: 999px;
+}
+
+.docs-topbar-ask-ai:hover,
+.docs-theme-toggle:hover,
+.page-action-btn:hover,
+.docs-search-btn:hover {
+  border-color: var(--docs-border-strong);
+  background: var(--docs-surface-hover);
+  color: var(--docs-text);
+}
+
+.docs-topbar-dashboard-btn {
+  border-radius: 999px;
+  background: var(--docs-green);
+  color: #02130b;
+  font-weight: 650;
+}
+
+.docs-topbar-dashboard-btn:hover {
+  background: #27f59a;
+}
+
+.docs-content > h1:first-child {
+  display: none;
+}
+
+.docs-content img {
+  display: block;
+  width: 100%;
+  margin: 28px 0;
+  border: 1px solid var(--docs-border);
+  border-radius: 18px;
+  background: var(--docs-card);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.28);
+}
+
+.docs-content p:has(img[src*="img.shields.io"]) {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin: 18px 0 24px;
+}
+
+.docs-content p:has(img[src*="img.shields.io"]) img {
+  width: auto;
+  height: 22px;
+  margin: 0;
+  border-radius: 999px;
+  box-shadow: none;
+  background: transparent;
+}
+
+.docs-content hr + p a,
+.docs-content p:has(a) > a:only-child,
+.docs-content p a[href^="#"] {
+  font-weight: 600;
+}
+
+.docs-content blockquote,
+.callout {
+  border-radius: 14px;
+  border-color: var(--docs-green-border);
+  background: var(--docs-green-soft);
+}
+
+@media (max-width: 1180px) {
+  .docs-body {
+    grid-template-columns: 250px minmax(0, 1fr);
+    gap: 34px;
+  }
+
+  .docs-toc {
+    display: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .docs-topbar {
+    display: flex;
+    padding: 0 14px;
+  }
+
+  .docs-body {
+    display: block;
+    padding: 0 16px;
+  }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -36,6 +36,29 @@ body {
 }
 
 /* Top bar */
+.docs-skip-link {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  z-index: 100;
+  transform: translateY(-150%);
+  border-radius: 8px;
+  background: #16a34a;
+  color: #ffffff;
+  padding: 8px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.24);
+  transition: transform 0.15s ease;
+}
+
+.docs-skip-link:focus {
+  transform: translateY(0);
+  outline: 2px solid #bbf7d0;
+  outline-offset: 2px;
+}
+
 .docs-topbar {
   position: sticky;
   top: 0;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1485,14 +1485,22 @@ pre.mermaid svg {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
+  gap: 0.375rem;
+  min-width: 64px;
   height: 36px;
+  padding: 0 0.75rem;
   border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.1);
   background: rgba(255, 255, 255, 0.04);
   color: #9ca3af;
   cursor: pointer;
   transition: all 0.15s;
+}
+
+.docs-feedback-btn-label {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1;
 }
 
 .docs-feedback-btn:hover {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2638,9 +2638,15 @@ pre.mermaid svg {
   z-index: 50;
   display: flex;
   flex-direction: column;
+  width: auto;
   max-height: 480px;
+  max-width: none;
+  margin: 0;
+  padding: 0;
   background: #111315;
+  border: 0;
   border-top: 1px solid rgba(255, 255, 255, 0.08);
+  color: inherit;
   box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.4);
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -330,6 +330,15 @@ body {
   border-color: #4b5563;
 }
 
+.page-copy-btn.copied {
+  width: auto;
+  gap: 6px;
+  padding: 0 10px;
+  color: #d1fae5;
+  border-color: rgba(16, 185, 129, 0.45);
+  background: rgba(16, 185, 129, 0.12);
+}
+
 .page-actions-dropdown {
   position: relative;
 }
@@ -2273,6 +2282,12 @@ pre.mermaid svg {
   background: #f3f4f6;
   color: #111827;
   border-color: #9ca3af;
+}
+
+[data-theme="light"] .page-copy-btn.copied {
+  color: #047857;
+  border-color: rgba(16, 185, 129, 0.5);
+  background: #ecfdf5;
 }
 
 [data-theme="light"] .page-actions-menu {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2603,6 +2603,42 @@ pre.mermaid svg {
   font-size: 13px;
 }
 
+.chat-widget-suggestions {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: stretch;
+  margin-top: 4px;
+}
+
+.chat-widget-suggestions-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: #9ca3af;
+  text-align: left;
+}
+
+.chat-widget-suggestion {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: #d1d5db;
+  border-radius: 10px;
+  padding: 8px 10px;
+  font-size: 12px;
+  line-height: 1.3;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.chat-widget-suggestion:hover {
+  background: rgba(52, 211, 153, 0.1);
+  border-color: rgba(52, 211, 153, 0.3);
+  color: #ecfdf5;
+}
+
 .chat-message {
   display: flex;
   gap: 8px;
@@ -2826,6 +2862,22 @@ pre.mermaid svg {
 
 [data-theme="light"] .chat-widget-messages {
   background: #fafafa;
+}
+
+[data-theme="light"] .chat-widget-suggestions-label {
+  color: #6b7280;
+}
+
+[data-theme="light"] .chat-widget-suggestion {
+  border-color: #e5e7eb;
+  background: #ffffff;
+  color: #374151;
+}
+
+[data-theme="light"] .chat-widget-suggestion:hover {
+  background: #ecfdf5;
+  border-color: #86efac;
+  color: #166534;
 }
 
 [data-theme="light"] .chat-message-avatar {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2740,11 +2740,49 @@ pre.mermaid svg {
 
 .chat-widget-input-area {
   display: flex;
+  flex-wrap: wrap;
   align-items: flex-end;
   gap: 8px;
   padding: 8px 12px 12px;
   border-top: 1px solid rgba(255, 255, 255, 0.06);
   flex-shrink: 0;
+}
+
+.chat-attachments {
+  display: flex;
+  flex-basis: 100%;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+}
+
+.chat-attachment-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 220px;
+  border: 1px solid rgba(16, 185, 129, 0.35);
+  border-radius: 999px;
+  padding: 3px 7px;
+  color: #d1fae5;
+  background: rgba(16, 185, 129, 0.1);
+}
+
+.chat-attachment-chip button {
+  border: 0;
+  padding: 0;
+  color: inherit;
+  background: transparent;
+  cursor: pointer;
+}
+
+.chat-attachment-note {
+  color: #9ca3af;
+}
+
+.chat-attachment-input {
+  display: none;
 }
 
 .chat-widget-textarea {
@@ -2776,6 +2814,7 @@ pre.mermaid svg {
   opacity: 0.5;
 }
 
+.chat-widget-attachment-btn,
 .chat-widget-send-btn {
   display: flex;
   align-items: center;
@@ -2791,10 +2830,22 @@ pre.mermaid svg {
   transition: background 0.15s, opacity 0.15s;
 }
 
+.chat-widget-attachment-btn {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: #9ca3af;
+}
+
+.chat-widget-attachment-btn:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.1);
+  color: #e5e7eb;
+}
+
 .chat-widget-send-btn:hover:not(:disabled) {
   background: #15803d;
 }
 
+.chat-widget-attachment-btn:disabled,
 .chat-widget-send-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
@@ -2842,6 +2893,27 @@ pre.mermaid svg {
   background: #f3f4f6;
   border-color: rgba(0, 0, 0, 0.1);
   color: #111827;
+}
+
+[data-theme="light"] .chat-attachment-chip {
+  color: #047857;
+  border-color: rgba(16, 185, 129, 0.4);
+  background: #ecfdf5;
+}
+
+[data-theme="light"] .chat-attachment-note {
+  color: #6b7280;
+}
+
+[data-theme="light"] .chat-widget-attachment-btn {
+  color: #6b7280;
+  background: #f9fafb;
+  border-color: #e5e7eb;
+}
+
+[data-theme="light"] .chat-widget-attachment-btn:hover:not(:disabled) {
+  color: #111827;
+  background: #f3f4f6;
 }
 
 [data-theme="light"] .chat-widget-disclaimer {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,6 @@
+import { getServerSession } from "@/lib/session";
 import Link from "next/link";
+import { redirect } from "next/navigation";
 
 const links = [
   {
@@ -19,7 +21,13 @@ const links = [
   },
 ];
 
-export default function Home() {
+export default async function Home() {
+  const session = await getServerSession();
+
+  if (session) {
+    redirect("/dashboard");
+  }
+
   return (
     <main className="min-h-screen bg-[#0b0b0d] text-white">
       <div className="mx-auto flex min-h-screen max-w-6xl flex-col justify-center px-6 py-20">

--- a/src/components/docs/api-playground.tsx
+++ b/src/components/docs/api-playground.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import {
+  apiPlaygroundStatusClass,
+  normalizeApiPlaygroundProxyResult,
+} from "@/lib/api-playground-response";
 import { useEffect, useRef } from "react";
 
 interface ApiPlaygroundProps {
@@ -151,12 +155,15 @@ async function handleSend(btn: HTMLButtonElement): Promise<void> {
     });
 
     const elapsed = Math.round(performance.now() - startTime);
-    const result = await proxyRes.json();
+    const result = normalizeApiPlaygroundProxyResult(
+      await proxyRes.json(),
+      proxyRes.status,
+    );
 
     if (responseArea) responseArea.style.display = "block";
     if (statusEl) {
       statusEl.textContent = `${result.status}`;
-      statusEl.className = `api-status-code status-${Math.floor(result.status / 100)}xx`;
+      statusEl.className = apiPlaygroundStatusClass(result.status);
     }
     if (timeEl) timeEl.textContent = `${elapsed}ms`;
 

--- a/src/components/docs/api-playground.tsx
+++ b/src/components/docs/api-playground.tsx
@@ -134,6 +134,9 @@ async function handleSend(btn: HTMLButtonElement): Promise<void> {
   const headersContent = playground.querySelector<HTMLElement>(
     ".api-response-headers-content",
   );
+  const downloadLink = playground.querySelector<HTMLAnchorElement>(
+    ".api-response-download",
+  );
 
   const startTime = performance.now();
 
@@ -161,6 +164,7 @@ async function handleSend(btn: HTMLButtonElement): Promise<void> {
     if (timeEl) timeEl.textContent = `${elapsed}ms`;
 
     // Format response body
+    let responseBodyText = "";
     if (bodyContent) {
       let formatted = result.body || "";
       try {
@@ -168,8 +172,10 @@ async function handleSend(btn: HTMLButtonElement): Promise<void> {
       } catch {
         // not JSON, display raw
       }
+      responseBodyText = formatted;
       bodyContent.textContent = formatted;
     }
+    updateDownloadLink(downloadLink, responseBodyText);
 
     // Format response headers
     if (headersContent) {
@@ -188,8 +194,24 @@ async function handleSend(btn: HTMLButtonElement): Promise<void> {
       bodyContent.textContent =
         err instanceof Error ? err.message : "Request failed";
     }
+    updateDownloadLink(
+      downloadLink,
+      err instanceof Error ? err.message : "Request failed",
+    );
   } finally {
     btn.disabled = false;
     btn.textContent = "Send";
   }
+}
+
+function updateDownloadLink(
+  link: HTMLAnchorElement | null,
+  content: string,
+): void {
+  if (!link) return;
+
+  const text = content || "";
+  link.href = `data:text/plain;charset=utf-8,${encodeURIComponent(text)}`;
+  link.download = "response.txt";
+  link.style.display = "inline-flex";
 }

--- a/src/components/docs/api-playground.tsx
+++ b/src/components/docs/api-playground.tsx
@@ -32,31 +32,78 @@ export function ApiPlayground({ html }: ApiPlaygroundProps) {
     // Wire up response tab switching
     const respTabButtons =
       container.querySelectorAll<HTMLButtonElement>(".api-resp-tab");
+    const activateResponseTab = (btn: HTMLButtonElement) => {
+      const playground = btn.closest(".api-playground");
+      if (!playground) return;
+      const tab = btn.dataset.respTab;
+
+      // Deactivate all tabs
+      const allTabs =
+        playground.querySelectorAll<HTMLButtonElement>(".api-resp-tab");
+      for (const t of allTabs) {
+        t.classList.remove("active");
+        t.setAttribute("aria-selected", String(t === btn));
+        t.tabIndex = t === btn ? 0 : -1;
+      }
+      btn.classList.add("active");
+
+      // Show/hide panels
+      const bodyPanel =
+        playground.querySelector<HTMLDivElement>(".api-response-body");
+      const headersPanel = playground.querySelector<HTMLDivElement>(
+        ".api-response-headers",
+      );
+      if (bodyPanel)
+        bodyPanel.style.display = tab === "body" ? "block" : "none";
+      if (headersPanel)
+        headersPanel.style.display = tab === "headers" ? "block" : "none";
+    };
+
+    const moveResponseTabFocus = (
+      btn: HTMLButtonElement,
+      direction: "first" | "last" | "next" | "previous",
+    ) => {
+      const playground = btn.closest(".api-playground");
+      if (!playground) return;
+      const tabs = Array.from(
+        playground.querySelectorAll<HTMLButtonElement>(".api-resp-tab"),
+      );
+      const currentIndex = tabs.indexOf(btn);
+      if (currentIndex === -1) return;
+
+      const targetIndex =
+        direction === "first"
+          ? 0
+          : direction === "last"
+            ? tabs.length - 1
+            : direction === "next"
+              ? (currentIndex + 1) % tabs.length
+              : (currentIndex - 1 + tabs.length) % tabs.length;
+
+      const target = tabs[targetIndex];
+      target.focus();
+      activateResponseTab(target);
+    };
+
     for (const btn of respTabButtons) {
-      btn.addEventListener("click", () => {
-        const playground = btn.closest(".api-playground");
-        if (!playground) return;
-        const tab = btn.dataset.respTab;
-
-        // Deactivate all tabs
-        const allTabs =
-          playground.querySelectorAll<HTMLButtonElement>(".api-resp-tab");
-        for (const t of allTabs) {
-          t.classList.remove("active");
-          t.setAttribute("aria-selected", String(t === btn));
+      btn.addEventListener("click", () => activateResponseTab(btn));
+      btn.addEventListener("keydown", (event) => {
+        if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+          event.preventDefault();
+          moveResponseTabFocus(btn, "next");
+        } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+          event.preventDefault();
+          moveResponseTabFocus(btn, "previous");
+        } else if (event.key === "Home") {
+          event.preventDefault();
+          moveResponseTabFocus(btn, "first");
+        } else if (event.key === "End") {
+          event.preventDefault();
+          moveResponseTabFocus(btn, "last");
+        } else if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          activateResponseTab(btn);
         }
-        btn.classList.add("active");
-
-        // Show/hide panels
-        const bodyPanel =
-          playground.querySelector<HTMLDivElement>(".api-response-body");
-        const headersPanel = playground.querySelector<HTMLDivElement>(
-          ".api-response-headers",
-        );
-        if (bodyPanel)
-          bodyPanel.style.display = tab === "body" ? "block" : "none";
-        if (headersPanel)
-          headersPanel.style.display = tab === "headers" ? "block" : "none";
       });
     }
   }, [html]);

--- a/src/components/docs/api-playground.tsx
+++ b/src/components/docs/api-playground.tsx
@@ -37,7 +37,10 @@ export function ApiPlayground({ html }: ApiPlaygroundProps) {
         // Deactivate all tabs
         const allTabs =
           playground.querySelectorAll<HTMLButtonElement>(".api-resp-tab");
-        for (const t of allTabs) t.classList.remove("active");
+        for (const t of allTabs) {
+          t.classList.remove("active");
+          t.setAttribute("aria-selected", String(t === btn));
+        }
         btn.classList.add("active");
 
         // Show/hide panels

--- a/src/components/docs/api-reference-layout.tsx
+++ b/src/components/docs/api-reference-layout.tsx
@@ -148,27 +148,69 @@ export function ApiReferenceLayout({ html }: ApiReferenceLayoutProps) {
       ".api-ref-status-panel",
     );
 
+    const activateStatusTab = (tab: HTMLButtonElement) => {
+      const status = tab.dataset.status;
+      for (const t of statusTabs) {
+        t.classList.remove("active");
+        t.setAttribute("aria-selected", "false");
+        t.tabIndex = -1;
+      }
+      for (const p of statusPanels) {
+        p.classList.remove("active");
+        p.hidden = true;
+      }
+      tab.classList.add("active");
+      tab.setAttribute("aria-selected", "true");
+      tab.tabIndex = 0;
+      const target = container.querySelector<HTMLDivElement>(
+        `.api-ref-status-panel[data-status="${status}"]`,
+      );
+      if (target) {
+        target.classList.add("active");
+        target.hidden = false;
+      }
+    };
+
+    const moveStatusTabFocus = (
+      tab: HTMLButtonElement,
+      direction: "first" | "last" | "next" | "previous",
+    ) => {
+      const tabs = Array.from(statusTabs);
+      const currentIndex = tabs.indexOf(tab);
+      if (currentIndex === -1) return;
+
+      const targetIndex =
+        direction === "first"
+          ? 0
+          : direction === "last"
+            ? tabs.length - 1
+            : direction === "next"
+              ? (currentIndex + 1) % tabs.length
+              : (currentIndex - 1 + tabs.length) % tabs.length;
+
+      const target = tabs[targetIndex];
+      target.focus();
+      activateStatusTab(target);
+    };
+
     for (const tab of statusTabs) {
-      tab.addEventListener("click", () => {
-        const status = tab.dataset.status;
-        for (const t of statusTabs) {
-          t.classList.remove("active");
-          t.setAttribute("aria-selected", "false");
-          t.tabIndex = -1;
-        }
-        for (const p of statusPanels) {
-          p.classList.remove("active");
-          p.hidden = true;
-        }
-        tab.classList.add("active");
-        tab.setAttribute("aria-selected", "true");
-        tab.tabIndex = 0;
-        const target = container.querySelector<HTMLDivElement>(
-          `.api-ref-status-panel[data-status="${status}"]`,
-        );
-        if (target) {
-          target.classList.add("active");
-          target.hidden = false;
+      tab.addEventListener("click", () => activateStatusTab(tab));
+      tab.addEventListener("keydown", (event) => {
+        if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+          event.preventDefault();
+          moveStatusTabFocus(tab, "next");
+        } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+          event.preventDefault();
+          moveStatusTabFocus(tab, "previous");
+        } else if (event.key === "Home") {
+          event.preventDefault();
+          moveStatusTabFocus(tab, "first");
+        } else if (event.key === "End") {
+          event.preventDefault();
+          moveStatusTabFocus(tab, "last");
+        } else if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          activateStatusTab(tab);
         }
       });
     }

--- a/src/components/docs/api-reference-layout.tsx
+++ b/src/components/docs/api-reference-layout.tsx
@@ -96,13 +96,25 @@ export function ApiReferenceLayout({ html }: ApiReferenceLayoutProps) {
     for (const tab of statusTabs) {
       tab.addEventListener("click", () => {
         const status = tab.dataset.status;
-        for (const t of statusTabs) t.classList.remove("active");
-        for (const p of statusPanels) p.classList.remove("active");
+        for (const t of statusTabs) {
+          t.classList.remove("active");
+          t.setAttribute("aria-selected", "false");
+          t.tabIndex = -1;
+        }
+        for (const p of statusPanels) {
+          p.classList.remove("active");
+          p.hidden = true;
+        }
         tab.classList.add("active");
+        tab.setAttribute("aria-selected", "true");
+        tab.tabIndex = 0;
         const target = container.querySelector<HTMLDivElement>(
           `.api-ref-status-panel[data-status="${status}"]`,
         );
-        if (target) target.classList.add("active");
+        if (target) {
+          target.classList.add("active");
+          target.hidden = false;
+        }
       });
     }
 

--- a/src/components/docs/api-reference-layout.tsx
+++ b/src/components/docs/api-reference-layout.tsx
@@ -79,7 +79,7 @@ export function ApiReferenceLayout({ html }: ApiReferenceLayoutProps) {
         );
         const code = activeBlock?.querySelector("code")?.textContent || "";
         const lang = activeBlock?.dataset.lang || "curl";
-        window.dispatchEvent(
+        document.dispatchEvent(
           new CustomEvent("ask-ai-code", { detail: { code, language: lang } }),
         );
       });

--- a/src/components/docs/api-reference-layout.tsx
+++ b/src/components/docs/api-reference-layout.tsx
@@ -26,24 +26,79 @@ export function ApiReferenceLayout({ html }: ApiReferenceLayoutProps) {
       ".api-ref-code-block",
     );
 
-    for (const tab of langTabs) {
-      tab.addEventListener("click", () => {
-        const lang = tab.dataset.lang;
-        // Deactivate all tabs and blocks
-        for (const t of langTabs) t.classList.remove("active");
-        for (const b of codeBlocks) b.classList.remove("active");
-        // Activate selected
-        tab.classList.add("active");
-        const target = container.querySelector<HTMLDivElement>(
-          `.api-ref-code-block[data-lang="${lang}"]`,
-        );
-        if (target) target.classList.add("active");
+    const activateLanguageTab = (tab: HTMLButtonElement) => {
+      const lang = tab.dataset.lang;
+      // Deactivate all tabs and blocks
+      for (const t of langTabs) {
+        t.classList.remove("active");
+        t.setAttribute("aria-selected", "false");
+        t.tabIndex = -1;
+      }
+      for (const b of codeBlocks) {
+        b.classList.remove("active");
+        b.hidden = true;
+      }
+      // Activate selected
+      tab.classList.add("active");
+      tab.setAttribute("aria-selected", "true");
+      tab.tabIndex = 0;
+      const target = container.querySelector<HTMLDivElement>(
+        `.api-ref-code-block[data-lang="${lang}"]`,
+      );
+      if (target) {
+        target.classList.add("active");
+        target.hidden = false;
+      }
 
-        // Update copy button label
-        const copyBtn = container.querySelector<HTMLButtonElement>(
-          ".api-ref-copy-btn span",
-        );
-        if (copyBtn) copyBtn.textContent = tab.textContent || "cURL";
+      // Update copy button label
+      const copyBtn = container.querySelector<HTMLButtonElement>(
+        ".api-ref-copy-btn span",
+      );
+      if (copyBtn) copyBtn.textContent = tab.textContent || "cURL";
+    };
+
+    const moveLanguageTabFocus = (
+      tab: HTMLButtonElement,
+      direction: "first" | "last" | "next" | "previous",
+    ) => {
+      const tabs = Array.from(langTabs);
+      const currentIndex = tabs.indexOf(tab);
+      if (currentIndex === -1) return;
+
+      const targetIndex =
+        direction === "first"
+          ? 0
+          : direction === "last"
+            ? tabs.length - 1
+            : direction === "next"
+              ? (currentIndex + 1) % tabs.length
+              : (currentIndex - 1 + tabs.length) % tabs.length;
+
+      const target = tabs[targetIndex];
+      target.focus();
+      activateLanguageTab(target);
+    };
+
+    for (const tab of langTabs) {
+      tab.addEventListener("click", () => activateLanguageTab(tab));
+      tab.addEventListener("keydown", (event) => {
+        if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+          event.preventDefault();
+          moveLanguageTabFocus(tab, "next");
+        } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+          event.preventDefault();
+          moveLanguageTabFocus(tab, "previous");
+        } else if (event.key === "Home") {
+          event.preventDefault();
+          moveLanguageTabFocus(tab, "first");
+        } else if (event.key === "End") {
+          event.preventDefault();
+          moveLanguageTabFocus(tab, "last");
+        } else if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          tab.classList.add("active");
+          activateLanguageTab(tab);
+        }
       });
     }
 

--- a/src/components/docs/chat-widget.tsx
+++ b/src/components/docs/chat-widget.tsx
@@ -138,6 +138,12 @@ interface ChatWidgetProps {
   currentPath?: string;
 }
 
+const STARTER_SUGGESTIONS = [
+  "How do I get started?",
+  "What features does it offer?",
+  "What is this documentation about?",
+];
+
 export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
   const [state, dispatch] = useReducer(chatReducer, {
     messages: [],
@@ -314,6 +320,11 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
     }
   };
 
+  const applySuggestion = useCallback((suggestion: string) => {
+    setInput(suggestion);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }, []);
+
   if (!state.isOpen) return null;
 
   return (
@@ -402,6 +413,22 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
               <path d="M18 14l1 3 3 1-3 1-1 3-1-3-3-1 3-1 1-3z" />
             </svg>
             <p>Ask a question about the documentation</p>
+            <div
+              className="chat-widget-suggestions"
+              data-testid="chat-suggestions"
+            >
+              <span className="chat-widget-suggestions-label">Suggestions</span>
+              {STARTER_SUGGESTIONS.map((suggestion) => (
+                <button
+                  key={suggestion}
+                  type="button"
+                  className="chat-widget-suggestion"
+                  onClick={() => applySuggestion(suggestion)}
+                >
+                  {suggestion}
+                </button>
+              ))}
+            </div>
           </div>
         )}
 

--- a/src/components/docs/chat-widget.tsx
+++ b/src/components/docs/chat-widget.tsx
@@ -18,6 +18,13 @@ interface ChatState {
   threadId: string | null;
 }
 
+interface ChatAttachment {
+  id: string;
+  name: string;
+  size: number;
+  type: string;
+}
+
 type ChatAction =
   | { type: "TOGGLE" }
   | { type: "OPEN" }
@@ -147,8 +154,10 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
   });
 
   const [input, setInput] = useState("");
+  const [attachments, setAttachments] = useState<ChatAttachment[]>([]);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const abortRef = useRef<AbortController | null>(null);
 
   // Listen for toggle-ask-ai custom event from topbar button
@@ -199,10 +208,22 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
 
   const sendMessage = useCallback(async () => {
     const trimmed = input.trim();
-    if (!trimmed || state.isStreaming) return;
+    if ((!trimmed && attachments.length === 0) || state.isStreaming) return;
+
+    const attachmentSummary =
+      attachments.length > 0
+        ? `\n\nAttachments selected (metadata only): ${attachments
+            .map((file) => `${file.name} (${file.type || "unknown type"})`)
+            .join(", ")}`
+        : "";
+    const messageContent =
+      trimmed || "Please review the selected attachment metadata.";
+    const contentWithAttachments = `${messageContent}${attachmentSummary}`;
 
     setInput("");
-    dispatch({ type: "ADD_USER_MESSAGE", content: trimmed });
+    setAttachments([]);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+    dispatch({ type: "ADD_USER_MESSAGE", content: contentWithAttachments });
     dispatch({ type: "START_STREAMING" });
 
     // Build messages for request (current messages + new user message)
@@ -215,7 +236,7 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
       {
         id: `msg-${Date.now()}`,
         role: "user",
-        content: trimmed,
+        content: contentWithAttachments,
       },
     ];
 
@@ -300,6 +321,7 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
     }
   }, [
     input,
+    attachments,
     state.isStreaming,
     state.messages,
     state.threadId,
@@ -312,6 +334,21 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
       e.preventDefault();
       sendMessage();
     }
+  };
+
+  const handleAttachmentChange = (files: FileList | null) => {
+    const selected = Array.from(files ?? []).map((file) => ({
+      id: `${file.name}-${file.size}-${file.lastModified}`,
+      name: file.name,
+      size: file.size,
+      type: file.type,
+    }));
+    setAttachments(selected);
+  };
+
+  const removeAttachment = (id: string) => {
+    setAttachments((current) => current.filter((file) => file.id !== id));
+    if (fileInputRef.current) fileInputRef.current.value = "";
   };
 
   if (!state.isOpen) return null;
@@ -474,6 +511,25 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
 
       {/* Input */}
       <div className="chat-widget-input-area">
+        {attachments.length > 0 && (
+          <div className="chat-attachments" data-testid="chat-attachments">
+            {attachments.map((file) => (
+              <span className="chat-attachment-chip" key={file.id}>
+                {file.name}
+                <button
+                  type="button"
+                  aria-label={`Remove attachment ${file.name}`}
+                  onClick={() => removeAttachment(file.id)}
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+            <span className="chat-attachment-note">
+              File contents are not uploaded yet.
+            </span>
+          </div>
+        )}
         <textarea
           ref={inputRef}
           data-testid="chat-input"
@@ -485,11 +541,45 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
           rows={1}
           disabled={state.isStreaming}
         />
+        <input
+          ref={fileInputRef}
+          data-testid="chat-attachment-input"
+          className="chat-attachment-input"
+          type="file"
+          multiple
+          accept="image/*,.pdf,.js,.jsx,.ts,.tsx,.mjs,.cjs,.md,.mdx,.json,.html,.css,.py,.csv,.txt,.yaml,.yml,.xml"
+          onChange={(e) => handleAttachmentChange(e.target.files)}
+        />
+        <button
+          type="button"
+          data-testid="chat-attachment-btn"
+          className="chat-widget-attachment-btn"
+          aria-label="Add attachment"
+          title="Add attachment"
+          disabled={state.isStreaming}
+          onClick={() => fileInputRef.current?.click()}
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M21.44 11.05 12.25 20.24a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+          </svg>
+        </button>
         <button
           type="button"
           data-testid="chat-send-btn"
           className="chat-widget-send-btn"
-          disabled={!input.trim() || state.isStreaming}
+          disabled={
+            (!input.trim() && attachments.length === 0) || state.isStreaming
+          }
           onClick={sendMessage}
           title="Send message"
         >

--- a/src/components/docs/chat-widget.tsx
+++ b/src/components/docs/chat-widget.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -165,6 +172,7 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const titleId = useId();
 
   // Listen for toggle-ask-ai custom event from topbar button
   useEffect(() => {
@@ -210,6 +218,20 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
     if (state.isOpen) {
       setTimeout(() => inputRef.current?.focus(), 100);
     }
+  }, [state.isOpen]);
+
+  // Match docs assistant drawer behavior: Escape dismisses the open panel.
+  useEffect(() => {
+    if (!state.isOpen) return;
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        dispatch({ type: "CLOSE" });
+      }
+    };
+
+    window.addEventListener("keydown", handleEscape, true);
+    return () => window.removeEventListener("keydown", handleEscape, true);
   }, [state.isOpen]);
 
   const sendMessage = useCallback(async () => {
@@ -336,6 +358,12 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
   ]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      dispatch({ type: "CLOSE" });
+      return;
+    }
+
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       sendMessage();
@@ -365,7 +393,13 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
   if (!state.isOpen) return null;
 
   return (
-    <div className="chat-widget" data-testid="chat-panel">
+    <dialog
+      open
+      className="chat-widget"
+      data-testid="chat-panel"
+      aria-modal="false"
+      aria-labelledby={titleId}
+    >
       {/* Header */}
       <div className="chat-widget-header">
         <div className="chat-widget-header-left">
@@ -383,13 +417,14 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
             <path d="M12 3l1.5 4.5L18 9l-4.5 1.5L12 15l-1.5-4.5L6 9l4.5-1.5L12 3z" />
             <path d="M18 14l1 3 3 1-3 1-1 3-1-3-3-1 3-1 1-3z" />
           </svg>
-          <span>AI Assistant</span>
+          <span id={titleId}>AI Assistant</span>
         </div>
         <div className="chat-widget-header-actions">
           <button
             type="button"
             data-testid="chat-clear-btn"
             className="chat-widget-icon-btn"
+            aria-label="Clear assistant conversation"
             title="Clear conversation"
             onClick={() => dispatch({ type: "CLEAR" })}
           >
@@ -411,6 +446,7 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
             type="button"
             data-testid="chat-close-btn"
             className="chat-widget-icon-btn"
+            aria-label="Close assistant panel"
             title="Close"
             onClick={() => dispatch({ type: "CLOSE" })}
           >
@@ -604,6 +640,7 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
           type="button"
           data-testid="chat-send-btn"
           className="chat-widget-send-btn"
+          aria-label="Send message"
           disabled={
             (!input.trim() && attachments.length === 0) || state.isStreaming
           }
@@ -625,6 +662,6 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
           </svg>
         </button>
       </div>
-    </div>
+    </dialog>
   );
 }

--- a/src/components/docs/docs-sidebar.tsx
+++ b/src/components/docs/docs-sidebar.tsx
@@ -8,7 +8,7 @@ import {
 import type { DocsNavEntry } from "@/lib/mdx-renderer";
 import { ChevronDown, FileText } from "lucide-react";
 import Link from "next/link";
-import { useState } from "react";
+import { useId, useState } from "react";
 
 interface DocsSidebarProps {
   nav: DocsNavEntry[];
@@ -132,14 +132,17 @@ function NavGroup({
   activePath: string;
   subdomain: string;
 }) {
-  const isGroupActive = entry.items.some((item) => item.path === activePath);
   const [isOpen, setIsOpen] = useState(true);
+  const groupItemsId = useId();
 
   return (
     <div className="docs-nav-group">
       <button
         type="button"
         className="docs-nav-group-label"
+        aria-label={`Toggle ${entry.label} section`}
+        aria-expanded={isOpen}
+        aria-controls={groupItemsId}
         onClick={() => setIsOpen(!isOpen)}
       >
         <span>{entry.label}</span>
@@ -149,7 +152,7 @@ function NavGroup({
         />
       </button>
       {isOpen && (
-        <div className="docs-nav-group-items">
+        <div className="docs-nav-group-items" id={groupItemsId}>
           {entry.items.map((item) => (
             <NavItem
               key={item.pageId}

--- a/src/components/docs/docs-toc.tsx
+++ b/src/components/docs/docs-toc.tsx
@@ -10,14 +10,22 @@ interface DocsTocProps {
 export function DocsToc({ entries }: DocsTocProps) {
   // Filter to H2 and H3 only for display
   const displayEntries = entries.filter((e) => e.level >= 2 && e.level <= 3);
-  const [activeId, setActiveId] = useState<string>(displayEntries[0]?.id ?? "");
+  const [activeId, setActiveId] = useState<string>("");
   const manuallySelectedIdRef = useRef<string | null>(null);
+  const suppressObserverRef = useRef(false);
+  const entryIdsRef = useRef<Set<string>>(new Set());
   const manualSelectionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+  const observerSuppressionTimerRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
 
   useEffect(() => {
-    setActiveId((current) => current || displayEntries[0]?.id || "");
+    entryIdsRef.current = new Set(displayEntries.map((entry) => entry.id));
+    setActiveId((current) =>
+      current && entryIdsRef.current.has(current) ? current : "",
+    );
   }, [displayEntries]);
 
   useEffect(() => {
@@ -25,7 +33,8 @@ export function DocsToc({ entries }: DocsTocProps) {
 
     const observer = new IntersectionObserver(
       (observerEntries) => {
-        if (manuallySelectedIdRef.current) return;
+        if (manuallySelectedIdRef.current || suppressObserverRef.current)
+          return;
 
         for (const entry of observerEntries) {
           if (entry.isIntersecting) {
@@ -45,9 +54,51 @@ export function DocsToc({ entries }: DocsTocProps) {
   }, [displayEntries]);
 
   useEffect(() => {
+    const suppressExternalHashNavigation = () => {
+      if (manuallySelectedIdRef.current) return;
+      if (observerSuppressionTimerRef.current) {
+        clearTimeout(observerSuppressionTimerRef.current);
+      }
+      suppressObserverRef.current = true;
+      setActiveId("");
+      observerSuppressionTimerRef.current = setTimeout(() => {
+        suppressObserverRef.current = false;
+        observerSuppressionTimerRef.current = null;
+      }, 1500);
+    };
+
+    const handleDocumentClick = (event: MouseEvent) => {
+      const anchor = (event.target as Element | null)?.closest?.(
+        "a[href]",
+      ) as HTMLAnchorElement | null;
+      if (!anchor || anchor.closest(".docs-toc")) return;
+      const href = anchor.getAttribute("href") || "";
+      const hash = href.startsWith("#")
+        ? href.slice(1)
+        : new URL(anchor.href).hash.slice(1);
+      if (hash && entryIdsRef.current.has(hash)) {
+        suppressExternalHashNavigation();
+      }
+    };
+
+    const handleHashChange = () => {
+      const hash = window.location.hash.slice(1);
+      if (hash && entryIdsRef.current.has(hash)) {
+        suppressExternalHashNavigation();
+      }
+    };
+
+    document.addEventListener("click", handleDocumentClick, true);
+    window.addEventListener("hashchange", handleHashChange);
+
     return () => {
+      document.removeEventListener("click", handleDocumentClick, true);
+      window.removeEventListener("hashchange", handleHashChange);
       if (manualSelectionTimerRef.current) {
         clearTimeout(manualSelectionTimerRef.current);
+      }
+      if (observerSuppressionTimerRef.current) {
+        clearTimeout(observerSuppressionTimerRef.current);
       }
     };
   }, []);

--- a/src/components/docs/docs-toc.tsx
+++ b/src/components/docs/docs-toc.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { TocEntry } from "@/lib/editor";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 interface DocsTocProps {
   entries: TocEntry[];
@@ -11,6 +11,10 @@ export function DocsToc({ entries }: DocsTocProps) {
   // Filter to H2 and H3 only for display
   const displayEntries = entries.filter((e) => e.level >= 2 && e.level <= 3);
   const [activeId, setActiveId] = useState<string>(displayEntries[0]?.id ?? "");
+  const manuallySelectedIdRef = useRef<string | null>(null);
+  const manualSelectionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
   useEffect(() => {
     setActiveId((current) => current || displayEntries[0]?.id || "");
@@ -21,6 +25,8 @@ export function DocsToc({ entries }: DocsTocProps) {
 
     const observer = new IntersectionObserver(
       (observerEntries) => {
+        if (manuallySelectedIdRef.current) return;
+
         for (const entry of observerEntries) {
           if (entry.isIntersecting) {
             setActiveId(entry.target.id);
@@ -38,15 +44,31 @@ export function DocsToc({ entries }: DocsTocProps) {
     return () => observer.disconnect();
   }, [displayEntries]);
 
+  useEffect(() => {
+    return () => {
+      if (manualSelectionTimerRef.current) {
+        clearTimeout(manualSelectionTimerRef.current);
+      }
+    };
+  }, []);
+
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>, id: string) => {
       e.preventDefault();
       const target = document.getElementById(id);
       if (target) {
+        if (manualSelectionTimerRef.current) {
+          clearTimeout(manualSelectionTimerRef.current);
+        }
+        manuallySelectedIdRef.current = id;
         target.scrollIntoView({ behavior: "smooth", block: "start" });
         // Update URL hash without jumping
         window.history.pushState(null, "", `#${id}`);
         setActiveId(id);
+        manualSelectionTimerRef.current = setTimeout(() => {
+          manuallySelectedIdRef.current = null;
+          manualSelectionTimerRef.current = null;
+        }, 1500);
       }
     },
     [],

--- a/src/components/docs/docs-toc.tsx
+++ b/src/components/docs/docs-toc.tsx
@@ -10,7 +10,11 @@ interface DocsTocProps {
 export function DocsToc({ entries }: DocsTocProps) {
   // Filter to H2 and H3 only for display
   const displayEntries = entries.filter((e) => e.level >= 2 && e.level <= 3);
-  const [activeId, setActiveId] = useState<string>("");
+  const [activeId, setActiveId] = useState<string>(displayEntries[0]?.id ?? "");
+
+  useEffect(() => {
+    setActiveId((current) => current || displayEntries[0]?.id || "");
+  }, [displayEntries]);
 
   useEffect(() => {
     if (displayEntries.length === 0) return;

--- a/src/components/docs/docs-topbar.tsx
+++ b/src/components/docs/docs-topbar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { mergeDocsConfig } from "@/lib/docs-config";
 import type { VersionsConfig } from "@/lib/versions";
 import Link from "next/link";
 import { LanguageSwitcher } from "./language-switcher";
@@ -87,6 +88,35 @@ export function AskAiButton() {
   );
 }
 
+export function getConfiguredDocsLogo(
+  settings: DocsTopbarProps["settings"],
+): { path: string; href: string } | null {
+  const raw = (settings || {}) as Record<string, unknown>;
+  const rawDocsConfig = raw.docsConfig;
+
+  if (!rawDocsConfig || typeof rawDocsConfig !== "object") {
+    const legacyLogo =
+      typeof raw.logoUrl === "string"
+        ? raw.logoUrl
+        : typeof raw.logoDarkUrl === "string"
+          ? raw.logoDarkUrl
+          : "";
+    return legacyLogo ? { path: legacyLogo, href: "" } : null;
+  }
+
+  const docsConfig = mergeDocsConfig(
+    rawDocsConfig as Partial<Record<string, unknown>>,
+  );
+  const path =
+    docsConfig.headerTopbar.logoPath ||
+    docsConfig.visualBranding.logoDarkPath ||
+    docsConfig.visualBranding.logoLightPath;
+
+  if (!path) return null;
+
+  return { path, href: docsConfig.visualBranding.logoLink || "/" };
+}
+
 export function DocsTopbar({
   projectName,
   subdomain,
@@ -98,6 +128,8 @@ export function DocsTopbar({
   const githubProps = getGithubLinkProps(s.githubUrl);
   const supportHref = buildSupportHref(s.supportEmail);
   const dashboardUrl = buildDashboardUrl(subdomain);
+  const configuredLogo = getConfiguredDocsLogo(settings);
+  const logoHref = configuredLogo?.href || `/docs/${subdomain}`;
 
   return (
     <>
@@ -107,37 +139,45 @@ export function DocsTopbar({
       <div className="docs-topbar">
         <div className="docs-topbar-left">
           <MobileMenuButton />
-          <Link href={`/docs/${subdomain}`} className="docs-topbar-logo">
-            <svg
-              width="28"
-              height="28"
-              viewBox="0 0 24 24"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              aria-label="Logo"
-              className="docs-topbar-logo-icon"
-            >
-              <title>Logo</title>
-              <path
-                d="M12 2L2 7l10 5 10-5-10-5Z"
-                fill="#16A34A"
-                opacity="0.8"
+          <Link href={logoHref} className="docs-topbar-logo">
+            {configuredLogo ? (
+              <img
+                src={configuredLogo.path}
+                alt="Logo"
+                className="docs-topbar-logo-image"
               />
-              <path
-                d="M2 17l10 5 10-5"
-                stroke="#16A34A"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M2 12l10 5 10-5"
-                stroke="#16A34A"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
+            ) : (
+              <svg
+                width="28"
+                height="28"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-label="Logo"
+                className="docs-topbar-logo-icon"
+              >
+                <title>Logo</title>
+                <path
+                  d="M12 2L2 7l10 5 10-5-10-5Z"
+                  fill="currentColor"
+                  opacity="0.8"
+                />
+                <path
+                  d="M2 17l10 5 10-5"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M2 12l10 5 10-5"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            )}
             <span className="docs-topbar-title">{projectName}</span>
           </Link>
         </div>

--- a/src/components/docs/docs-topbar.tsx
+++ b/src/components/docs/docs-topbar.tsx
@@ -63,6 +63,7 @@ export function AskAiButton() {
       type="button"
       data-testid="ask-ai-btn"
       className="docs-topbar-ask-ai"
+      aria-label="Toggle assistant panel"
       onClick={() => {
         document.dispatchEvent(new CustomEvent("toggle-ask-ai"));
       }}
@@ -137,6 +138,7 @@ export function DocsTopbar({
         <button
           type="button"
           className="docs-search-btn"
+          aria-label="Open search"
           onClick={() => {
             document.dispatchEvent(new CustomEvent("open-search"));
           }}
@@ -148,9 +150,8 @@ export function DocsTopbar({
             fill="none"
             stroke="currentColor"
             strokeWidth="2"
-            aria-label="Search"
+            aria-hidden="true"
           >
-            <title>Search</title>
             <circle cx="11" cy="11" r="8" />
             <path d="m21 21-4.35-4.35" />
           </svg>

--- a/src/components/docs/docs-topbar.tsx
+++ b/src/components/docs/docs-topbar.tsx
@@ -99,144 +99,153 @@ export function DocsTopbar({
   const dashboardUrl = buildDashboardUrl(subdomain);
 
   return (
-    <div className="docs-topbar">
-      <div className="docs-topbar-left">
-        <MobileMenuButton />
-        <Link href={`/docs/${subdomain}`} className="docs-topbar-logo">
-          <svg
-            width="28"
-            height="28"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            aria-label="Logo"
-            className="docs-topbar-logo-icon"
-          >
-            <title>Logo</title>
-            <path d="M12 2L2 7l10 5 10-5-10-5Z" fill="#16A34A" opacity="0.8" />
-            <path
-              d="M2 17l10 5 10-5"
-              stroke="#16A34A"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-            <path
-              d="M2 12l10 5 10-5"
-              stroke="#16A34A"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-          <span className="docs-topbar-title">{projectName}</span>
-        </Link>
-      </div>
+    <>
+      <a className="docs-skip-link" href="#main-content">
+        Skip to main content
+      </a>
+      <div className="docs-topbar">
+        <div className="docs-topbar-left">
+          <MobileMenuButton />
+          <Link href={`/docs/${subdomain}`} className="docs-topbar-logo">
+            <svg
+              width="28"
+              height="28"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              aria-label="Logo"
+              className="docs-topbar-logo-icon"
+            >
+              <title>Logo</title>
+              <path
+                d="M12 2L2 7l10 5 10-5-10-5Z"
+                fill="#16A34A"
+                opacity="0.8"
+              />
+              <path
+                d="M2 17l10 5 10-5"
+                stroke="#16A34A"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M2 12l10 5 10-5"
+                stroke="#16A34A"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+            <span className="docs-topbar-title">{projectName}</span>
+          </Link>
+        </div>
 
-      <div className="docs-topbar-center">
-        <button
-          type="button"
-          className="docs-search-btn"
-          onClick={() => {
-            document.dispatchEvent(new CustomEvent("open-search"));
-          }}
-        >
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            aria-label="Search"
-          >
-            <title>Search</title>
-            <circle cx="11" cy="11" r="8" />
-            <path d="m21 21-4.35-4.35" />
-          </svg>
-          <span className="docs-search-text">Search...</span>
-          <kbd>&#8984;K</kbd>
-        </button>
-        <AskAiButton />
-      </div>
-
-      <div className="docs-topbar-right">
-        <a
-          data-testid="topbar-support-link"
-          href={supportHref}
-          className="docs-topbar-link"
-        >
-          Support
-        </a>
-
-        {githubProps && (
-          <a
-            data-testid="topbar-github-link"
-            href={githubProps.href}
-            target={githubProps.target}
-            rel={githubProps.rel}
-            className="docs-topbar-icon-link"
-            aria-label="GitHub repository"
+        <div className="docs-topbar-center">
+          <button
+            type="button"
+            className="docs-search-btn"
+            onClick={() => {
+              document.dispatchEvent(new CustomEvent("open-search"));
+            }}
           >
             <svg
-              width="20"
-              height="20"
+              width="16"
+              height="16"
               viewBox="0 0 24 24"
-              fill="currentColor"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              aria-label="Search"
+            >
+              <title>Search</title>
+              <circle cx="11" cy="11" r="8" />
+              <path d="m21 21-4.35-4.35" />
+            </svg>
+            <span className="docs-search-text">Search...</span>
+            <kbd>&#8984;K</kbd>
+          </button>
+          <AskAiButton />
+        </div>
+
+        <div className="docs-topbar-right">
+          <a
+            data-testid="topbar-support-link"
+            href={supportHref}
+            className="docs-topbar-link"
+          >
+            Support
+          </a>
+
+          {githubProps && (
+            <a
+              data-testid="topbar-github-link"
+              href={githubProps.href}
+              target={githubProps.target}
+              rel={githubProps.rel}
+              className="docs-topbar-icon-link"
+              aria-label="GitHub repository"
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+              </svg>
+              <span className="sr-only">GitHub</span>
+            </a>
+          )}
+
+          <Link
+            data-testid="topbar-dashboard-link"
+            href={dashboardUrl}
+            className="docs-topbar-dashboard-btn"
+          >
+            Dashboard
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
               aria-hidden="true"
             >
-              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+              <path d="M7 17L17 7" />
+              <path d="M7 7h10v10" />
             </svg>
-            <span className="sr-only">GitHub</span>
-          </a>
-        )}
+          </Link>
 
-        <Link
-          data-testid="topbar-dashboard-link"
-          href={dashboardUrl}
-          className="docs-topbar-dashboard-btn"
-        >
-          Dashboard
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M7 17L17 7" />
-            <path d="M7 7h10v10" />
-          </svg>
-        </Link>
+          {version && version.availableVersions.length > 1 && (
+            <VersionSwitcher
+              currentVersion={version.currentVersion}
+              availableVersions={version.availableVersions}
+              versionsConfig={version.versionsConfig}
+              subdomain={subdomain}
+              pagePath={version.pagePath}
+              locale={version.locale}
+              defaultLanguage={version.defaultLanguage}
+            />
+          )}
 
-        {version && version.availableVersions.length > 1 && (
-          <VersionSwitcher
-            currentVersion={version.currentVersion}
-            availableVersions={version.availableVersions}
-            versionsConfig={version.versionsConfig}
-            subdomain={subdomain}
-            pagePath={version.pagePath}
-            locale={version.locale}
-            defaultLanguage={version.defaultLanguage}
-          />
-        )}
+          {i18n && i18n.availableLocales.length > 1 && (
+            <LanguageSwitcher
+              currentLocale={i18n.currentLocale}
+              availableLocales={i18n.availableLocales}
+              subdomain={subdomain}
+              pagePath={i18n.pagePath}
+              defaultLanguage={i18n.defaultLanguage}
+            />
+          )}
 
-        {i18n && i18n.availableLocales.length > 1 && (
-          <LanguageSwitcher
-            currentLocale={i18n.currentLocale}
-            availableLocales={i18n.availableLocales}
-            subdomain={subdomain}
-            pagePath={i18n.pagePath}
-            defaultLanguage={i18n.defaultLanguage}
-          />
-        )}
-
-        <ThemeToggle />
+          <ThemeToggle />
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/components/docs/feedback-widget.tsx
+++ b/src/components/docs/feedback-widget.tsx
@@ -90,7 +90,8 @@ export function FeedbackWidget({ subdomain, pagePath }: FeedbackWidgetProps) {
               data-testid="feedback-thumbs-up"
               aria-label="Yes, this page was helpful"
             >
-              <ThumbsUp size={16} />
+              <ThumbsUp size={16} aria-hidden="true" />
+              <span className="docs-feedback-btn-label">Yes</span>
             </button>
             <button
               type="button"
@@ -99,7 +100,8 @@ export function FeedbackWidget({ subdomain, pagePath }: FeedbackWidgetProps) {
               data-testid="feedback-thumbs-down"
               aria-label="No, this page was not helpful"
             >
-              <ThumbsDown size={16} />
+              <ThumbsDown size={16} aria-hidden="true" />
+              <span className="docs-feedback-btn-label">No</span>
             </button>
           </div>
         </div>

--- a/src/components/docs/feedback-widget.tsx
+++ b/src/components/docs/feedback-widget.tsx
@@ -17,10 +17,13 @@ export function FeedbackWidget({ subdomain, pagePath }: FeedbackWidgetProps) {
   const [toast, setToast] = useState(false);
   const commentLabelId = useId();
   const commentRef = useRef<HTMLTextAreaElement>(null);
+  const thanksRef = useRef<HTMLParagraphElement>(null);
 
   useEffect(() => {
     if (state === "rated") {
       commentRef.current?.focus();
+    } else if (state === "submitted") {
+      thanksRef.current?.focus();
     }
   }, [state]);
 
@@ -73,7 +76,12 @@ export function FeedbackWidget({ subdomain, pagePath }: FeedbackWidgetProps) {
   if (state === "submitted") {
     return (
       <div className="docs-feedback-widget" data-testid="feedback-widget">
-        <p className="docs-feedback-thanks" data-testid="feedback-thanks">
+        <p
+          ref={thanksRef}
+          className="docs-feedback-thanks"
+          data-testid="feedback-thanks"
+          tabIndex={-1}
+        >
           Thanks for your feedback!
         </p>
         {toast && (

--- a/src/components/docs/feedback-widget.tsx
+++ b/src/components/docs/feedback-widget.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ThumbsDown, ThumbsUp } from "lucide-react";
-import { useCallback, useId, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 
 type WidgetState = "idle" | "rated" | "submitting" | "submitted";
 
@@ -16,6 +16,13 @@ export function FeedbackWidget({ subdomain, pagePath }: FeedbackWidgetProps) {
   const [comment, setComment] = useState("");
   const [toast, setToast] = useState(false);
   const commentLabelId = useId();
+  const commentRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (state === "rated") {
+      commentRef.current?.focus();
+    }
+  }, [state]);
 
   const submitFeedback = useCallback(
     async (
@@ -116,6 +123,7 @@ export function FeedbackWidget({ subdomain, pagePath }: FeedbackWidgetProps) {
               : "Sorry to hear that. How can we improve?"}
           </p>
           <textarea
+            ref={commentRef}
             className="docs-feedback-textarea"
             data-testid="feedback-textarea"
             aria-labelledby={commentLabelId}

--- a/src/components/docs/feedback-widget.tsx
+++ b/src/components/docs/feedback-widget.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ThumbsDown, ThumbsUp } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback, useId, useState } from "react";
 
 type WidgetState = "idle" | "rated" | "submitting" | "submitted";
 
@@ -15,6 +15,7 @@ export function FeedbackWidget({ subdomain, pagePath }: FeedbackWidgetProps) {
   const [rating, setRating] = useState<"helpful" | "not_helpful" | null>(null);
   const [comment, setComment] = useState("");
   const [toast, setToast] = useState(false);
+  const commentLabelId = useId();
 
   const submitFeedback = useCallback(
     async (
@@ -109,7 +110,7 @@ export function FeedbackWidget({ subdomain, pagePath }: FeedbackWidgetProps) {
 
       {(state === "rated" || state === "submitting") && (
         <div className="docs-feedback-comment-section">
-          <p className="docs-feedback-comment-label">
+          <p id={commentLabelId} className="docs-feedback-comment-label">
             {rating === "helpful"
               ? "Great! Any additional feedback?"
               : "Sorry to hear that. How can we improve?"}
@@ -117,6 +118,7 @@ export function FeedbackWidget({ subdomain, pagePath }: FeedbackWidgetProps) {
           <textarea
             className="docs-feedback-textarea"
             data-testid="feedback-textarea"
+            aria-labelledby={commentLabelId}
             placeholder="Tell us more (optional)"
             value={comment}
             onChange={(e) => setComment(e.target.value)}

--- a/src/components/docs/language-switcher.tsx
+++ b/src/components/docs/language-switcher.tsx
@@ -60,6 +60,7 @@ export function LanguageSwitcher({
         type="button"
         className="lang-switcher-btn"
         onClick={() => setOpen((v) => !v)}
+        aria-label={`Select docs language, current language ${currentInfo?.name ?? currentLocale}`}
         aria-expanded={open}
         aria-haspopup="listbox"
         data-testid="language-switcher-btn"
@@ -109,6 +110,7 @@ export function LanguageSwitcher({
               <button
                 key={locale}
                 type="button"
+                aria-label={`Switch to ${info?.name ?? locale}`}
                 aria-current={isActive ? "true" : undefined}
                 className={`lang-switcher-option ${isActive ? "lang-switcher-option-active" : ""}`}
                 onClick={() => handleSelect(locale)}

--- a/src/components/docs/language-switcher.tsx
+++ b/src/components/docs/language-switcher.tsx
@@ -22,6 +22,7 @@ export function LanguageSwitcher({
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const dropdownId = useId();
   const router = useRouter();
 
@@ -54,6 +55,27 @@ export function LanguageSwitcher({
       if (e.key === "Escape") {
         e.preventDefault();
         closeDropdown({ restoreFocus: true });
+        return;
+      }
+
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        const options = optionRefs.current.filter(Boolean);
+        if (options.length === 0) return;
+
+        e.preventDefault();
+        const activeIndex = options.findIndex(
+          (option) => option === document.activeElement,
+        );
+        const nextIndex =
+          e.key === "ArrowDown"
+            ? activeIndex === -1
+              ? 0
+              : (activeIndex + 1) % options.length
+            : activeIndex === -1
+              ? options.length - 1
+              : (activeIndex - 1 + options.length) % options.length;
+
+        options[nextIndex]?.focus();
       }
     }
 
@@ -135,12 +157,15 @@ export function LanguageSwitcher({
           aria-label="Language selection"
           data-testid="language-switcher-dropdown"
         >
-          {availableLocales.map((locale) => {
+          {availableLocales.map((locale, index) => {
             const info = getLanguageInfo(locale);
             const isActive = locale === currentLocale;
             return (
               <button
                 key={locale}
+                ref={(element) => {
+                  optionRefs.current[index] = element;
+                }}
                 type="button"
                 aria-label={`Switch to ${info?.name ?? locale}`}
                 aria-current={isActive ? "true" : undefined}

--- a/src/components/docs/language-switcher.tsx
+++ b/src/components/docs/language-switcher.tsx
@@ -2,7 +2,7 @@
 
 import { getLanguageInfo } from "@/lib/i18n";
 import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 
 interface LanguageSwitcherProps {
   currentLocale: string;
@@ -21,20 +21,49 @@ export function LanguageSwitcher({
 }: LanguageSwitcherProps) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const dropdownId = useId();
   const router = useRouter();
 
-  // Close on click outside
+  const closeDropdown = useCallback(
+    ({ restoreFocus }: { restoreFocus: boolean }) => {
+      setOpen(false);
+      if (restoreFocus) {
+        triggerRef.current?.focus();
+      }
+    },
+    [],
+  );
+
+  const toggleDropdown = useCallback(() => {
+    triggerRef.current?.focus();
+    setOpen((value) => !value);
+  }, []);
+
+  // Close on click outside or Escape
   useEffect(() => {
+    if (!open) return;
+
     function handleClick(e: MouseEvent) {
       if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
+        closeDropdown({ restoreFocus: false });
       }
     }
-    if (open) {
-      document.addEventListener("mousedown", handleClick);
-      return () => document.removeEventListener("mousedown", handleClick);
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        closeDropdown({ restoreFocus: true });
+      }
     }
-  }, [open]);
+
+    document.addEventListener("mousedown", handleClick);
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      window.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, [closeDropdown, open]);
 
   if (availableLocales.length <= 1) return null;
 
@@ -57,12 +86,14 @@ export function LanguageSwitcher({
   return (
     <div className="lang-switcher" ref={ref} data-testid="language-switcher">
       <button
+        ref={triggerRef}
         type="button"
         className="lang-switcher-btn"
-        onClick={() => setOpen((v) => !v)}
+        onClick={toggleDropdown}
         aria-label={`Select docs language, current language ${currentInfo?.name ?? currentLocale}`}
         aria-expanded={open}
         aria-haspopup="listbox"
+        aria-controls={open ? dropdownId : undefined}
         data-testid="language-switcher-btn"
       >
         <svg
@@ -99,6 +130,7 @@ export function LanguageSwitcher({
 
       {open && (
         <nav
+          id={dropdownId}
           className="lang-switcher-dropdown"
           aria-label="Language selection"
           data-testid="language-switcher-dropdown"

--- a/src/components/docs/mdx-content.tsx
+++ b/src/components/docs/mdx-content.tsx
@@ -18,6 +18,25 @@ export function MdxContent({ html }: MdxContentProps) {
     const container = containerRef.current;
     if (!container) return;
 
+    // Imported READMEs often include dynamic GitHub shields that render as
+    // "invalid" when the source repo is private, renamed, or unavailable. Hide
+    // those volatile social/count badges rather than surfacing broken chrome at
+    // the top of generated docs pages.
+    const volatileBadgeImages = container.querySelectorAll<HTMLImageElement>(
+      'img[src*="img.shields.io/github/stars"], img[src*="img.shields.io/github/issues"]',
+    );
+    for (const img of volatileBadgeImages) {
+      const parentAnchor = img.parentElement;
+      if (
+        parentAnchor?.tagName === "A" &&
+        parentAnchor.textContent?.trim() === ""
+      ) {
+        parentAnchor.remove();
+      } else {
+        img.remove();
+      }
+    }
+
     // Wire up tab switching
     const tabButtons = container.querySelectorAll<HTMLButtonElement>(
       ".tab-bar .tab-button",

--- a/src/components/docs/mobile-nav.tsx
+++ b/src/components/docs/mobile-nav.tsx
@@ -5,6 +5,21 @@ import { X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { DocsSidebar } from "./docs-sidebar";
 
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    .filter((element) => element.tabIndex >= 0)
+    .filter((element) => element.getAttribute("aria-hidden") !== "true");
+}
+
 export function MobileMenuButton() {
   return (
     <button
@@ -91,6 +106,38 @@ export function MobileSidebar({
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") {
         setIsOpen(false);
+      }
+      if (event.key === "Tab" && overlayRef.current) {
+        const focusableElements = getFocusableElements(overlayRef.current);
+        const firstFocusable = focusableElements[0];
+        const lastFocusable = focusableElements[focusableElements.length - 1];
+
+        if (!firstFocusable || !lastFocusable) {
+          event.preventDefault();
+          overlayRef.current.focus();
+          return;
+        }
+
+        const activeElement = document.activeElement;
+        if (
+          !(activeElement instanceof HTMLElement) ||
+          !overlayRef.current.contains(activeElement)
+        ) {
+          event.preventDefault();
+          firstFocusable.focus();
+          return;
+        }
+
+        if (event.shiftKey && activeElement === firstFocusable) {
+          event.preventDefault();
+          lastFocusable.focus();
+          return;
+        }
+
+        if (!event.shiftKey && activeElement === lastFocusable) {
+          event.preventDefault();
+          firstFocusable.focus();
+        }
       }
     }
 

--- a/src/components/docs/mobile-nav.tsx
+++ b/src/components/docs/mobile-nav.tsx
@@ -2,7 +2,7 @@
 
 import type { DocsNavEntry } from "@/lib/mdx-renderer";
 import { X } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { DocsSidebar } from "./docs-sidebar";
 
 export function MobileMenuButton() {
@@ -49,6 +49,7 @@ export function MobileSidebar({
   projectName,
 }: MobileSidebarProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const overlayRef = useRef<HTMLDialogElement>(null);
 
   useEffect(() => {
     function handleToggle() {
@@ -77,17 +78,49 @@ export function MobileSidebar({
     };
   }, [isOpen]);
 
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const previouslyFocused =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+
+    overlayRef.current?.focus();
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      previouslyFocused?.focus();
+    };
+  }, [isOpen]);
+
   if (!isOpen) return null;
 
   return (
-    <div
+    <dialog
+      ref={overlayRef}
       data-testid="mobile-sidebar"
+      open
+      aria-modal="true"
+      aria-label={`${projectName} navigation`}
       className="mobile-sidebar-overlay"
       onClick={(e) => {
         if (e.target === e.currentTarget) setIsOpen(false);
       }}
       onKeyDown={(e) => {
         if (e.key === "Escape") setIsOpen(false);
+      }}
+      onCancel={(e) => {
+        e.preventDefault();
+        setIsOpen(false);
       }}
     >
       <div className="mobile-sidebar-panel">
@@ -99,7 +132,7 @@ export function MobileSidebar({
             onClick={() => setIsOpen(false)}
             aria-label="Close navigation"
           >
-            <X size={20} />
+            <X size={20} aria-hidden="true" />
           </button>
         </div>
         <DocsSidebar
@@ -109,6 +142,6 @@ export function MobileSidebar({
           projectName={projectName}
         />
       </div>
-    </div>
+    </dialog>
   );
 }

--- a/src/components/docs/page-chrome.tsx
+++ b/src/components/docs/page-chrome.tsx
@@ -68,11 +68,13 @@ export function PageHeaderActions({
       <button
         type="button"
         data-testid="copy-page-btn"
-        className="page-action-btn"
+        className={`page-action-btn page-copy-btn${copied ? " copied" : ""}`}
         onClick={handleCopy}
-        title="Copy page as markdown"
+        aria-label={copied ? "Copied page markdown" : "Copy page as markdown"}
+        title={copied ? "Copied" : "Copy page as markdown"}
       >
         {copied ? <Check size={16} /> : <Copy size={16} />}
+        {copied && <span>Copied</span>}
       </button>
 
       <div className="page-actions-dropdown" ref={menuRef}>

--- a/src/components/docs/page-chrome.tsx
+++ b/src/components/docs/page-chrome.tsx
@@ -3,7 +3,7 @@
 import type { ContextualAiMenuConfig } from "@/lib/contextual-ai-menu";
 import { pageToMarkdown } from "@/lib/page-chrome";
 import { Check, Copy, Link2, MoreVertical } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { ContextualAiMenu } from "./contextual-ai-menu";
 
 interface PageHeaderActionsProps {
@@ -23,6 +23,7 @@ export function PageHeaderActions({
   const [copied, setCopied] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const menuId = useId();
 
   const handleCopy = useCallback(async () => {
     const md = pageToMarkdown(title, content);
@@ -83,16 +84,21 @@ export function PageHeaderActions({
           data-testid="page-actions-btn"
           className="page-action-btn"
           onClick={() => setMenuOpen(!menuOpen)}
+          aria-label="More page actions"
+          aria-haspopup="menu"
+          aria-expanded={menuOpen}
+          aria-controls={menuOpen ? menuId : undefined}
           title="More actions"
         >
           <MoreVertical size={16} />
         </button>
 
         {menuOpen && (
-          <div className="page-actions-menu">
+          <div className="page-actions-menu" id={menuId} role="menu">
             <button
               type="button"
               className="page-actions-menu-item"
+              role="menuitem"
               onClick={handleCopyLink}
             >
               <Link2 size={14} />
@@ -101,6 +107,7 @@ export function PageHeaderActions({
             <button
               type="button"
               className="page-actions-menu-item"
+              role="menuitem"
               onClick={handleViewSource}
             >
               <Copy size={14} />

--- a/src/components/docs/page-chrome.tsx
+++ b/src/components/docs/page-chrome.tsx
@@ -23,6 +23,7 @@ export function PageHeaderActions({
   const [copied, setCopied] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
   const menuId = useId();
 
   const handleCopy = useCallback(async () => {
@@ -43,16 +44,41 @@ export function PageHeaderActions({
     setMenuOpen(false);
   }, [pageUrl]);
 
-  // Close menu on click outside
+  const handleToggleMenu = useCallback(() => {
+    menuButtonRef.current?.focus();
+    setMenuOpen((open) => !open);
+  }, []);
+
+  // Close menu on click outside or Escape.
   useEffect(() => {
     if (!menuOpen) return;
-    function handleClick(e: MouseEvent) {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMenuOpen(false);
+
+    function closeMenu({ restoreFocus }: { restoreFocus: boolean }) {
+      setMenuOpen(false);
+      if (restoreFocus) {
+        menuButtonRef.current?.focus();
       }
     }
+
+    function handleClick(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        closeMenu({ restoreFocus: false });
+      }
+    }
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        closeMenu({ restoreFocus: true });
+      }
+    }
+
     document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      window.removeEventListener("keydown", handleKeyDown, true);
+    };
   }, [menuOpen]);
 
   return (
@@ -80,10 +106,11 @@ export function PageHeaderActions({
 
       <div className="page-actions-dropdown" ref={menuRef}>
         <button
+          ref={menuButtonRef}
           type="button"
           data-testid="page-actions-btn"
           className="page-action-btn"
-          onClick={() => setMenuOpen(!menuOpen)}
+          onClick={handleToggleMenu}
           aria-label="More page actions"
           aria-haspopup="menu"
           aria-expanded={menuOpen}

--- a/src/components/docs/search-modal.tsx
+++ b/src/components/docs/search-modal.tsx
@@ -47,6 +47,14 @@ export function filterPages(
 
 const RECENT_KEY = "docs-recent-searches";
 const MAX_RECENT = 5;
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
 
 type DocsSearchWindow = Window & { __docsSearchRequested?: boolean };
 
@@ -84,6 +92,12 @@ function saveRecentSearch(query: string): void {
   }
 }
 
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    .filter((element) => element.tabIndex >= 0)
+    .filter((element) => element.getAttribute("aria-hidden") !== "true");
+}
+
 // ── Group results by first breadcrumb segment ─────────────────────────────────
 
 function groupResults(results: SearchResultItem[]): SearchResultGroup[] {
@@ -119,6 +133,7 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
   const [selectedIdx, setSelectedIdx] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
+  const dialogRef = useRef<HTMLDialogElement>(null);
   const abortRef = useRef<AbortController | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const restoreFocusRef = useRef<HTMLElement | null>(null);
@@ -151,6 +166,42 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
       setTimeout(() => {
         restoreFocusTarget.focus();
       }, 0);
+    }
+  }, []);
+
+  const trapTabFocus = useCallback((event: KeyboardEvent) => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const focusableElements = getFocusableElements(dialog);
+    const firstFocusable = focusableElements[0];
+    const lastFocusable = focusableElements[focusableElements.length - 1];
+
+    if (!firstFocusable || !lastFocusable) {
+      event.preventDefault();
+      dialog.focus();
+      return;
+    }
+
+    const activeElement = document.activeElement;
+    if (
+      !(activeElement instanceof HTMLElement) ||
+      !dialog.contains(activeElement)
+    ) {
+      event.preventDefault();
+      firstFocusable.focus();
+      return;
+    }
+
+    if (event.shiftKey && activeElement === firstFocusable) {
+      event.preventDefault();
+      lastFocusable.focus();
+      return;
+    }
+
+    if (!event.shiftKey && activeElement === lastFocusable) {
+      event.preventDefault();
+      firstFocusable.focus();
     }
   }, []);
 
@@ -240,10 +291,13 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
       if (e.key === "Escape" && isOpen) {
         close();
       }
+      if (e.key === "Tab" && isOpen) {
+        trapTabFocus(e);
+      }
     }
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [isOpen, close, open]);
+  }, [isOpen, close, open, trapTabFocus]);
 
   // Auto-focus input
   useEffect(() => {
@@ -336,6 +390,7 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
       }}
     >
       <dialog
+        ref={dialogRef}
         className="search-modal"
         open
         aria-label="Search docs"

--- a/src/components/docs/search-modal.tsx
+++ b/src/components/docs/search-modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -114,6 +114,11 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const abortRef = useRef<AbortController | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const listboxId = useId();
+  const optionIdForIndex = useCallback(
+    (index: number) => `${listboxId}-option-${index}`,
+    [listboxId],
+  );
 
   const open = useCallback(() => {
     setIsOpen(true);
@@ -267,6 +272,19 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
   const grouped = groupResults(results);
   const hasQuery = query.trim().length > 0;
   const showRecent = !hasQuery && recentSearches.length > 0;
+  const activeDescendant = allResults[selectedIdx]
+    ? optionIdForIndex(selectedIdx)
+    : undefined;
+  const listboxProps = {
+    role: "listbox",
+    tabIndex: -1,
+    "aria-label": "Search results",
+  } as const;
+  const optionProps = (selected: boolean) =>
+    ({
+      role: "option",
+      "aria-selected": selected,
+    }) as const;
 
   return (
     <div
@@ -302,6 +320,12 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
             ref={inputRef}
             data-testid="search-input"
             type="text"
+            role="combobox"
+            aria-label="Search documentation"
+            aria-autocomplete="list"
+            aria-expanded="true"
+            aria-controls={listboxId}
+            aria-activedescendant={activeDescendant}
             className="search-modal-input"
             placeholder="Search documentation..."
             value={query}
@@ -310,7 +334,12 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
           <kbd className="search-modal-esc">Esc</kbd>
         </div>
 
-        <div className="search-modal-results" data-testid="search-results">
+        <div
+          id={listboxId}
+          className="search-modal-results"
+          data-testid="search-results"
+          {...listboxProps}
+        >
           {/* Loading indicator */}
           {loading && hasQuery && (
             <div className="search-modal-loading">Searching...</div>
@@ -320,31 +349,35 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
           {showRecent && (
             <div data-testid="recent-searches" className="search-modal-section">
               <div className="search-modal-section-title">Recent searches</div>
-              {recentSearches.map((q) => (
-                <button
-                  key={q}
-                  type="button"
-                  className="search-modal-result search-modal-recent"
-                  onClick={() => {
-                    setQuery(q);
-                    fetchResults(q);
-                  }}
-                >
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    aria-hidden="true"
+              {recentSearches.map((q, index) => {
+                return (
+                  <button
+                    key={q}
+                    id={optionIdForIndex(index)}
+                    type="button"
+                    {...optionProps(false)}
+                    className="search-modal-result search-modal-recent"
+                    onClick={() => {
+                      setQuery(q);
+                      fetchResults(q);
+                    }}
                   >
-                    <circle cx="12" cy="12" r="10" />
-                    <polyline points="12 6 12 12 16 14" />
-                  </svg>
-                  <span>{q}</span>
-                </button>
-              ))}
+                    <svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      aria-hidden="true"
+                    >
+                      <circle cx="12" cy="12" r="10" />
+                      <polyline points="12 6 12 12 16 14" />
+                    </svg>
+                    <span>{q}</span>
+                  </button>
+                );
+              })}
             </div>
           )}
 
@@ -367,7 +400,9 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
                   return (
                     <Link
                       key={result.path}
+                      id={optionIdForIndex(flatIdx)}
                       href={`/docs/${subdomain}/${result.path}`}
+                      {...optionProps(flatIdx === selectedIdx)}
                       className={`search-modal-result ${flatIdx === selectedIdx ? "search-modal-result-active" : ""}`}
                       onClick={() => {
                         saveRecentSearch(query);
@@ -410,29 +445,33 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
           {/* Default: show all pages when no query */}
           {!hasQuery &&
             !showRecent &&
-            pages.slice(0, 10).map((page) => (
-              <Link
-                key={page.path}
-                href={`/docs/${subdomain}/${page.path}`}
-                className="search-modal-result"
-                onClick={close}
-              >
-                <svg
-                  width="16"
-                  height="16"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  aria-hidden="true"
+            pages.slice(0, 10).map((page, index) => {
+              return (
+                <Link
+                  key={page.path}
+                  id={optionIdForIndex(index)}
+                  href={`/docs/${subdomain}/${page.path}`}
+                  {...optionProps(false)}
+                  className="search-modal-result"
+                  onClick={close}
                 >
-                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-                  <polyline points="14 2 14 8 20 8" />
-                </svg>
-                <span>{page.title}</span>
-                <span className="search-modal-result-path">{page.path}</span>
-              </Link>
-            ))}
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    aria-hidden="true"
+                  >
+                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                    <polyline points="14 2 14 8 20 8" />
+                  </svg>
+                  <span>{page.title}</span>
+                  <span className="search-modal-result-path">{page.path}</span>
+                </Link>
+              );
+            })}
         </div>
 
         {/* Footer with keyboard hints */}

--- a/src/components/docs/search-modal.tsx
+++ b/src/components/docs/search-modal.tsx
@@ -255,18 +255,29 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
   }, [open]);
 
   // Keyboard navigation within results
-  const allResults = results;
+  const hasQuery = query.trim().length > 0;
+  const showRecent = !hasQuery && recentSearches.length > 0;
+  const defaultPages = !hasQuery && !showRecent ? pages.slice(0, 10) : [];
+  const navigableCount = hasQuery ? results.length : defaultPages.length;
   const handleModalKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "ArrowDown") {
       e.preventDefault();
-      setSelectedIdx((prev) => Math.min(prev + 1, allResults.length - 1));
+      if (navigableCount > 0) {
+        setSelectedIdx((prev) => Math.min(prev + 1, navigableCount - 1));
+      }
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       setSelectedIdx((prev) => Math.max(prev - 1, 0));
-    } else if (e.key === "Enter" && allResults[selectedIdx]) {
+    } else if (e.key === "Enter") {
+      const resultTarget = hasQuery ? results[selectedIdx] : undefined;
+      const defaultTarget = !hasQuery ? defaultPages[selectedIdx] : undefined;
+      const target = resultTarget || defaultTarget;
+      if (!target) return;
+
       e.preventDefault();
-      saveRecentSearch(query);
-      const target = allResults[selectedIdx];
+      if (hasQuery) {
+        saveRecentSearch(query);
+      }
       window.location.href = `/docs/${subdomain}/${target.path}`;
     }
   };
@@ -274,11 +285,8 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
   if (!isOpen) return null;
 
   const grouped = groupResults(results);
-  const hasQuery = query.trim().length > 0;
-  const showRecent = !hasQuery && recentSearches.length > 0;
-  const activeDescendant = allResults[selectedIdx]
-    ? optionIdForIndex(selectedIdx)
-    : undefined;
+  const activeDescendant =
+    navigableCount > 0 ? optionIdForIndex(selectedIdx) : undefined;
   const listboxProps = {
     role: "listbox",
     tabIndex: -1,
@@ -400,7 +408,7 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
                   {group.section}
                 </div>
                 {group.results.map((result) => {
-                  const flatIdx = allResults.indexOf(result);
+                  const flatIdx = results.indexOf(result);
                   return (
                     <Link
                       key={result.path}
@@ -449,14 +457,15 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
           {/* Default: show all pages when no query */}
           {!hasQuery &&
             !showRecent &&
-            pages.slice(0, 10).map((page, index) => {
+            defaultPages.map((page, index) => {
+              const selected = index === selectedIdx;
               return (
                 <Link
                   key={page.path}
                   id={optionIdForIndex(index)}
                   href={`/docs/${subdomain}/${page.path}`}
-                  {...optionProps(false)}
-                  className="search-modal-result"
+                  {...optionProps(selected)}
+                  className={`search-modal-result ${selected ? "search-modal-result-active" : ""}`}
                   onClick={close}
                 >
                   <svg

--- a/src/components/docs/search-modal.tsx
+++ b/src/components/docs/search-modal.tsx
@@ -121,6 +121,7 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const abortRef = useRef<AbortController | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
   const listboxId = useId();
   const optionIdForIndex = useCallback(
     (index: number) => `${listboxId}-option-${index}`,
@@ -128,6 +129,9 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
   );
 
   const open = useCallback(() => {
+    const activeElement = document.activeElement;
+    restoreFocusRef.current =
+      activeElement instanceof HTMLElement ? activeElement : null;
     setIsOpen(true);
     setQuery("");
     setResults([]);
@@ -136,10 +140,18 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
   }, []);
 
   const close = useCallback(() => {
+    const restoreFocusTarget = restoreFocusRef.current;
     setIsOpen(false);
     setQuery("");
     setResults([]);
     setSelectedIdx(0);
+    restoreFocusRef.current = null;
+
+    if (restoreFocusTarget?.isConnected) {
+      setTimeout(() => {
+        restoreFocusTarget.focus();
+      }, 0);
+    }
   }, []);
 
   // Fetch results from API with debounce

--- a/src/components/docs/search-modal.tsx
+++ b/src/components/docs/search-modal.tsx
@@ -27,10 +27,7 @@ interface SearchResultGroup {
 
 /** Returns true if the shortcut should open the search modal */
 export function handleSearchShortcut(event: KeyboardEvent): boolean {
-  if (event.key === "k" && (event.metaKey || event.ctrlKey)) {
-    return true;
-  }
-  return false;
+  return event.key.toLowerCase() === "k" && (event.metaKey || event.ctrlKey);
 }
 
 /** Filter pages by search query (case-insensitive, matches title or path) — client-side fallback */
@@ -50,6 +47,16 @@ export function filterPages(
 
 const RECENT_KEY = "docs-recent-searches";
 const MAX_RECENT = 5;
+
+type DocsSearchWindow = Window & { __docsSearchRequested?: boolean };
+
+function consumePendingSearchRequest(): boolean {
+  if (typeof window === "undefined") return false;
+  const docsWindow = window as DocsSearchWindow;
+  if (!docsWindow.__docsSearchRequested) return false;
+  docsWindow.__docsSearchRequested = false;
+  return true;
+}
 
 function getRecentSearches(): string[] {
   if (typeof window === "undefined") return [];
@@ -211,15 +218,7 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
     function onKeyDown(e: KeyboardEvent) {
       if (handleSearchShortcut(e)) {
         e.preventDefault();
-        setIsOpen((prev) => {
-          if (!prev) {
-            setQuery("");
-            setResults([]);
-            setSelectedIdx(0);
-            setRecentSearches(getRecentSearches());
-          }
-          return !prev;
-        });
+        open();
       }
       if (e.key === "Escape" && isOpen) {
         close();
@@ -227,7 +226,7 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
     }
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [isOpen, close]);
+  }, [isOpen, close, open]);
 
   // Auto-focus input
   useEffect(() => {
@@ -236,9 +235,14 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
     }
   }, [isOpen]);
 
-  // Expose open via custom event
+  // Expose open via custom event and consume any shortcut pressed before hydration.
   useEffect(() => {
+    if (consumePendingSearchRequest()) {
+      open();
+    }
+
     function handleOpenSearch() {
+      consumePendingSearchRequest();
       open();
     }
     document.addEventListener("open-search", handleOpenSearch);

--- a/src/components/docs/search-modal.tsx
+++ b/src/components/docs/search-modal.tsx
@@ -258,7 +258,11 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
   const hasQuery = query.trim().length > 0;
   const showRecent = !hasQuery && recentSearches.length > 0;
   const defaultPages = !hasQuery && !showRecent ? pages.slice(0, 10) : [];
-  const navigableCount = hasQuery ? results.length : defaultPages.length;
+  const navigableCount = hasQuery
+    ? results.length
+    : showRecent
+      ? recentSearches.length
+      : defaultPages.length;
   const handleModalKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "ArrowDown") {
       e.preventDefault();
@@ -270,8 +274,18 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
       setSelectedIdx((prev) => Math.max(prev - 1, 0));
     } else if (e.key === "Enter") {
       const resultTarget = hasQuery ? results[selectedIdx] : undefined;
-      const defaultTarget = !hasQuery ? defaultPages[selectedIdx] : undefined;
+      const recentTarget = showRecent ? recentSearches[selectedIdx] : undefined;
+      const defaultTarget =
+        !hasQuery && !showRecent ? defaultPages[selectedIdx] : undefined;
       const target = resultTarget || defaultTarget;
+
+      if (recentTarget) {
+        e.preventDefault();
+        setQuery(recentTarget);
+        fetchResults(recentTarget);
+        return;
+      }
+
       if (!target) return;
 
       e.preventDefault();
@@ -362,13 +376,14 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
             <div data-testid="recent-searches" className="search-modal-section">
               <div className="search-modal-section-title">Recent searches</div>
               {recentSearches.map((q, index) => {
+                const selected = index === selectedIdx;
                 return (
                   <button
                     key={q}
                     id={optionIdForIndex(index)}
                     type="button"
-                    {...optionProps(false)}
-                    className="search-modal-result search-modal-recent"
+                    {...optionProps(selected)}
+                    className={`search-modal-result search-modal-recent ${selected ? "search-modal-result-active" : ""}`}
                     onClick={() => {
                       setQuery(q);
                       fetchResults(q);

--- a/src/components/docs/version-switcher.tsx
+++ b/src/components/docs/version-switcher.tsx
@@ -7,7 +7,7 @@ import {
   getVersionByTag,
 } from "@/lib/versions";
 import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 
 interface VersionSwitcherProps {
   currentVersion: string;
@@ -30,20 +30,49 @@ export function VersionSwitcher({
 }: VersionSwitcherProps) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const dropdownId = useId();
   const router = useRouter();
 
-  // Close on click outside
+  const closeDropdown = useCallback(
+    ({ restoreFocus }: { restoreFocus: boolean }) => {
+      setOpen(false);
+      if (restoreFocus) {
+        triggerRef.current?.focus();
+      }
+    },
+    [],
+  );
+
+  const toggleDropdown = useCallback(() => {
+    triggerRef.current?.focus();
+    setOpen((value) => !value);
+  }, []);
+
+  // Close on click outside or Escape
   useEffect(() => {
+    if (!open) return;
+
     function handleClick(e: MouseEvent) {
       if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
+        closeDropdown({ restoreFocus: false });
       }
     }
-    if (open) {
-      document.addEventListener("mousedown", handleClick);
-      return () => document.removeEventListener("mousedown", handleClick);
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        closeDropdown({ restoreFocus: true });
+      }
     }
-  }, [open]);
+
+    document.addEventListener("mousedown", handleClick);
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      window.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, [closeDropdown, open]);
 
   if (availableVersions.length <= 1) return null;
 
@@ -66,12 +95,14 @@ export function VersionSwitcher({
   return (
     <div className="version-switcher" ref={ref} data-testid="version-switcher">
       <button
+        ref={triggerRef}
         type="button"
         className="version-switcher-btn"
-        onClick={() => setOpen((v) => !v)}
+        onClick={toggleDropdown}
         aria-label={`Select docs version, current version ${currentInfo?.name ?? currentVersion}`}
         aria-expanded={open}
         aria-haspopup="listbox"
+        aria-controls={open ? dropdownId : undefined}
         data-testid="version-switcher-btn"
       >
         <svg
@@ -107,6 +138,7 @@ export function VersionSwitcher({
 
       {open && (
         <nav
+          id={dropdownId}
           className="version-switcher-dropdown"
           aria-label="Version selection"
           data-testid="version-switcher-dropdown"

--- a/src/components/docs/version-switcher.tsx
+++ b/src/components/docs/version-switcher.tsx
@@ -31,6 +31,7 @@ export function VersionSwitcher({
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const dropdownId = useId();
   const router = useRouter();
 
@@ -63,6 +64,27 @@ export function VersionSwitcher({
       if (e.key === "Escape") {
         e.preventDefault();
         closeDropdown({ restoreFocus: true });
+        return;
+      }
+
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        const options = optionRefs.current.filter(Boolean);
+        if (options.length === 0) return;
+
+        e.preventDefault();
+        const activeIndex = options.findIndex(
+          (option) => option === document.activeElement,
+        );
+        const nextIndex =
+          e.key === "ArrowDown"
+            ? activeIndex === -1
+              ? 0
+              : (activeIndex + 1) % options.length
+            : activeIndex === -1
+              ? options.length - 1
+              : (activeIndex - 1 + options.length) % options.length;
+
+        options[nextIndex]?.focus();
       }
     }
 
@@ -143,13 +165,16 @@ export function VersionSwitcher({
           aria-label="Version selection"
           data-testid="version-switcher-dropdown"
         >
-          {availableVersions.map((tag) => {
+          {availableVersions.map((tag, index) => {
             const info = getVersionByTag(versionsConfig, tag);
             const isActive = tag === currentVersion;
             const isDefault = tag === defaultTag;
             return (
               <button
                 key={tag}
+                ref={(element) => {
+                  optionRefs.current[index] = element;
+                }}
                 type="button"
                 aria-label={`Switch to docs version ${info?.name ?? tag}${isDefault ? " (default)" : ""}`}
                 aria-current={isActive ? "true" : undefined}

--- a/src/components/docs/version-switcher.tsx
+++ b/src/components/docs/version-switcher.tsx
@@ -69,6 +69,7 @@ export function VersionSwitcher({
         type="button"
         className="version-switcher-btn"
         onClick={() => setOpen((v) => !v)}
+        aria-label={`Select docs version, current version ${currentInfo?.name ?? currentVersion}`}
         aria-expanded={open}
         aria-haspopup="listbox"
         data-testid="version-switcher-btn"
@@ -118,6 +119,7 @@ export function VersionSwitcher({
               <button
                 key={tag}
                 type="button"
+                aria-label={`Switch to docs version ${info?.name ?? tag}${isDefault ? " (default)" : ""}`}
                 aria-current={isActive ? "true" : undefined}
                 className={`version-switcher-option ${isActive ? "version-switcher-option-active" : ""}`}
                 onClick={() => handleSelect(tag)}

--- a/src/components/editor/configs-panel.tsx
+++ b/src/components/editor/configs-panel.tsx
@@ -298,6 +298,10 @@ function FieldLabel({ children }: { children: React.ReactNode }) {
   return <span className="block text-xs text-gray-400 mb-1">{children}</span>;
 }
 
+function FieldHelp({ children }: { children: React.ReactNode }) {
+  return <p className="mt-1 text-[11px] leading-4 text-gray-500">{children}</p>;
+}
+
 function TextInput({
   value,
   onChange,
@@ -537,6 +541,10 @@ function VisualBrandingForm({ config, updateSection }: SectionProps) {
         onChange={(v) => update({ primaryColor: v })}
         testId="config-branding-primary"
       />
+      <FieldHelp>
+        Applies to published docs accents such as active navigation, links,
+        buttons, API tabs, and the default OpenDocs logo color after Save.
+      </FieldHelp>
       <ColorField
         label="Light color"
         value={d.lightColor}
@@ -557,6 +565,10 @@ function VisualBrandingForm({ config, updateSection }: SectionProps) {
           placeholder="/logo-light.svg"
           testId="config-branding-logo-light"
         />
+        <FieldHelp>
+          Optional public asset path for light theme. Header &amp; Topbar logo
+          path below takes precedence when set.
+        </FieldHelp>
       </div>
       <div>
         <FieldLabel>Logo (dark mode path)</FieldLabel>
@@ -566,6 +578,10 @@ function VisualBrandingForm({ config, updateSection }: SectionProps) {
           placeholder="/logo-dark.svg"
           testId="config-branding-logo-dark"
         />
+        <FieldHelp>
+          Optional public asset path for dark theme. Use paths such as
+          /logo-dark.svg or uploaded public asset URLs.
+        </FieldHelp>
       </div>
       <div>
         <FieldLabel>Logo link</FieldLabel>
@@ -575,6 +591,10 @@ function VisualBrandingForm({ config, updateSection }: SectionProps) {
           placeholder="/"
           testId="config-branding-logo-link"
         />
+        <FieldHelp>
+          Destination for the docs logo link, for example /, /docs, or an
+          absolute marketing-site URL.
+        </FieldHelp>
       </div>
     </>
   );
@@ -639,6 +659,10 @@ function HeaderTopbarForm({ config, updateSection }: SectionProps) {
           placeholder="/logo.svg"
           testId="config-topbar-logo"
         />
+        <FieldHelp>
+          Primary logo shown in the docs topbar. Leave blank to use the visual
+          branding light/dark logo paths or the default OpenDocs mark.
+        </FieldHelp>
       </div>
       <div>
         <div className="flex items-center justify-between mb-1">

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -56,27 +56,31 @@ const mainNavItems: NavItem[] = [
 
 const agentNavItems: NavItem[] = [
   {
+    label: "Workflows",
+    href: "/products/workflows",
+    icon: <GitBranch size={18} />,
+    badge: "New",
+  },
+  {
     label: "Agent",
     href: "/products/agent",
     icon: <Bot size={18} />,
-    badge: "New",
   },
   {
     label: "Assistant",
     href: "/products/assistant",
     icon: <MessageCircle size={18} />,
   },
-  {
-    label: "Workflows",
-    href: "/products/workflows",
-    icon: <GitBranch size={18} />,
-  },
   { label: "MCP", href: "/products/mcp", icon: <Server size={18} /> },
 ];
 
 function isActive(pathname: string, href: string): boolean {
   if (href === "/dashboard") {
-    return pathname === "/dashboard" || pathname.endsWith("/dashboard");
+    return (
+      pathname === "/dashboard" ||
+      pathname.endsWith("/dashboard") ||
+      pathname.endsWith("/home")
+    );
   }
   return pathname.startsWith(href);
 }
@@ -412,6 +416,31 @@ export function Sidebar({
             ))}
           </div>
         </nav>
+
+        <div className="px-3 pb-3">
+          <Link
+            href="/products/workflows"
+            onClick={() => onCloseMobile?.()}
+            className={clsx(
+              "block rounded-xl border p-3 transition-colors",
+              theme === "light"
+                ? "border-slate-200 bg-slate-50 hover:bg-slate-100"
+                : "border-white/[0.08] bg-white/[0.03] hover:bg-white/[0.06]",
+            )}
+          >
+            <div
+              className={clsx("text-xs font-medium", shellTheme.primaryText)}
+            >
+              Workflows
+            </div>
+            <div className={clsx("mt-1 text-xs", shellTheme.secondaryText)}>
+              Control when the agent takes autonomous actions
+            </div>
+            <div className="mt-2 text-xs font-medium text-emerald-400">
+              Check it out
+            </div>
+          </Link>
+        </div>
 
         <div className={clsx("border-t px-3 py-3", shellTheme.divider)}>
           {isMobile ? (

--- a/src/components/layout/trial-banner.tsx
+++ b/src/components/layout/trial-banner.tsx
@@ -48,8 +48,8 @@ export function TrialBanner({
         <strong className={bannerTheme.title}>
           Your team is on a free trial.
         </strong>{" "}
-        Your trial ends on April 19, 2026. You will be switched to the Hobby
-        plan after.
+        Your trial ends on May 18, 2026. You will be switched to the Hobby plan
+        after.
       </p>
       <div className="flex items-center gap-3 shrink-0">
         <Link

--- a/src/lib/api-playground-response.ts
+++ b/src/lib/api-playground-response.ts
@@ -1,0 +1,60 @@
+export interface ApiPlaygroundProxyResult {
+  status: number;
+  body: string;
+  headers: Record<string, string>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringifyBody(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+}
+
+function normalizeHeaders(value: unknown): Record<string, string> {
+  if (!isRecord(value)) return {};
+
+  const headers: Record<string, string> = {};
+  for (const [key, headerValue] of Object.entries(value)) {
+    headers[key] = String(headerValue);
+  }
+  return headers;
+}
+
+export function normalizeApiPlaygroundProxyResult(
+  value: unknown,
+  fallbackStatus: number,
+): ApiPlaygroundProxyResult {
+  if (!isRecord(value)) {
+    return {
+      status: fallbackStatus,
+      body: stringifyBody(value),
+      headers: {},
+    };
+  }
+
+  const payloadStatus =
+    typeof value.status === "number" && value.status > 0
+      ? value.status
+      : undefined;
+  const body =
+    value.body !== undefined
+      ? stringifyBody(value.body)
+      : stringifyBody(value.error);
+
+  return {
+    status: payloadStatus ?? fallbackStatus,
+    body,
+    headers: normalizeHeaders(value.headers),
+  };
+}
+
+export function apiPlaygroundStatusClass(status: number): string {
+  if (!Number.isFinite(status) || status <= 0) {
+    return "api-status-code status-5xx";
+  }
+  return `api-status-code status-${Math.floor(status / 100)}xx`;
+}

--- a/src/lib/api-reference.ts
+++ b/src/lib/api-reference.ts
@@ -306,11 +306,11 @@ export function renderApiReferencePage(endpoint: OpenApiEndpoint): string {
       ${langTabs}
     </div>
     <div class="api-ref-code-actions">
-      <button class="api-ref-copy-btn" data-testid="copy-btn" title="Copy code">
+      <button class="api-ref-copy-btn" data-testid="copy-btn" title="Copy code" aria-label="Copy the contents from the code block">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
         <span>cURL</span>
       </button>
-      <button class="api-ref-askai-btn" data-testid="askai-btn" title="Ask AI">
+      <button class="api-ref-askai-btn" data-testid="askai-btn" title="Ask AI" aria-label="Ask AI">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
         Ask AI
       </button>

--- a/src/lib/api-reference.ts
+++ b/src/lib/api-reference.ts
@@ -279,7 +279,7 @@ export function renderApiReferencePage(endpoint: OpenApiEndpoint): string {
     <span class="method-badge ${badge.colorClass}">${escapeHtml(badge.label)}</span>
     <span class="api-ref-path">${escapeHtml(endpoint.path)}</span>
   </div>
-  <button class="api-ref-tryit-btn" data-testid="tryit-btn">Try it ▶</button>
+  <button class="api-ref-tryit-btn" data-testid="tryit-btn" aria-label="Try it">Try it ▶</button>
 </div>`;
 
   // Code examples with language selector

--- a/src/lib/api-reference.ts
+++ b/src/lib/api-reference.ts
@@ -264,6 +264,15 @@ function escapeHtml(str: string): string {
     .replace(/"/g, "&quot;");
 }
 
+function safeAttributeId(str: string): string {
+  return (
+    str
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "code"
+  );
+}
+
 /**
  * Render a full API reference endpoint page as HTML.
  * Includes: method+URL header, cURL code block with language selector,
@@ -285,24 +294,24 @@ export function renderApiReferencePage(endpoint: OpenApiEndpoint): string {
   // Code examples with language selector
   const examples = generateCodeExamples(endpoint);
   const langTabs = examples
-    .map(
-      (ex, i) =>
-        `<button class="api-ref-lang-tab${i === 0 ? " active" : ""}" data-lang="${escapeHtml(ex.language)}">${escapeHtml(ex.label)}</button>`,
-    )
+    .map((ex, i) => {
+      const langId = safeAttributeId(ex.language);
+      return `<button id="api-ref-lang-tab-${langId}" class="api-ref-lang-tab${i === 0 ? " active" : ""}" data-lang="${escapeHtml(ex.language)}" role="tab" aria-selected="${i === 0 ? "true" : "false"}" aria-controls="api-ref-code-panel-${langId}" tabindex="${i === 0 ? "0" : "-1"}">${escapeHtml(ex.label)}</button>`;
+    })
     .join("\n  ");
 
   const codeBlocks = examples
-    .map(
-      (ex, i) =>
-        `<div class="api-ref-code-block${i === 0 ? " active" : ""}" data-lang="${escapeHtml(ex.language)}">
+    .map((ex, i) => {
+      const langId = safeAttributeId(ex.language);
+      return `<div id="api-ref-code-panel-${langId}" class="api-ref-code-block${i === 0 ? " active" : ""}" data-lang="${escapeHtml(ex.language)}" role="tabpanel" aria-labelledby="api-ref-lang-tab-${langId}"${i === 0 ? "" : " hidden"}>
     <pre><code>${escapeHtml(ex.code)}</code></pre>
-  </div>`,
-    )
+  </div>`;
+    })
     .join("\n");
 
   const codeSection = `<div class="api-ref-code-section" data-testid="code-section">
   <div class="api-ref-code-header">
-    <div class="api-ref-lang-tabs">
+    <div class="api-ref-lang-tabs" role="tablist" aria-label="Code examples">
       ${langTabs}
     </div>
     <div class="api-ref-code-actions">

--- a/src/lib/api-reference.ts
+++ b/src/lib/api-reference.ts
@@ -324,24 +324,24 @@ export function renderApiReferencePage(endpoint: OpenApiEndpoint): string {
   let responseSection = "";
   if (responseTabs.length > 0) {
     const tabs = responseTabs
-      .map(
-        (tab, i) =>
-          `<button class="api-ref-status-tab${i === 0 ? " active" : ""}" data-status="${escapeHtml(tab.statusCode)}">${escapeHtml(tab.statusCode)}</button>`,
-      )
+      .map((tab, i) => {
+        const status = escapeHtml(tab.statusCode);
+        return `<button id="api-response-tab-${status}" class="api-ref-status-tab${i === 0 ? " active" : ""}" data-status="${status}" role="tab" aria-selected="${i === 0 ? "true" : "false"}" aria-controls="api-response-panel-${status}" tabindex="${i === 0 ? "0" : "-1"}">${status}</button>`;
+      })
       .join("\n    ");
 
     const panels = responseTabs
-      .map(
-        (tab, i) =>
-          `<div class="api-ref-status-panel${i === 0 ? " active" : ""}" data-status="${escapeHtml(tab.statusCode)}">
+      .map((tab, i) => {
+        const status = escapeHtml(tab.statusCode);
+        return `<div id="api-response-panel-${status}" class="api-ref-status-panel${i === 0 ? " active" : ""}" data-status="${status}" role="tabpanel" aria-labelledby="api-response-tab-${status}"${i === 0 ? "" : " hidden"}>
       ${tab.description ? `<p class="api-ref-status-desc">${escapeHtml(tab.description)}</p>` : ""}
       <pre><code class="api-ref-response-example">${escapeHtml(getExampleResponse(tab.statusCode))}</code></pre>
-    </div>`,
-      )
+    </div>`;
+      })
       .join("\n");
 
     responseSection = `<div class="api-ref-responses" data-testid="response-tabs">
-  <div class="api-ref-status-tabs">
+  <div class="api-ref-status-tabs" role="tablist" aria-label="Response status codes">
     ${tabs}
   </div>
   ${panels}

--- a/src/lib/assistant-settings.ts
+++ b/src/lib/assistant-settings.ts
@@ -78,6 +78,7 @@ export function formatBillingDate(dateStr: string | null): string {
     month: "short",
     day: "numeric",
     year: "numeric",
+    timeZone: "UTC",
   });
 }
 

--- a/src/lib/collaboration.ts
+++ b/src/lib/collaboration.ts
@@ -193,5 +193,9 @@ export function formatCommentDate(dateStr: string): string {
   if (diffMins < 60) return `${diffMins}m ago`;
   if (diffHours < 24) return `${diffHours}h ago`;
   if (diffDays < 7) return `${diffDays}d ago`;
-  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
 }

--- a/src/lib/dashboard.ts
+++ b/src/lib/dashboard.ts
@@ -66,6 +66,31 @@ export function formatDomainDisplay(
 
 export type ProjectDisplayStatus = "active" | "deploying" | "error";
 
+type DeploymentStatus = "queued" | "in_progress" | "succeeded" | "failed";
+
+/**
+ * Normalize deployment rows for dashboard display.
+ *
+ * In manual execution mode, deployment rows can remain queued/in_progress even
+ * after the project has published pages. For the user's dashboard, published
+ * live content is the stronger source of truth, so show those stale rows as
+ * successful instead of leaving the activity feed stuck on Updating.
+ */
+export function effectiveDeploymentStatus(params: {
+  status: string;
+  projectStatus: string;
+  publishedPageCount: number;
+}): DeploymentStatus {
+  if (params.status === "failed") return "failed";
+  if (params.status === "succeeded") return "succeeded";
+
+  if (params.projectStatus === "active" && params.publishedPageCount > 0) {
+    return "succeeded";
+  }
+
+  return params.status === "in_progress" ? "in_progress" : "queued";
+}
+
 /** Determine the dashboard status from deploy state and published content. */
 export function projectDisplayStatus(params: {
   projectStatus: string;

--- a/src/lib/docs-config.ts
+++ b/src/lib/docs-config.ts
@@ -346,6 +346,15 @@ export function mergeDocsConfig(
   };
 }
 
+export function getDocsThemeCssVars(
+  config: DocsConfig,
+): Record<string, string> {
+  return {
+    "--docs-primary": config.visualBranding.primaryColor,
+    "--docs-primary-soft": `${config.visualBranding.primaryColor}22`,
+  };
+}
+
 // ── Validation ───────────────────────────────────────────────────────────
 
 export type ValidationResult =

--- a/src/lib/docs-entry.ts
+++ b/src/lib/docs-entry.ts
@@ -1,0 +1,60 @@
+export interface DocsEntryRow {
+  projectId: string;
+  projectName: string;
+  subdomain: string | null;
+  pagePath: string;
+  pageTitle: string;
+  pageDescription: string | null;
+}
+
+export interface DocsEntryProject {
+  id: string;
+  name: string;
+  subdomain: string;
+  href: string;
+  pageTitle: string;
+  pageDescription: string | null;
+}
+
+function pagePriority(path: string): number {
+  if (path === "introduction") return 0;
+  if (path === "getting-started") return 1;
+  if (path === "quickstart") return 2;
+  return 3;
+}
+
+function docsHref(subdomain: string, pagePath: string): string {
+  return `/docs/${subdomain}/${pagePath.replace(/^\/+/, "")}`;
+}
+
+export function buildDocsEntryProjects(
+  rows: DocsEntryRow[],
+): DocsEntryProject[] {
+  const projects = new Map<
+    string,
+    DocsEntryProject & { selectedPriority: number }
+  >();
+
+  for (const row of rows) {
+    if (!row.subdomain || !row.pagePath) continue;
+
+    const candidate = {
+      id: row.projectId,
+      name: row.projectName,
+      subdomain: row.subdomain,
+      href: docsHref(row.subdomain, row.pagePath),
+      pageTitle: row.pageTitle,
+      pageDescription: row.pageDescription,
+      selectedPriority: pagePriority(row.pagePath),
+    };
+
+    const existing = projects.get(row.projectId);
+    if (!existing || candidate.selectedPriority < existing.selectedPriority) {
+      projects.set(row.projectId, candidate);
+    }
+  }
+
+  return Array.from(projects.values()).map(
+    ({ selectedPriority: _, ...p }) => p,
+  );
+}

--- a/src/lib/docs-footer.ts
+++ b/src/lib/docs-footer.ts
@@ -46,12 +46,12 @@ export function getValidSocialLinks(
   );
 }
 
-/** Get the brand name, defaulting to project name or "Mintlify" */
+/** Get the brand name, defaulting to the OpenDocs platform brand */
 export function getBrandName(
   footerSettings: FooterSettings,
-  projectName?: string,
+  _projectName?: string,
 ): string {
-  return footerSettings.brandName || projectName || "Mintlify";
+  return footerSettings.brandName || "OpenDocs";
 }
 
 /** Get the brand URL, defaulting to "/" */

--- a/src/lib/github-source.ts
+++ b/src/lib/github-source.ts
@@ -95,8 +95,9 @@ export function resolveGitHubSource(params: {
 export function mergeProjectSettingsWithGitHubSource(
   existing: Record<string, unknown> | null | undefined,
   selection: GitHubSourceSelection | null,
+  updates?: Record<string, unknown> | null,
 ): Record<string, unknown> {
-  const next = { ...(existing ?? {}) };
+  const next = { ...(existing ?? {}), ...(updates ?? {}) };
 
   if (selection) {
     next.githubSource = selection;

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -289,8 +289,10 @@ export function getAvailableLocalesForPage(
   allPages: { path: string }[],
   pagePath: string,
   config: LanguagesConfig,
+  options?: { includeConfiguredRoutes?: boolean },
 ): string[] {
   if (!config.enabled) return [config.defaultLanguage];
+  if (options?.includeConfiguredRoutes) return config.supportedLanguages;
 
   const available: string[] = [];
 

--- a/src/lib/mdx-renderer.ts
+++ b/src/lib/mdx-renderer.ts
@@ -310,7 +310,7 @@ export function parseMdxToHtml(content: string): string {
       const text = headingMatch[2].trim();
       const id = slugify(text);
       output.push(
-        `<h${level} id="${id}"><a href="#${id}" class="heading-anchor">${renderInline(text)}</a></h${level}>`,
+        `<h${level} id="${id}"><a href="#${id}" class="heading-anchor" aria-label="Navigate to header">${renderInline(text)}</a></h${level}>`,
       );
       i++;
       continue;

--- a/src/lib/openapi-parser.ts
+++ b/src/lib/openapi-parser.ts
@@ -373,13 +373,13 @@ export function renderApiPlaygroundHtml(endpoint: OpenApiEndpoint): string {
     <a class="api-response-download" aria-label="Download response file" download="response.txt" href="#" style="display:none">Download</a>
   </div>
   <div class="api-response-tabs" role="tablist" aria-label="Response sections">
-    <button type="button" class="api-resp-tab active" data-resp-tab="body" role="tab" aria-selected="true" aria-label="Show response body">Body</button>
-    <button type="button" class="api-resp-tab" data-resp-tab="headers" role="tab" aria-selected="false" aria-label="Show response headers">Headers</button>
+    <button type="button" id="api-response-body-tab" class="api-resp-tab active" data-resp-tab="body" role="tab" aria-selected="true" aria-controls="api-response-body-panel" tabindex="0" aria-label="Show response body">Body</button>
+    <button type="button" id="api-response-headers-tab" class="api-resp-tab" data-resp-tab="headers" role="tab" aria-selected="false" aria-controls="api-response-headers-panel" tabindex="-1" aria-label="Show response headers">Headers</button>
   </div>
-  <div class="api-response-body" role="tabpanel" aria-label="Response body">
+  <div id="api-response-body-panel" class="api-response-body" role="tabpanel" aria-labelledby="api-response-body-tab" aria-label="Response body">
     <pre><code class="api-response-content"></code></pre>
   </div>
-  <div class="api-response-headers" role="tabpanel" aria-label="Response headers" style="display:none">
+  <div id="api-response-headers-panel" class="api-response-headers" role="tabpanel" aria-labelledby="api-response-headers-tab" aria-label="Response headers" style="display:none">
     <pre><code class="api-response-headers-content"></code></pre>
   </div>
 </div>`;

--- a/src/lib/openapi-parser.ts
+++ b/src/lib/openapi-parser.ts
@@ -246,6 +246,22 @@ function methodClass(method: string): string {
   return HTTP_METHODS.has(normalized) ? normalized : "unknown";
 }
 
+function apiPlaygroundInputLabel(
+  name: string,
+  location: OpenApiParameter["in"],
+): string {
+  switch (location) {
+    case "header":
+      return `Enter ${name} header`;
+    case "path":
+      return `Enter ${name} path parameter`;
+    case "query":
+      return `Enter ${name} query parameter`;
+    case "cookie":
+      return `Enter ${name} cookie parameter`;
+  }
+}
+
 /** Escape for textarea content — only & and < need escaping, not quotes. */
 function escapeTextarea(str: string): string {
   return str.replace(/&/g, "&amp;").replace(/</g, "&lt;");
@@ -280,7 +296,7 @@ export function renderApiPlaygroundHtml(endpoint: OpenApiEndpoint): string {
   <h4 class="api-section-title">Authorization</h4>
   <div class="api-param-row auth-header-input">
     <label class="api-param-label">Authorization</label>
-    <input type="text" class="api-param-input" data-param-name="Authorization" data-param-in="header" placeholder="${escapeAttribute(placeholder)}" value="${endpoint.auth.scheme === "bearer" ? "Bearer " : ""}" />
+    <input type="text" class="api-param-input" data-param-name="Authorization" data-param-in="header" aria-label="${escapeAttribute(apiPlaygroundInputLabel("Authorization", "header"))}" placeholder="${escapeAttribute(placeholder)}" value="${endpoint.auth.scheme === "bearer" ? "Bearer " : ""}" />
   </div>
 </div>`;
   }
@@ -295,7 +311,7 @@ export function renderApiPlaygroundHtml(endpoint: OpenApiEndpoint): string {
           `<div class="api-param-row">
     <label class="api-param-label">${escapeHtml(p.name)} <span class="param-required">required</span></label>
     ${p.description ? `<span class="param-description">${escapeHtml(p.description)}</span>` : ""}
-    <input type="text" class="api-param-input" data-param-name="${escapeAttribute(p.name)}" data-param-in="path" placeholder="${escapeAttribute(p.schema?.type || "string")}" />
+    <input type="text" class="api-param-input" data-param-name="${escapeAttribute(p.name)}" data-param-in="path" aria-label="${escapeAttribute(apiPlaygroundInputLabel(p.name, "path"))}" placeholder="${escapeAttribute(p.schema?.type || "string")}" />
   </div>`,
       )
       .join("\n");
@@ -315,7 +331,7 @@ export function renderApiPlaygroundHtml(endpoint: OpenApiEndpoint): string {
           `<div class="api-param-row">
     <label class="api-param-label">${escapeHtml(p.name)}${p.required ? ' <span class="param-required">required</span>' : ""}</label>
     ${p.description ? `<span class="param-description">${escapeHtml(p.description)}</span>` : ""}
-    <input type="text" class="api-param-input" data-param-name="${escapeAttribute(p.name)}" data-param-in="query" placeholder="${escapeAttribute(`${p.schema?.type || "string"}${p.schema?.default !== undefined ? ` (default: ${p.schema.default})` : ""}`)}" />
+    <input type="text" class="api-param-input" data-param-name="${escapeAttribute(p.name)}" data-param-in="query" aria-label="${escapeAttribute(apiPlaygroundInputLabel(p.name, "query"))}" placeholder="${escapeAttribute(`${p.schema?.type || "string"}${p.schema?.default !== undefined ? ` (default: ${p.schema.default})` : ""}`)}" />
   </div>`,
       )
       .join("\n");
@@ -338,7 +354,7 @@ export function renderApiPlaygroundHtml(endpoint: OpenApiEndpoint): string {
     bodyHtml = `<div class="api-section">
   <h4 class="api-section-title">Body</h4>
   <div class="request-body-editor">
-    <textarea class="api-body-textarea" data-content-type="${escapeAttribute(endpoint.requestBody.contentType)}" rows="8" spellcheck="false">${escapeTextarea(exampleJson)}</textarea>
+    <textarea class="api-body-textarea" data-content-type="${escapeAttribute(endpoint.requestBody.contentType)}" aria-label="Enter request body" rows="8" spellcheck="false">${escapeTextarea(exampleJson)}</textarea>
   </div>
 </div>`;
   }

--- a/src/lib/openapi-parser.ts
+++ b/src/lib/openapi-parser.ts
@@ -345,7 +345,7 @@ export function renderApiPlaygroundHtml(endpoint: OpenApiEndpoint): string {
 
   // Send button
   const sendBtn = `<div class="api-send-section">
-  <button class="api-send-btn" data-method="${methodLower}" data-path="${escapeAttribute(endpoint.path)}" data-base-url="${escapeAttribute(endpoint.baseUrl)}">Send</button>
+  <button class="api-send-btn" aria-label="Send" data-method="${methodLower}" data-path="${escapeAttribute(endpoint.path)}" data-base-url="${escapeAttribute(endpoint.baseUrl)}">Send</button>
 </div>`;
 
   // Response area

--- a/src/lib/openapi-parser.ts
+++ b/src/lib/openapi-parser.ts
@@ -354,6 +354,7 @@ export function renderApiPlaygroundHtml(endpoint: OpenApiEndpoint): string {
     <h4 class="api-section-title">Response</h4>
     <span class="api-status-code"></span>
     <span class="api-response-time"></span>
+    <a class="api-response-download" aria-label="Download response file" download="response.txt" href="#" style="display:none">Download</a>
   </div>
   <div class="api-response-tabs">
     <button class="api-resp-tab active" data-resp-tab="body">Body</button>

--- a/src/lib/openapi-parser.ts
+++ b/src/lib/openapi-parser.ts
@@ -355,14 +355,14 @@ export function renderApiPlaygroundHtml(endpoint: OpenApiEndpoint): string {
     <span class="api-status-code"></span>
     <span class="api-response-time"></span>
   </div>
-  <div class="api-response-tabs">
-    <button class="api-resp-tab active" data-resp-tab="body">Body</button>
-    <button class="api-resp-tab" data-resp-tab="headers">Headers</button>
+  <div class="api-response-tabs" role="tablist" aria-label="Response sections">
+    <button type="button" class="api-resp-tab active" data-resp-tab="body" role="tab" aria-selected="true" aria-label="Show response body">Body</button>
+    <button type="button" class="api-resp-tab" data-resp-tab="headers" role="tab" aria-selected="false" aria-label="Show response headers">Headers</button>
   </div>
-  <div class="api-response-body">
+  <div class="api-response-body" role="tabpanel" aria-label="Response body">
     <pre><code class="api-response-content"></code></pre>
   </div>
-  <div class="api-response-headers" style="display:none">
+  <div class="api-response-headers" role="tabpanel" aria-label="Response headers" style="display:none">
     <pre><code class="api-response-headers-content"></code></pre>
   </div>
 </div>`;

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -156,14 +156,14 @@ export function validateCreateProjectRequest(body: unknown):
 export function validateUpdateProjectRequest(
   body: unknown,
 ):
-  | { valid: true; fields: Record<string, string> }
+  | { valid: true; fields: Record<string, unknown> }
   | { valid: false; error: string } {
   if (!body || typeof body !== "object") {
     return { valid: false, error: "No fields to update" };
   }
 
   const raw = body as Record<string, unknown>;
-  const fields: Record<string, string> = {};
+  const fields: Record<string, unknown> = {};
 
   if (raw.name !== undefined) {
     if (typeof raw.name !== "string") {
@@ -260,5 +260,5 @@ export function validateUpdateProjectRequest(
     result.settings = settingsUpdate;
   }
 
-  return { valid: true, fields: result as Record<string, string> };
+  return { valid: true, fields: result };
 }

--- a/src/lib/public-docs-llms.ts
+++ b/src/lib/public-docs-llms.ts
@@ -1,0 +1,54 @@
+import { db } from "@/lib/db";
+import { pages, projects } from "@/lib/db/schema";
+import { generateLlmsFullTxt, generateLlmsTxt } from "@/lib/llms-txt";
+import { and, eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+
+export type PublicLlmsType = "index" | "full";
+
+export function buildPublicDocsBaseUrl(origin: string, subdomain: string) {
+  return `${origin.replace(/\/+$/, "")}/docs/${subdomain}`;
+}
+
+export async function getPublicDocsLlmsResponse(
+  request: Request,
+  subdomain: string,
+  type: PublicLlmsType,
+) {
+  const [project] = await db
+    .select({ id: projects.id, name: projects.name })
+    .from(projects)
+    .where(eq(projects.subdomain, subdomain))
+    .limit(1);
+
+  if (!project) {
+    return new NextResponse("Project not found", { status: 404 });
+  }
+
+  const publishedPages = await db
+    .select({
+      path: pages.path,
+      title: pages.title,
+      content: pages.content,
+    })
+    .from(pages)
+    .where(and(eq(pages.projectId, project.id), eq(pages.isPublished, true)))
+    .orderBy(pages.path);
+
+  const baseUrl = buildPublicDocsBaseUrl(
+    new URL(request.url).origin,
+    subdomain,
+  );
+  const content =
+    type === "full"
+      ? generateLlmsFullTxt(project.name, baseUrl, publishedPages)
+      : generateLlmsTxt(project.name, baseUrl, publishedPages);
+
+  return new NextResponse(content, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+    },
+  });
+}

--- a/src/lib/public-markdown-export.ts
+++ b/src/lib/public-markdown-export.ts
@@ -1,0 +1,19 @@
+export interface PublicMarkdownExportPath {
+  subdomain: string;
+  pagePath: string;
+}
+
+export function parsePublicMarkdownExportPath(
+  pathname: string,
+): PublicMarkdownExportPath | null {
+  const match = pathname.match(/^\/docs\/([^/]+)\/(.+)\.md$/);
+  if (!match) return null;
+
+  const [, rawSubdomain, rawPagePath] = match;
+  if (!rawSubdomain || !rawPagePath) return null;
+
+  return {
+    subdomain: decodeURIComponent(rawSubdomain),
+    pagePath: decodeURIComponent(rawPagePath).replace(/^\/+/, ""),
+  };
+}

--- a/src/lib/public-mcp.ts
+++ b/src/lib/public-mcp.ts
@@ -1,0 +1,83 @@
+import { slugToTitle } from "@/lib/mcp";
+
+export interface PublicMcpDescriptorProject {
+  name: string;
+  subdomain: string;
+}
+
+export function toMcpToolLabel(subdomain: string) {
+  return subdomain.replace(/[^a-zA-Z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+}
+
+export function buildPublicMcpDescriptor(
+  project: PublicMcpDescriptorProject,
+  origin: string,
+) {
+  const toolLabel = toMcpToolLabel(project.subdomain) || "docs";
+  const title = project.name || slugToTitle(project.subdomain);
+  const docsBaseUrl = `${origin.replace(/\/+$/, "")}/docs/${project.subdomain}`;
+
+  return {
+    server: {
+      name: title,
+      version: "1.0.0",
+      transport: "http",
+    },
+    capabilities: {
+      tools: {
+        [`search_${toolLabel}`]: {
+          name: `search_${toolLabel}`,
+          description: `Search across the ${title} documentation knowledge base to find relevant pages, code examples, API references, and guides. Results should link back to ${docsBaseUrl}. Use query_docs_filesystem_${toolLabel} when full Markdown page content is needed.`,
+          inputSchema: {
+            type: "object",
+            properties: {
+              query: {
+                type: "string",
+                description:
+                  "A query to search the documentation content with.",
+              },
+              language: {
+                type: "string",
+                description:
+                  "Filter to a specific language code, such as 'en'. Defaults to 'en'.",
+              },
+            },
+            required: ["query"],
+          },
+          operationId: `${toolLabel}_search`,
+        },
+        [`query_docs_filesystem_${toolLabel}`]: {
+          name: `query_docs_filesystem_${toolLabel}`,
+          description: `Run a read-only shell-like query against the ${title} documentation content. Use this tool for exact keyword matches, docs structure exploration, or reading full page content from ${docsBaseUrl} Markdown exports. Supported commands include rg, grep, find, tree, ls, cat, head, tail, stat, wc, sort, uniq, cut, sed, awk, and jq.`,
+          inputSchema: {
+            type: "object",
+            properties: {
+              command: {
+                type: "string",
+                description:
+                  'A shell-like read-only command for the documentation content, such as `rg -il "keyword" /`, `tree / -L 2`, or `head -80 /introduction.md`.',
+              },
+            },
+            required: ["command"],
+          },
+          operationId: `${toolLabel}_query_docs_filesystem`,
+        },
+      },
+      resources: [
+        {
+          uri: `${docsBaseUrl}/llms.txt`,
+          name: `${title} llms.txt`,
+          description: `Machine-readable index for ${title} documentation pages.`,
+          mimeType: "text/markdown",
+        },
+        {
+          uri: `${docsBaseUrl}/llms-full.txt`,
+          name: `${title} llms-full.txt`,
+          description: `Full Markdown export for ${title} documentation pages.`,
+          mimeType: "text/markdown",
+        },
+      ],
+      prompts: [],
+    },
+  };
+}

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -252,8 +252,12 @@ export function getAvailableVersionsForPage(
   allPages: { path: string }[],
   pagePath: string,
   config: VersionsConfig,
+  options?: { includeConfiguredRoutes?: boolean },
 ): string[] {
   if (!config.enabled || config.versions.length === 0) return [];
+  if (options?.includeConfiguredRoutes) {
+    return config.versions.map((v) => v.tag);
+  }
 
   const defaultTag = getDefaultVersion(config)?.tag ?? "";
   const available: string[] = [];

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,3 +1,4 @@
+import { parsePublicMarkdownExportPath } from "@/lib/public-markdown-export";
 import { getSessionCookie } from "better-auth/cookies";
 import { type NextRequest, NextResponse } from "next/server";
 
@@ -12,6 +13,17 @@ export async function proxy(request: NextRequest) {
   const start = Date.now();
   const sessionCookie = getSessionCookie(request);
   const { pathname, search } = request.nextUrl;
+
+  const markdownExport = parsePublicMarkdownExportPath(pathname);
+  if (markdownExport) {
+    const markdownUrl = new URL(
+      `/api/docs/${markdownExport.subdomain}/markdown/${markdownExport.pagePath}`,
+      request.url,
+    );
+    const response = NextResponse.rewrite(markdownUrl);
+    response.headers.set("Server-Timing", `proxy;dur=${Date.now() - start}`);
+    return response;
+  }
 
   // Unauthenticated users visiting protected routes or onboarding → redirect to login
   if (
@@ -40,5 +52,6 @@ export const config = {
     "/products/:path*",
     "/analytics/:path*",
     "/onboarding",
+    "/docs/:path*",
   ],
 };

--- a/tests/api-playground-layout.test.tsx
+++ b/tests/api-playground-layout.test.tsx
@@ -1,0 +1,109 @@
+import { ApiPlayground } from "@/components/docs/api-playground";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it } from "vitest";
+
+// React 19 requires this flag for act() in non-testing-library environments.
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ApiPlayground response tabs", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("updates response tab ARIA state and panels on click", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<ApiPlayground html={apiPlaygroundTabsHtml()} />);
+    });
+
+    const bodyTab = container.querySelector<HTMLButtonElement>(
+      '[data-resp-tab="body"]',
+    );
+    const headersTab = container.querySelector<HTMLButtonElement>(
+      '[data-resp-tab="headers"]',
+    );
+    const bodyPanel =
+      container.querySelector<HTMLElement>(".api-response-body");
+    const headersPanel = container.querySelector<HTMLElement>(
+      ".api-response-headers",
+    );
+
+    expect(bodyTab?.getAttribute("aria-selected")).toBe("true");
+    expect(bodyTab?.tabIndex).toBe(0);
+    expect(bodyPanel?.style.display).not.toBe("none");
+    expect(headersTab?.getAttribute("aria-selected")).toBe("false");
+    expect(headersTab?.tabIndex).toBe(-1);
+    expect(headersPanel?.style.display).toBe("none");
+
+    await act(async () => {
+      headersTab?.click();
+    });
+
+    expect(bodyTab?.getAttribute("aria-selected")).toBe("false");
+    expect(bodyTab?.tabIndex).toBe(-1);
+    expect(bodyPanel?.style.display).toBe("none");
+    expect(headersTab?.getAttribute("aria-selected")).toBe("true");
+    expect(headersTab?.tabIndex).toBe(0);
+    expect(headersPanel?.style.display).toBe("block");
+  });
+
+  it("supports keyboard navigation for response tabs", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<ApiPlayground html={apiPlaygroundTabsHtml()} />);
+    });
+
+    const bodyTab = container.querySelector<HTMLButtonElement>(
+      '[data-resp-tab="body"]',
+    );
+    const headersTab = container.querySelector<HTMLButtonElement>(
+      '[data-resp-tab="headers"]',
+    );
+
+    await act(async () => {
+      bodyTab?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+      );
+    });
+
+    expect(headersTab?.getAttribute("aria-selected")).toBe("true");
+    expect(document.activeElement).toBe(headersTab);
+
+    await act(async () => {
+      headersTab?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }),
+      );
+    });
+
+    expect(bodyTab?.getAttribute("aria-selected")).toBe("true");
+    expect(document.activeElement).toBe(bodyTab);
+  });
+});
+
+function apiPlaygroundTabsHtml() {
+  return `
+    <div class="api-playground">
+      <div class="api-response" style="display:block">
+        <div class="api-response-tabs" role="tablist" aria-label="Response sections">
+          <button type="button" id="api-response-body-tab" class="api-resp-tab active" data-resp-tab="body" role="tab" aria-selected="true" aria-controls="api-response-body-panel" tabindex="0" aria-label="Show response body">Body</button>
+          <button type="button" id="api-response-headers-tab" class="api-resp-tab" data-resp-tab="headers" role="tab" aria-selected="false" aria-controls="api-response-headers-panel" tabindex="-1" aria-label="Show response headers">Headers</button>
+        </div>
+        <div id="api-response-body-panel" class="api-response-body" role="tabpanel" aria-labelledby="api-response-body-tab" aria-label="Response body">
+          <pre><code class="api-response-content">{}</code></pre>
+        </div>
+        <div id="api-response-headers-panel" class="api-response-headers" role="tabpanel" aria-labelledby="api-response-headers-tab" aria-label="Response headers" style="display:none">
+          <pre><code class="api-response-headers-content"></code></pre>
+        </div>
+      </div>
+    </div>
+  `;
+}

--- a/tests/api-playground-response.test.ts
+++ b/tests/api-playground-response.test.ts
@@ -1,0 +1,61 @@
+import {
+  apiPlaygroundStatusClass,
+  normalizeApiPlaygroundProxyResult,
+} from "@/lib/api-playground-response";
+import { describe, expect, it } from "vitest";
+
+describe("normalizeApiPlaygroundProxyResult", () => {
+  it("keeps upstream response status, body, and headers", () => {
+    expect(
+      normalizeApiPlaygroundProxyResult(
+        {
+          status: 404,
+          body: '{"error":"missing"}',
+          headers: { "content-type": "application/json" },
+        },
+        200,
+      ),
+    ).toEqual({
+      status: 404,
+      body: '{"error":"missing"}',
+      headers: { "content-type": "application/json" },
+    });
+  });
+
+  it("uses the proxy HTTP status and error message for proxy errors", () => {
+    expect(
+      normalizeApiPlaygroundProxyResult(
+        { error: "Too many proxy requests" },
+        429,
+      ),
+    ).toEqual({
+      status: 429,
+      body: "Too many proxy requests",
+      headers: {},
+    });
+  });
+
+  it("uses proxy HTTP status when the proxy payload has status zero", () => {
+    expect(
+      normalizeApiPlaygroundProxyResult(
+        { status: 0, body: "fetch failed", headers: {} },
+        502,
+      ),
+    ).toEqual({
+      status: 502,
+      body: "fetch failed",
+      headers: {},
+    });
+  });
+});
+
+describe("apiPlaygroundStatusClass", () => {
+  it("maps HTTP status classes", () => {
+    expect(apiPlaygroundStatusClass(202)).toBe("api-status-code status-2xx");
+    expect(apiPlaygroundStatusClass(429)).toBe("api-status-code status-4xx");
+  });
+
+  it("falls back to an error style for invalid statuses", () => {
+    expect(apiPlaygroundStatusClass(0)).toBe("api-status-code status-5xx");
+  });
+});

--- a/tests/api-playground.test.ts
+++ b/tests/api-playground.test.ts
@@ -311,16 +311,16 @@ describe("API Playground HTML Renderer", () => {
     expect(html).toContain('class="api-response"');
     expect(html).toContain('role="tablist" aria-label="Response sections"');
     expect(html).toContain(
-      'role="tab" aria-selected="true" aria-label="Show response body"',
+      'role="tab" aria-selected="true" aria-controls="api-response-body-panel" tabindex="0" aria-label="Show response body"',
     );
     expect(html).toContain(
-      'role="tab" aria-selected="false" aria-label="Show response headers"',
+      'role="tab" aria-selected="false" aria-controls="api-response-headers-panel" tabindex="-1" aria-label="Show response headers"',
     );
     expect(html).toContain(
-      'class="api-response-body" role="tabpanel" aria-label="Response body"',
+      'class="api-response-body" role="tabpanel" aria-labelledby="api-response-body-tab" aria-label="Response body"',
     );
     expect(html).toContain(
-      'class="api-response-headers" role="tabpanel" aria-label="Response headers"',
+      'class="api-response-headers" role="tabpanel" aria-labelledby="api-response-headers-tab" aria-label="Response headers"',
     );
     expect(html).toContain('class="api-response-download"');
     expect(html).toContain('aria-label="Download response file"');

--- a/tests/api-playground.test.ts
+++ b/tests/api-playground.test.ts
@@ -304,6 +304,19 @@ describe("API Playground HTML Renderer", () => {
     const endpoints = parseOpenApiSpec(SAMPLE_OPENAPI_SPEC);
     const html = renderApiPlaygroundHtml(endpoints[0]);
     expect(html).toContain('class="api-response"');
+    expect(html).toContain('role="tablist" aria-label="Response sections"');
+    expect(html).toContain(
+      'role="tab" aria-selected="true" aria-label="Show response body"',
+    );
+    expect(html).toContain(
+      'role="tab" aria-selected="false" aria-label="Show response headers"',
+    );
+    expect(html).toContain(
+      'class="api-response-body" role="tabpanel" aria-label="Response body"',
+    );
+    expect(html).toContain(
+      'class="api-response-headers" role="tabpanel" aria-label="Response headers"',
+    );
   });
 
   it("renders different method badges with correct classes", () => {

--- a/tests/api-playground.test.ts
+++ b/tests/api-playground.test.ts
@@ -304,6 +304,9 @@ describe("API Playground HTML Renderer", () => {
     const endpoints = parseOpenApiSpec(SAMPLE_OPENAPI_SPEC);
     const html = renderApiPlaygroundHtml(endpoints[0]);
     expect(html).toContain('class="api-response"');
+    expect(html).toContain('class="api-response-download"');
+    expect(html).toContain('aria-label="Download response file"');
+    expect(html).toContain('download="response.txt"');
   });
 
   it("renders different method badges with correct classes", () => {

--- a/tests/api-playground.test.ts
+++ b/tests/api-playground.test.ts
@@ -263,6 +263,7 @@ describe("API Playground HTML Renderer", () => {
     const html = renderApiPlaygroundHtml(getUser);
     expect(html).toContain('data-param-name="id"');
     expect(html).toContain('data-param-in="path"');
+    expect(html).toContain('aria-label="Enter id path parameter"');
   });
 
   it("renders parameter inputs for query params", () => {
@@ -273,6 +274,7 @@ describe("API Playground HTML Renderer", () => {
     const html = renderApiPlaygroundHtml(listUsers);
     expect(html).toContain('data-param-name="limit"');
     expect(html).toContain('data-param-in="query"');
+    expect(html).toContain('aria-label="Enter limit query parameter"');
   });
 
   it("renders request body editor for POST endpoints", () => {
@@ -282,6 +284,7 @@ describe("API Playground HTML Renderer", () => {
     ) as OpenApiEndpoint;
     const html = renderApiPlaygroundHtml(createUser);
     expect(html).toContain('class="request-body-editor"');
+    expect(html).toContain('aria-label="Enter request body"');
     expect(html).toContain("Body");
   });
 
@@ -290,6 +293,7 @@ describe("API Playground HTML Renderer", () => {
     const html = renderApiPlaygroundHtml(endpoints[0]);
     expect(html).toContain("auth-header-input");
     expect(html).toContain("Authorization");
+    expect(html).toContain('aria-label="Enter Authorization header"');
     expect(html).toContain("Bearer");
   });
 

--- a/tests/api-playground.test.ts
+++ b/tests/api-playground.test.ts
@@ -297,6 +297,7 @@ describe("API Playground HTML Renderer", () => {
     const endpoints = parseOpenApiSpec(SAMPLE_OPENAPI_SPEC);
     const html = renderApiPlaygroundHtml(endpoints[0]);
     expect(html).toContain('class="api-send-btn"');
+    expect(html).toContain('aria-label="Send"');
     expect(html).toContain("Send");
   });
 

--- a/tests/api-reference-layout.test.tsx
+++ b/tests/api-reference-layout.test.tsx
@@ -1,0 +1,107 @@
+import { ApiReferenceLayout } from "@/components/docs/api-reference-layout";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it } from "vitest";
+
+// React 19 requires this flag for act() in non-testing-library environments.
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ApiReferenceLayout", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("updates code language tab ARIA state and panels on click", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<ApiReferenceLayout html={apiReferenceTabsHtml()} />);
+    });
+
+    const curlTab =
+      container.querySelector<HTMLButtonElement>('[data-lang="curl"]');
+    const pythonTab = container.querySelector<HTMLButtonElement>(
+      '[data-lang="python"]',
+    );
+    const curlPanel = container.querySelector<HTMLDivElement>(
+      '[data-lang="curl"].api-ref-code-block',
+    );
+    const pythonPanel = container.querySelector<HTMLDivElement>(
+      '[data-lang="python"].api-ref-code-block',
+    );
+
+    expect(curlTab?.getAttribute("aria-selected")).toBe("true");
+    expect(curlTab?.tabIndex).toBe(0);
+    expect(curlPanel?.hidden).toBe(false);
+    expect(pythonTab?.getAttribute("aria-selected")).toBe("false");
+    expect(pythonTab?.tabIndex).toBe(-1);
+    expect(pythonPanel?.hidden).toBe(true);
+
+    await act(async () => {
+      pythonTab?.click();
+    });
+
+    expect(curlTab?.getAttribute("aria-selected")).toBe("false");
+    expect(curlTab?.tabIndex).toBe(-1);
+    expect(curlPanel?.hidden).toBe(true);
+    expect(pythonTab?.getAttribute("aria-selected")).toBe("true");
+    expect(pythonTab?.tabIndex).toBe(0);
+    expect(pythonPanel?.hidden).toBe(false);
+  });
+
+  it("supports keyboard navigation for code language tabs", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<ApiReferenceLayout html={apiReferenceTabsHtml()} />);
+    });
+
+    const curlTab =
+      container.querySelector<HTMLButtonElement>('[data-lang="curl"]');
+    const pythonTab = container.querySelector<HTMLButtonElement>(
+      '[data-lang="python"]',
+    );
+
+    await act(async () => {
+      curlTab?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+      );
+    });
+
+    expect(pythonTab?.getAttribute("aria-selected")).toBe("true");
+    expect(document.activeElement).toBe(pythonTab);
+
+    await act(async () => {
+      pythonTab?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }),
+      );
+    });
+
+    expect(curlTab?.getAttribute("aria-selected")).toBe("true");
+    expect(document.activeElement).toBe(curlTab);
+  });
+});
+
+function apiReferenceTabsHtml() {
+  return `
+    <div class="api-ref-code-section">
+      <div class="api-ref-lang-tabs" role="tablist" aria-label="Code examples">
+        <button id="api-ref-lang-tab-curl" class="api-ref-lang-tab active" data-lang="curl" role="tab" aria-selected="true" aria-controls="api-ref-code-panel-curl" tabindex="0">cURL</button>
+        <button id="api-ref-lang-tab-python" class="api-ref-lang-tab" data-lang="python" role="tab" aria-selected="false" aria-controls="api-ref-code-panel-python" tabindex="-1">Python</button>
+      </div>
+      <button class="api-ref-copy-btn"><span>cURL</span></button>
+      <div id="api-ref-code-panel-curl" class="api-ref-code-block active" data-lang="curl" role="tabpanel" aria-labelledby="api-ref-lang-tab-curl">
+        <pre><code>curl --request GET</code></pre>
+      </div>
+      <div id="api-ref-code-panel-python" class="api-ref-code-block" data-lang="python" role="tabpanel" aria-labelledby="api-ref-lang-tab-python" hidden>
+        <pre><code>import requests</code></pre>
+      </div>
+    </div>
+  `;
+}

--- a/tests/api-reference-layout.test.tsx
+++ b/tests/api-reference-layout.test.tsx
@@ -86,6 +86,82 @@ describe("ApiReferenceLayout", () => {
     expect(curlTab?.getAttribute("aria-selected")).toBe("true");
     expect(document.activeElement).toBe(curlTab);
   });
+
+  it("updates response status tab ARIA state and panels on click", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<ApiReferenceLayout html={apiReferenceTabsHtml()} />);
+    });
+
+    const successTab = container.querySelector<HTMLButtonElement>(
+      '[data-status="200"]',
+    );
+    const errorTab = container.querySelector<HTMLButtonElement>(
+      '[data-status="400"]',
+    );
+    const successPanel = container.querySelector<HTMLDivElement>(
+      '[data-status="200"].api-ref-status-panel',
+    );
+    const errorPanel = container.querySelector<HTMLDivElement>(
+      '[data-status="400"].api-ref-status-panel',
+    );
+
+    expect(successTab?.getAttribute("aria-selected")).toBe("true");
+    expect(successTab?.tabIndex).toBe(0);
+    expect(successPanel?.hidden).toBe(false);
+    expect(errorTab?.getAttribute("aria-selected")).toBe("false");
+    expect(errorTab?.tabIndex).toBe(-1);
+    expect(errorPanel?.hidden).toBe(true);
+
+    await act(async () => {
+      errorTab?.click();
+    });
+
+    expect(successTab?.getAttribute("aria-selected")).toBe("false");
+    expect(successTab?.tabIndex).toBe(-1);
+    expect(successPanel?.hidden).toBe(true);
+    expect(errorTab?.getAttribute("aria-selected")).toBe("true");
+    expect(errorTab?.tabIndex).toBe(0);
+    expect(errorPanel?.hidden).toBe(false);
+  });
+
+  it("supports keyboard navigation for response status tabs", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<ApiReferenceLayout html={apiReferenceTabsHtml()} />);
+    });
+
+    const successTab = container.querySelector<HTMLButtonElement>(
+      '[data-status="200"]',
+    );
+    const errorTab = container.querySelector<HTMLButtonElement>(
+      '[data-status="400"]',
+    );
+
+    await act(async () => {
+      successTab?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+      );
+    });
+
+    expect(errorTab?.getAttribute("aria-selected")).toBe("true");
+    expect(document.activeElement).toBe(errorTab);
+
+    await act(async () => {
+      errorTab?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }),
+      );
+    });
+
+    expect(successTab?.getAttribute("aria-selected")).toBe("true");
+    expect(document.activeElement).toBe(successTab);
+  });
 });
 
 function apiReferenceTabsHtml() {
@@ -101,6 +177,16 @@ function apiReferenceTabsHtml() {
       </div>
       <div id="api-ref-code-panel-python" class="api-ref-code-block" data-lang="python" role="tabpanel" aria-labelledby="api-ref-lang-tab-python" hidden>
         <pre><code>import requests</code></pre>
+      </div>
+      <div class="api-ref-status-tabs" role="tablist" aria-label="Response status codes">
+        <button id="api-response-tab-200" class="api-ref-status-tab active" data-status="200" role="tab" aria-selected="true" aria-controls="api-response-panel-200" tabindex="0">200</button>
+        <button id="api-response-tab-400" class="api-ref-status-tab" data-status="400" role="tab" aria-selected="false" aria-controls="api-response-panel-400" tabindex="-1">400</button>
+      </div>
+      <div id="api-response-panel-200" class="api-ref-status-panel active" data-status="200" role="tabpanel" aria-labelledby="api-response-tab-200">
+        <pre><code>{"ok": true}</code></pre>
+      </div>
+      <div id="api-response-panel-400" class="api-ref-status-panel" data-status="400" role="tabpanel" aria-labelledby="api-response-tab-400" hidden>
+        <pre><code>{"error": true}</code></pre>
       </div>
     </div>
   `;

--- a/tests/api-reference.test.ts
+++ b/tests/api-reference.test.ts
@@ -314,10 +314,16 @@ describe("renderApiReferencePage", () => {
     expect(html).toContain("JavaScript");
   });
 
-  it("renders response status tabs 200 and 400", () => {
+  it("renders response status controls with tab semantics", () => {
     const html = renderApiReferencePage(endpoint);
+    expect(html).toContain('role="tablist"');
+    expect(html).toContain('aria-label="Response status codes"');
     expect(html).toContain('data-status="200"');
+    expect(html).toContain('role="tab"');
+    expect(html).toContain('aria-selected="true"');
+    expect(html).toContain('role="tabpanel"');
     expect(html).toContain('data-status="400"');
+    expect(html).toContain('aria-selected="false"');
   });
 
   it("renders auth section for bearer token", () => {

--- a/tests/api-reference.test.ts
+++ b/tests/api-reference.test.ts
@@ -300,10 +300,11 @@ describe("renderApiReferencePage", () => {
     expect(html).toContain("/plants");
   });
 
-  it("renders Try it button", () => {
+  it("renders Try it button with Mintlify-parity accessible label", () => {
     const html = renderApiReferencePage(endpoint);
     expect(html).toContain("Try it");
     expect(html).toContain("tryit-btn");
+    expect(html).toContain('aria-label="Try it"');
   });
 
   it("renders code section with language tabs", () => {

--- a/tests/api-reference.test.ts
+++ b/tests/api-reference.test.ts
@@ -306,12 +306,16 @@ describe("renderApiReferencePage", () => {
     expect(html).toContain("tryit-btn");
   });
 
-  it("renders code section with language tabs", () => {
+  it("renders code section with language tabs and labeled actions", () => {
     const html = renderApiReferencePage(endpoint);
     expect(html).toContain("api-ref-lang-tab");
     expect(html).toContain("cURL");
     expect(html).toContain("Python");
     expect(html).toContain("JavaScript");
+    expect(html).toContain(
+      'aria-label="Copy the contents from the code block"',
+    );
+    expect(html).toContain('aria-label="Ask AI"');
   });
 
   it("renders response status tabs 200 and 400", () => {

--- a/tests/api-reference.test.ts
+++ b/tests/api-reference.test.ts
@@ -309,7 +309,15 @@ describe("renderApiReferencePage", () => {
 
   it("renders code section with language tabs and labeled actions", () => {
     const html = renderApiReferencePage(endpoint);
+    expect(html).toContain('role="tablist"');
+    expect(html).toContain('aria-label="Code examples"');
     expect(html).toContain("api-ref-lang-tab");
+    expect(html).toContain('role="tab"');
+    expect(html).toContain('aria-selected="true"');
+    expect(html).toContain('aria-selected="false"');
+    expect(html).toContain('aria-controls="api-ref-code-panel-curl"');
+    expect(html).toContain('role="tabpanel"');
+    expect(html).toContain('aria-labelledby="api-ref-lang-tab-curl"');
     expect(html).toContain("cURL");
     expect(html).toContain("Python");
     expect(html).toContain("JavaScript");

--- a/tests/chat-widget.test.tsx
+++ b/tests/chat-widget.test.tsx
@@ -51,6 +51,48 @@ describe("Docs chat widget code context", () => {
     ).not.toBeNull();
   });
 
+  it("shows starter suggestions and applies one to the input", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <>
+          <AskAiButton />
+          <ChatWidget subdomain="feature004-qa" currentPath="introduction" />
+        </>,
+      );
+    });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="ask-ai-btn"]')
+        ?.click();
+    });
+
+    const suggestions = container.querySelector(
+      '[data-testid="chat-suggestions"]',
+    );
+    expect(suggestions?.textContent).toContain("Suggestions");
+    expect(suggestions?.textContent).toContain("How do I get started?");
+
+    await act(async () => {
+      Array.from(
+        container.querySelectorAll<HTMLButtonElement>(
+          ".chat-widget-suggestion",
+        ),
+      )
+        .find((button) => button.textContent === "How do I get started?")
+        ?.click();
+    });
+
+    expect(
+      container.querySelector<HTMLTextAreaElement>('[data-testid="chat-input"]')
+        ?.value,
+    ).toBe("How do I get started?");
+  });
+
   it("opens the chat panel with code context when a code-block Ask AI button is clicked", async () => {
     const html = renderMdxContent("```ts app.ts\nconst answer = 42;\n```");
     const container = document.createElement("div");

--- a/tests/chat-widget.test.tsx
+++ b/tests/chat-widget.test.tsx
@@ -1,3 +1,4 @@
+import { ApiReferenceLayout } from "@/components/docs/api-reference-layout";
 import { ChatWidget } from "@/components/docs/chat-widget";
 import { AskAiButton } from "@/components/docs/docs-topbar";
 import { MdxContent } from "@/components/docs/mdx-content";
@@ -247,5 +248,42 @@ describe("Docs chat widget code context", () => {
     expect(input?.value).toContain("Explain this ts code:");
     expect(input?.value).toContain("```ts");
     expect(input?.value).toContain("const answer = 42;");
+  });
+
+  it("opens the chat panel with API reference code context when Ask AI is clicked", async () => {
+    const html = `
+      <section class="api-ref-layout">
+        <div class="api-ref-code-block active" data-lang="curl">
+          <pre><code>curl --request GET \\
+  --url https://api.example.com/plants</code></pre>
+        </div>
+        <button type="button" class="api-ref-askai-btn">Ask AI</button>
+      </section>
+    `;
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <>
+          <ApiReferenceLayout html={html} />
+          <ChatWidget subdomain="feature004-qa" currentPath="api/plants" />
+        </>,
+      );
+    });
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>(".api-ref-askai-btn")?.click();
+    });
+
+    const input = container.querySelector<HTMLTextAreaElement>(
+      '[data-testid="chat-input"]',
+    );
+    expect(input).not.toBeNull();
+    expect(input?.value).toContain("Explain this curl code:");
+    expect(input?.value).toContain("```curl");
+    expect(input?.value).toContain("curl --request GET");
+    expect(input?.value).toContain("https://api.example.com/plants");
   });
 });

--- a/tests/chat-widget.test.tsx
+++ b/tests/chat-widget.test.tsx
@@ -51,6 +51,87 @@ describe("Docs chat widget code context", () => {
     ).not.toBeNull();
   });
 
+  it("labels assistant panel controls and closes with Escape", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <>
+          <AskAiButton />
+          <ChatWidget subdomain="feature004-qa" currentPath="introduction" />
+        </>,
+      );
+    });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="ask-ai-btn"]')
+        ?.click();
+    });
+
+    const panel = container.querySelector('[data-testid="chat-panel"]');
+    expect(panel?.tagName).toBe("DIALOG");
+    expect(panel?.hasAttribute("open")).toBe(true);
+    expect(panel?.getAttribute("aria-modal")).toBe("false");
+    expect(panel?.getAttribute("aria-labelledby")).toBeTruthy();
+    expect(
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="chat-clear-btn"]')
+        ?.getAttribute("aria-label"),
+    ).toBe("Clear assistant conversation");
+    expect(
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="chat-close-btn"]')
+        ?.getAttribute("aria-label"),
+    ).toBe("Close assistant panel");
+    expect(
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="chat-send-btn"]')
+        ?.getAttribute("aria-label"),
+    ).toBe("Send message");
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+
+    expect(container.querySelector('[data-testid="chat-panel"]')).toBeNull();
+  });
+
+  it("closes the assistant when Escape is pressed in the input", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <>
+          <AskAiButton />
+          <ChatWidget subdomain="feature004-qa" currentPath="introduction" />
+        </>,
+      );
+    });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="ask-ai-btn"]')
+        ?.click();
+    });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLTextAreaElement>('[data-testid="chat-input"]')
+        ?.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+        );
+    });
+
+    expect(container.querySelector('[data-testid="chat-panel"]')).toBeNull();
+  });
+
   it("shows starter suggestions and applies one to the input", async () => {
     const container = document.createElement("div");
     document.body.appendChild(container);

--- a/tests/chat-widget.test.tsx
+++ b/tests/chat-widget.test.tsx
@@ -51,6 +51,53 @@ describe("Docs chat widget code context", () => {
     ).not.toBeNull();
   });
 
+  it("shows an attachment picker and selected file feedback", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <>
+          <AskAiButton />
+          <ChatWidget subdomain="feature004-qa" currentPath="introduction" />
+        </>,
+      );
+    });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="ask-ai-btn"]')
+        ?.click();
+    });
+
+    expect(
+      container.querySelector<HTMLButtonElement>(
+        '[data-testid="chat-attachment-btn"][aria-label="Add attachment"]',
+      ),
+    ).not.toBeNull();
+
+    const fileInput = container.querySelector<HTMLInputElement>(
+      '[data-testid="chat-attachment-input"]',
+    );
+    const file = new File(["hello"], "notes.md", { type: "text/markdown" });
+    Object.defineProperty(fileInput, "files", {
+      configurable: true,
+      value: [file],
+    });
+
+    await act(async () => {
+      fileInput?.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    expect(
+      container.querySelector('[data-testid="chat-attachments"]')?.textContent,
+    ).toContain("notes.md");
+    expect(
+      container.querySelector('[data-testid="chat-attachments"]')?.textContent,
+    ).toContain("File contents are not uploaded yet.");
+  });
+
   it("opens the chat panel with code context when a code-block Ask AI button is clicked", async () => {
     const html = renderMdxContent("```ts app.ts\nconst answer = 42;\n```");
     const container = document.createElement("div");

--- a/tests/dashboard.test.ts
+++ b/tests/dashboard.test.ts
@@ -1,6 +1,7 @@
 import {
   buildQuickActionCards,
   buildSiteUrl,
+  effectiveDeploymentStatus,
   formatDomainDisplay,
   projectDisplayStatus,
   projectStatusSummary,
@@ -115,6 +116,48 @@ describe("projectStatusSummary", () => {
     expect(projectStatusSummary("active", "Something", null)).toBe(
       "No deployments yet",
     );
+  });
+});
+
+describe("effectiveDeploymentStatus", () => {
+  it("shows stale queued deployment rows as successful once published docs are live", () => {
+    expect(
+      effectiveDeploymentStatus({
+        status: "queued",
+        projectStatus: "active",
+        publishedPageCount: 3,
+      }),
+    ).toBe("succeeded");
+  });
+
+  it("shows stale in-progress deployment rows as successful once published docs are live", () => {
+    expect(
+      effectiveDeploymentStatus({
+        status: "in_progress",
+        projectStatus: "active",
+        publishedPageCount: 3,
+      }),
+    ).toBe("succeeded");
+  });
+
+  it("preserves failed deployment rows", () => {
+    expect(
+      effectiveDeploymentStatus({
+        status: "failed",
+        projectStatus: "active",
+        publishedPageCount: 3,
+      }),
+    ).toBe("failed");
+  });
+
+  it("keeps deployments pending while no pages are published", () => {
+    expect(
+      effectiveDeploymentStatus({
+        status: "in_progress",
+        projectStatus: "active",
+        publishedPageCount: 0,
+      }),
+    ).toBe("in_progress");
   });
 });
 

--- a/tests/docs-config.test.ts
+++ b/tests/docs-config.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_DOCS_CONFIG,
   type DocsConfig,
   exportDocsConfigJson,
+  getDocsThemeCssVars,
   importDocsConfigJson,
   mergeDocsConfig,
   sectionIdToConfigKey,
@@ -57,6 +58,16 @@ describe("mergeDocsConfig", () => {
     });
     expect(result.visualBranding.primaryColor).toBe("#FF0000");
     expect(result.visualBranding.theme).toBe("dark"); // default
+  });
+
+  it("exports CSS variables for applying the primary color to docs chrome", () => {
+    const config = mergeDocsConfig({
+      visualBranding: { primaryColor: "#FF0000" },
+    });
+    expect(getDocsThemeCssVars(config)).toEqual({
+      "--docs-primary": "#FF0000",
+      "--docs-primary-soft": "#FF000022",
+    });
   });
 
   it("preserves topbarLinks array when provided", () => {

--- a/tests/docs-entry.test.ts
+++ b/tests/docs-entry.test.ts
@@ -1,0 +1,51 @@
+import { buildDocsEntryProjects } from "@/lib/docs-entry";
+import { describe, expect, it } from "vitest";
+
+describe("buildDocsEntryProjects", () => {
+  it("selects introduction as the preferred public entry point", () => {
+    expect(
+      buildDocsEntryProjects([
+        {
+          projectId: "project-1",
+          projectName: "Test Project",
+          subdomain: "test-project",
+          pagePath: "quickstart",
+          pageTitle: "Quickstart",
+          pageDescription: null,
+        },
+        {
+          projectId: "project-1",
+          projectName: "Test Project",
+          subdomain: "test-project",
+          pagePath: "introduction",
+          pageTitle: "Introduction",
+          pageDescription: "Start here",
+        },
+      ]),
+    ).toEqual([
+      {
+        id: "project-1",
+        name: "Test Project",
+        subdomain: "test-project",
+        href: "/docs/test-project/introduction",
+        pageTitle: "Introduction",
+        pageDescription: "Start here",
+      },
+    ]);
+  });
+
+  it("omits projects without a public docs subdomain", () => {
+    expect(
+      buildDocsEntryProjects([
+        {
+          projectId: "project-1",
+          projectName: "Private Project",
+          subdomain: null,
+          pagePath: "introduction",
+          pageTitle: "Introduction",
+          pageDescription: null,
+        },
+      ]),
+    ).toEqual([]);
+  });
+});

--- a/tests/docs-footer.test.ts
+++ b/tests/docs-footer.test.ts
@@ -106,12 +106,12 @@ describe("docs-footer utilities", () => {
       expect(getBrandName({ brandName: "Acme Docs" })).toBe("Acme Docs");
     });
 
-    it("falls back to projectName when brandName not set", () => {
-      expect(getBrandName({}, "My Project")).toBe("My Project");
+    it("falls back to OpenDocs when brandName not set", () => {
+      expect(getBrandName({}, "My Project")).toBe("OpenDocs");
     });
 
-    it("falls back to Mintlify when nothing set", () => {
-      expect(getBrandName({})).toBe("Mintlify");
+    it("falls back to OpenDocs when nothing set", () => {
+      expect(getBrandName({})).toBe("OpenDocs");
     });
 
     it("prefers brandName over projectName", () => {
@@ -138,9 +138,9 @@ describe("docs-footer utilities", () => {
       );
     });
 
-    it("generates tooltip with Mintlify default", () => {
-      expect(getPoweredByTooltip("Mintlify")).toBe(
-        "This documentation is built and hosted on Mintlify",
+    it("generates tooltip with OpenDocs default", () => {
+      expect(getPoweredByTooltip("OpenDocs")).toBe(
+        "This documentation is built and hosted on OpenDocs",
       );
     });
   });

--- a/tests/docs-page-metadata.test.ts
+++ b/tests/docs-page-metadata.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMocks = vi.hoisted(() => ({
+  select: vi.fn(),
+  limit: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: dbMocks.select,
+  },
+}));
+
+function setupDbChain() {
+  const chain = {
+    from: vi.fn(() => chain),
+    where: vi.fn(() => chain),
+    limit: dbMocks.limit,
+  };
+  dbMocks.select.mockReturnValue(chain);
+}
+
+describe("docs page metadata", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDbChain();
+  });
+
+  it("uses the standard 404 title when the docs project is missing", async () => {
+    dbMocks.limit.mockResolvedValueOnce([]);
+
+    const { generateMetadata } = await import(
+      "@/app/docs/[subdomain]/[...slug]/page"
+    );
+
+    await expect(
+      generateMetadata({
+        params: Promise.resolve({
+          subdomain: "missing-docs",
+          slug: ["does-not-exist"],
+        }),
+      }),
+    ).resolves.toMatchObject({
+      title: "404: This page could not be found.",
+    });
+  });
+
+  it("uses the standard 404 title when a docs page slug is missing", async () => {
+    dbMocks.limit
+      .mockResolvedValueOnce([
+        { id: "project-1", name: "Test Project", settings: {} },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const { generateMetadata } = await import(
+      "@/app/docs/[subdomain]/[...slug]/page"
+    );
+
+    await expect(
+      generateMetadata({
+        params: Promise.resolve({
+          subdomain: "test-project",
+          slug: ["does-not-exist"],
+        }),
+      }),
+    ).resolves.toMatchObject({
+      title: "404: This page could not be found.",
+    });
+  });
+});

--- a/tests/docs-page-metadata.test.ts
+++ b/tests/docs-page-metadata.test.ts
@@ -67,4 +67,45 @@ describe("docs page metadata", () => {
       title: "404: This page could not be found.",
     });
   });
+  it("uses the Mintlify browser title for generated API pages", async () => {
+    dbMocks.limit
+      .mockResolvedValueOnce([
+        {
+          id: "project-1",
+          name: "Test Project",
+          settings: {
+            openApiSpec: {
+              openapi: "3.0.0",
+              info: { title: "Fixture API", version: "1.0.0" },
+              paths: {
+                "/plants": {
+                  get: {
+                    summary: "Get Plants",
+                    description: "Returns a list of plants.",
+                    responses: { "200": { description: "OK" } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const { generateMetadata } = await import(
+      "@/app/docs/[subdomain]/[...slug]/page"
+    );
+
+    await expect(
+      generateMetadata({
+        params: Promise.resolve({
+          subdomain: "test-project",
+          slug: ["api-reference", "get-plants"],
+        }),
+      }),
+    ).resolves.toMatchObject({
+      title: "Documentation",
+      description: "Returns a list of plants.",
+    });
+  });
 });

--- a/tests/docs-search-route.test.ts
+++ b/tests/docs-search-route.test.ts
@@ -1,0 +1,104 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { hasValidDocsAccessMock, selectMock } = vi.hoisted(() => ({
+  hasValidDocsAccessMock: vi.fn(),
+  selectMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: selectMock,
+  },
+}));
+
+vi.mock("@/lib/project-docs-access", () => ({
+  getDocsAccessCookieName: (subdomain: string) => `docs_access_${subdomain}`,
+  hasValidDocsAccess: hasValidDocsAccessMock,
+}));
+
+function makeRequest(url: string): NextRequest {
+  const request = new Request(url) as NextRequest;
+  Object.defineProperty(request, "cookies", {
+    value: { get: vi.fn().mockReturnValue(undefined) },
+    configurable: true,
+  });
+  return request;
+}
+
+function mockProjectLookup(settings: Record<string, unknown>) {
+  return {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue([{ id: "project-1", settings }]),
+  };
+}
+
+function mockPageSearch(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(rows),
+  };
+}
+
+describe("GET /api/docs/[subdomain]/search", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    hasValidDocsAccessMock.mockReturnValue(true);
+  });
+
+  it("includes generated OpenAPI pages when the query matches endpoint metadata", async () => {
+    const openApiSpec = {
+      openapi: "3.0.0",
+      info: { title: "Plants API", version: "1.0.0" },
+      paths: {
+        "/plants": {
+          get: {
+            operationId: "getPlants",
+            summary: "Get Plants",
+            description: "Returns a list of plants.",
+            responses: { "200": { description: "OK" } },
+          },
+        },
+      },
+    };
+
+    selectMock
+      .mockReturnValueOnce(mockProjectLookup({ openApiSpec }))
+      .mockReturnValueOnce(
+        mockPageSearch([
+          {
+            path: "quickstart",
+            title: "Quickstart",
+            description: null,
+            content: "Make your first request to the Plants API.",
+          },
+        ]),
+      );
+
+    const { GET } = await import("@/app/api/docs/[subdomain]/search/route");
+    const response = await GET(
+      makeRequest("http://localhost/api/docs/test-project/search?q=plants"),
+      { params: Promise.resolve({ subdomain: "test-project" }) },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "api-reference/get-plants",
+          title: "Get Plants",
+          snippet: expect.stringContaining("GET /plants"),
+        }),
+      ]),
+    );
+    expect(body[0]).toMatchObject({
+      path: "api-reference/get-plants",
+      title: "Get Plants",
+    });
+  });
+});

--- a/tests/docs-selector-a11y.test.tsx
+++ b/tests/docs-selector-a11y.test.tsx
@@ -1,0 +1,118 @@
+import { LanguageSwitcher } from "@/components/docs/language-switcher";
+import { VersionSwitcher } from "@/components/docs/version-switcher";
+import type { VersionsConfig } from "@/lib/versions";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const push = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+// React 19 requires this flag for act() in non-testing-library environments.
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("docs selector accessibility", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    push.mockClear();
+    document.body.innerHTML = "";
+  });
+
+  it("labels the version selector and version options", async () => {
+    const versionsConfig: VersionsConfig = {
+      enabled: true,
+      versions: [
+        { tag: "v1", name: "Version 1.0", isDefault: false },
+        { tag: "v2", name: "Version 2.0", isDefault: true },
+      ],
+    };
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <VersionSwitcher
+          currentVersion="v2"
+          availableVersions={["v1", "v2"]}
+          versionsConfig={versionsConfig}
+          subdomain="test-project"
+          pagePath="introduction"
+        />,
+      );
+    });
+
+    const trigger = container.querySelector<HTMLButtonElement>(
+      '[data-testid="version-switcher-btn"]',
+    );
+
+    expect(trigger?.getAttribute("aria-label")).toBe(
+      "Select docs version, current version Version 2.0",
+    );
+    expect(trigger?.getAttribute("aria-expanded")).toBe("false");
+
+    await act(async () => {
+      trigger?.click();
+    });
+
+    expect(trigger?.getAttribute("aria-expanded")).toBe("true");
+    expect(
+      container
+        .querySelector('[data-testid="version-option-v1"]')
+        ?.getAttribute("aria-label"),
+    ).toBe("Switch to docs version Version 1.0");
+    expect(
+      container
+        .querySelector('[data-testid="version-option-v2"]')
+        ?.getAttribute("aria-label"),
+    ).toBe("Switch to docs version Version 2.0 (default)");
+  });
+
+  it("labels the language selector and language options", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <LanguageSwitcher
+          currentLocale="en"
+          availableLocales={["en", "ko"]}
+          subdomain="test-project"
+          pagePath="introduction"
+          defaultLanguage="en"
+        />,
+      );
+    });
+
+    const trigger = container.querySelector<HTMLButtonElement>(
+      '[data-testid="language-switcher-btn"]',
+    );
+
+    expect(trigger?.getAttribute("aria-label")).toBe(
+      "Select docs language, current language English",
+    );
+    expect(trigger?.getAttribute("aria-expanded")).toBe("false");
+
+    await act(async () => {
+      trigger?.click();
+    });
+
+    expect(trigger?.getAttribute("aria-expanded")).toBe("true");
+    expect(
+      container
+        .querySelector('[data-testid="lang-option-en"]')
+        ?.getAttribute("aria-label"),
+    ).toBe("Switch to English");
+    expect(
+      container
+        .querySelector('[data-testid="lang-option-ko"]')
+        ?.getAttribute("aria-label"),
+    ).toBe("Switch to Korean");
+  });
+});

--- a/tests/docs-selector-a11y.test.tsx
+++ b/tests/docs-selector-a11y.test.tsx
@@ -78,6 +78,26 @@ describe("docs selector accessibility", () => {
 
     await act(async () => {
       window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+      );
+    });
+
+    expect(document.activeElement).toBe(
+      container.querySelector('[data-testid="version-option-v1"]'),
+    );
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }),
+      );
+    });
+
+    expect(document.activeElement).toBe(
+      container.querySelector('[data-testid="version-option-v2"]'),
+    );
+
+    await act(async () => {
+      window.dispatchEvent(
         new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
       );
     });
@@ -135,6 +155,26 @@ describe("docs selector accessibility", () => {
         .querySelector('[data-testid="lang-option-ko"]')
         ?.getAttribute("aria-label"),
     ).toBe("Switch to Korean");
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+      );
+    });
+
+    expect(document.activeElement).toBe(
+      container.querySelector('[data-testid="lang-option-en"]'),
+    );
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+      );
+    });
+
+    expect(document.activeElement).toBe(
+      container.querySelector('[data-testid="lang-option-ko"]'),
+    );
 
     await act(async () => {
       window.dispatchEvent(

--- a/tests/docs-selector-a11y.test.tsx
+++ b/tests/docs-selector-a11y.test.tsx
@@ -60,7 +60,11 @@ describe("docs selector accessibility", () => {
       trigger?.click();
     });
 
+    const dropdown = container.querySelector<HTMLElement>(
+      '[data-testid="version-switcher-dropdown"]',
+    );
     expect(trigger?.getAttribute("aria-expanded")).toBe("true");
+    expect(trigger?.getAttribute("aria-controls")).toBe(dropdown?.id);
     expect(
       container
         .querySelector('[data-testid="version-option-v1"]')
@@ -71,6 +75,19 @@ describe("docs selector accessibility", () => {
         .querySelector('[data-testid="version-option-v2"]')
         ?.getAttribute("aria-label"),
     ).toBe("Switch to docs version Version 2.0 (default)");
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+
+    expect(trigger?.getAttribute("aria-expanded")).toBe("false");
+    expect(trigger?.hasAttribute("aria-controls")).toBe(false);
+    expect(
+      container.querySelector('[data-testid="version-switcher-dropdown"]'),
+    ).toBeNull();
+    expect(document.activeElement).toBe(trigger);
   });
 
   it("labels the language selector and language options", async () => {
@@ -103,7 +120,11 @@ describe("docs selector accessibility", () => {
       trigger?.click();
     });
 
+    const dropdown = container.querySelector<HTMLElement>(
+      '[data-testid="language-switcher-dropdown"]',
+    );
     expect(trigger?.getAttribute("aria-expanded")).toBe("true");
+    expect(trigger?.getAttribute("aria-controls")).toBe(dropdown?.id);
     expect(
       container
         .querySelector('[data-testid="lang-option-en"]')
@@ -114,5 +135,18 @@ describe("docs selector accessibility", () => {
         .querySelector('[data-testid="lang-option-ko"]')
         ?.getAttribute("aria-label"),
     ).toBe("Switch to Korean");
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+
+    expect(trigger?.getAttribute("aria-expanded")).toBe("false");
+    expect(trigger?.hasAttribute("aria-controls")).toBe(false);
+    expect(
+      container.querySelector('[data-testid="language-switcher-dropdown"]'),
+    ).toBeNull();
+    expect(document.activeElement).toBe(trigger);
   });
 });

--- a/tests/docs-sidebar.test.tsx
+++ b/tests/docs-sidebar.test.tsx
@@ -1,0 +1,62 @@
+import { DocsSidebar } from "@/components/docs/docs-sidebar";
+import type { DocsNavEntry } from "@/lib/mdx-renderer";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it } from "vitest";
+
+// React 19 requires this flag for act() in non-testing-library environments.
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const nav: DocsNavEntry[] = [
+  {
+    type: "group",
+    label: "Guides",
+    items: [
+      {
+        type: "item",
+        label: "Quickstart",
+        path: "guides/quickstart",
+        pageId: "page-1",
+      },
+    ],
+  },
+];
+
+describe("DocsSidebar", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("labels sidebar group toggles and exposes expanded state", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <DocsSidebar
+          nav={nav}
+          activePath="introduction"
+          subdomain="test-project"
+          projectName="Test Project"
+        />,
+      );
+    });
+
+    const toggle = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Toggle Guides section"]',
+    );
+
+    expect(toggle).not.toBeNull();
+    expect(toggle?.getAttribute("aria-expanded")).toBe("true");
+    expect(toggle?.getAttribute("aria-controls")).toBeTruthy();
+
+    await act(async () => {
+      toggle?.click();
+    });
+
+    expect(toggle?.getAttribute("aria-expanded")).toBe("false");
+  });
+});

--- a/tests/docs-site-layout.test.ts
+++ b/tests/docs-site-layout.test.ts
@@ -256,6 +256,54 @@ describe("Docs site layout — feature-014", () => {
         root.unmount();
       });
     });
+
+    it("returns focus to the opener when Escape closes search", async () => {
+      const { SearchModal } = await import("@/components/docs/search-modal");
+      const opener = document.createElement("button");
+      const appRoot = document.createElement("div");
+      opener.type = "button";
+      opener.textContent = "Search documentation";
+      container.append(opener, appRoot);
+      opener.focus();
+
+      const root = createRoot(appRoot);
+
+      await act(async () => {
+        root.render(
+          createElement(SearchModal, {
+            subdomain: "test-project",
+            pages: [
+              { path: "introduction", title: "Introduction" },
+              { path: "quickstart", title: "Quickstart" },
+            ],
+          }),
+        );
+      });
+
+      await act(async () => {
+        document.dispatchEvent(new CustomEvent("open-search"));
+      });
+
+      const input = appRoot.querySelector<HTMLInputElement>(
+        '[data-testid="search-input"]',
+      );
+
+      expect(document.activeElement).toBe(input);
+
+      await act(async () => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+        );
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(appRoot.querySelector('[data-testid="search-modal"]')).toBeNull();
+      expect(document.activeElement).toBe(opener);
+
+      await act(async () => {
+        root.unmount();
+      });
+    });
   });
 
   describe("MobileNav", () => {

--- a/tests/docs-site-layout.test.ts
+++ b/tests/docs-site-layout.test.ts
@@ -47,6 +47,7 @@ describe("Docs site layout — feature-014", () => {
     beforeEach(() => {
       container = document.createElement("div");
       document.body.appendChild(container);
+      localStorage.removeItem("docs-recent-searches");
     });
 
     afterEach(() => {
@@ -150,8 +151,55 @@ describe("Docs site layout — feature-014", () => {
       expect(input?.getAttribute("aria-autocomplete")).toBe("list");
       expect(input?.getAttribute("aria-expanded")).toBe("true");
       expect(input?.getAttribute("aria-controls")).toBe(results?.id);
+      expect(input?.getAttribute("aria-activedescendant")).toBe(
+        firstOption?.id,
+      );
       expect(results?.getAttribute("role")).toBe("listbox");
-      expect(firstOption?.getAttribute("aria-selected")).toBe("false");
+      expect(firstOption?.getAttribute("aria-selected")).toBe("true");
+
+      await act(async () => {
+        root.unmount();
+      });
+    });
+
+    it("moves active selection through default results with arrow keys", async () => {
+      const { SearchModal } = await import("@/components/docs/search-modal");
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          createElement(SearchModal, {
+            subdomain: "test-project",
+            pages: [
+              { path: "introduction", title: "Introduction" },
+              { path: "quickstart", title: "Quickstart" },
+            ],
+          }),
+        );
+      });
+
+      await act(async () => {
+        document.dispatchEvent(new CustomEvent("open-search"));
+      });
+
+      const input = container.querySelector<HTMLInputElement>(
+        '[data-testid="search-input"]',
+      );
+      const options =
+        container.querySelectorAll<HTMLElement>('[role="option"]');
+
+      expect(input?.getAttribute("aria-activedescendant")).toBe(options[0].id);
+      expect(options[0].getAttribute("aria-selected")).toBe("true");
+
+      await act(async () => {
+        input?.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+        );
+      });
+
+      expect(input?.getAttribute("aria-activedescendant")).toBe(options[1].id);
+      expect(options[0].getAttribute("aria-selected")).toBe("false");
+      expect(options[1].getAttribute("aria-selected")).toBe("true");
 
       await act(async () => {
         root.unmount();

--- a/tests/docs-site-layout.test.ts
+++ b/tests/docs-site-layout.test.ts
@@ -304,6 +304,60 @@ describe("Docs site layout — feature-014", () => {
         root.unmount();
       });
     });
+
+    it("traps Tab focus inside the open search dialog", async () => {
+      const { SearchModal } = await import("@/components/docs/search-modal");
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          createElement(SearchModal, {
+            subdomain: "test-project",
+            pages: [
+              { path: "introduction", title: "Introduction" },
+              { path: "quickstart", title: "Quickstart" },
+            ],
+          }),
+        );
+      });
+
+      await act(async () => {
+        document.dispatchEvent(new CustomEvent("open-search"));
+      });
+
+      const input = container.querySelector<HTMLInputElement>(
+        '[data-testid="search-input"]',
+      );
+      const options =
+        container.querySelectorAll<HTMLElement>('[role="option"]');
+      const lastOption = options[options.length - 1];
+
+      lastOption.focus();
+
+      await act(async () => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Tab", bubbles: true }),
+        );
+      });
+
+      expect(document.activeElement).toBe(input);
+
+      await act(async () => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "Tab",
+            shiftKey: true,
+            bubbles: true,
+          }),
+        );
+      });
+
+      expect(document.activeElement).toBe(lastOption);
+
+      await act(async () => {
+        root.unmount();
+      });
+    });
   });
 
   describe("MobileNav", () => {

--- a/tests/docs-site-layout.test.ts
+++ b/tests/docs-site-layout.test.ts
@@ -169,6 +169,70 @@ describe("Docs site layout — feature-014", () => {
       const mod = await import("@/components/docs/mobile-nav");
       expect(mod.MobileSidebar).toBeDefined();
     });
+
+    it("opens mobile navigation as a labelled dialog and closes on Escape", async () => {
+      const { MobileMenuButton, MobileSidebar } = await import(
+        "@/components/docs/mobile-nav"
+      );
+      const container = document.createElement("div");
+      document.body.appendChild(container);
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          createElement(
+            "div",
+            null,
+            createElement(MobileMenuButton),
+            createElement(MobileSidebar, {
+              nav: [
+                {
+                  type: "item",
+                  label: "Introduction",
+                  path: "introduction",
+                  pageId: "intro",
+                },
+              ],
+              activePath: "introduction",
+              subdomain: "test-project",
+              projectName: "Test Project",
+            }),
+          ),
+        );
+      });
+
+      await act(async () => {
+        container
+          .querySelector<HTMLButtonElement>('[data-testid="mobile-menu-btn"]')
+          ?.click();
+      });
+
+      const dialog = container.querySelector<HTMLElement>(
+        '[data-testid="mobile-sidebar"]',
+      );
+      expect(dialog?.tagName).toBe("DIALOG");
+      expect(dialog?.getAttribute("aria-modal")).toBe("true");
+      expect(dialog?.getAttribute("aria-label")).toBe(
+        "Test Project navigation",
+      );
+      expect(document.body.style.overflow).toBe("hidden");
+
+      await act(async () => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+        );
+      });
+
+      expect(
+        container.querySelector('[data-testid="mobile-sidebar"]'),
+      ).toBeNull();
+      expect(document.body.style.overflow).toBe("");
+
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    });
   });
 
   describe("Layout structure", () => {

--- a/tests/docs-site-layout.test.ts
+++ b/tests/docs-site-layout.test.ts
@@ -205,6 +205,57 @@ describe("Docs site layout — feature-014", () => {
         root.unmount();
       });
     });
+
+    it("moves active selection through recent searches with arrow keys", async () => {
+      const { SearchModal } = await import("@/components/docs/search-modal");
+      localStorage.setItem(
+        "docs-recent-searches",
+        JSON.stringify(["plants", "quickstart"]),
+      );
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          createElement(SearchModal, {
+            subdomain: "test-project",
+            pages: [
+              { path: "introduction", title: "Introduction" },
+              { path: "quickstart", title: "Quickstart" },
+            ],
+          }),
+        );
+      });
+
+      await act(async () => {
+        document.dispatchEvent(new CustomEvent("open-search"));
+      });
+
+      const input = container.querySelector<HTMLInputElement>(
+        '[data-testid="search-input"]',
+      );
+      const options =
+        container.querySelectorAll<HTMLElement>('[role="option"]');
+
+      expect(
+        container.querySelector('[data-testid="recent-searches"]'),
+      ).not.toBeNull();
+      expect(input?.getAttribute("aria-activedescendant")).toBe(options[0].id);
+      expect(options[0].getAttribute("aria-selected")).toBe("true");
+
+      await act(async () => {
+        input?.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+        );
+      });
+
+      expect(input?.getAttribute("aria-activedescendant")).toBe(options[1].id);
+      expect(options[0].getAttribute("aria-selected")).toBe("false");
+      expect(options[1].getAttribute("aria-selected")).toBe("true");
+
+      await act(async () => {
+        root.unmount();
+      });
+    });
   });
 
   describe("MobileNav", () => {

--- a/tests/docs-site-layout.test.ts
+++ b/tests/docs-site-layout.test.ts
@@ -1,9 +1,16 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock next/navigation
 vi.mock("next/navigation", () => ({
   usePathname: () => "/docs/test-project/quickstart",
 }));
+
+// React 19 requires this flag for act() in non-testing-library environments.
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
 
 describe("Docs site layout — feature-014", () => {
   describe("ThemeProvider", () => {
@@ -108,6 +115,47 @@ describe("Docs site layout — feature-014", () => {
       const pages = [{ path: "quickstart", title: "Quickstart Guide" }];
       expect(filterPages(pages, "QUICK")).toHaveLength(1);
       expect(filterPages(pages, "quick")).toHaveLength(1);
+    });
+
+    it("renders search dialog with combobox and listbox semantics", async () => {
+      const { SearchModal } = await import("@/components/docs/search-modal");
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          createElement(SearchModal, {
+            subdomain: "test-project",
+            pages: [
+              { path: "introduction", title: "Introduction" },
+              { path: "quickstart", title: "Quickstart" },
+            ],
+          }),
+        );
+      });
+
+      await act(async () => {
+        document.dispatchEvent(new CustomEvent("open-search"));
+      });
+
+      const input = container.querySelector<HTMLInputElement>(
+        '[data-testid="search-input"]',
+      );
+      const results = container.querySelector<HTMLElement>(
+        '[data-testid="search-results"]',
+      );
+      const firstOption =
+        container.querySelector<HTMLElement>('[role="option"]');
+
+      expect(input?.getAttribute("role")).toBe("combobox");
+      expect(input?.getAttribute("aria-autocomplete")).toBe("list");
+      expect(input?.getAttribute("aria-expanded")).toBe("true");
+      expect(input?.getAttribute("aria-controls")).toBe(results?.id);
+      expect(results?.getAttribute("role")).toBe("listbox");
+      expect(firstOption?.getAttribute("aria-selected")).toBe("false");
+
+      await act(async () => {
+        root.unmount();
+      });
     });
   });
 

--- a/tests/docs-site-layout.test.ts
+++ b/tests/docs-site-layout.test.ts
@@ -434,6 +434,88 @@ describe("Docs site layout — feature-014", () => {
       });
       container.remove();
     });
+
+    it("traps Tab focus inside the open mobile navigation", async () => {
+      const { MobileMenuButton, MobileSidebar } = await import(
+        "@/components/docs/mobile-nav"
+      );
+      const container = document.createElement("div");
+      document.body.appendChild(container);
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          createElement(
+            "div",
+            null,
+            createElement(MobileMenuButton),
+            createElement(MobileSidebar, {
+              nav: [
+                {
+                  type: "item",
+                  label: "Introduction",
+                  path: "introduction",
+                  pageId: "intro",
+                },
+                {
+                  type: "item",
+                  label: "Quickstart",
+                  path: "quickstart",
+                  pageId: "quickstart",
+                },
+              ],
+              activePath: "introduction",
+              subdomain: "test-project",
+              projectName: "Test Project",
+            }),
+          ),
+        );
+      });
+
+      await act(async () => {
+        container
+          .querySelector<HTMLButtonElement>('[data-testid="mobile-menu-btn"]')
+          ?.click();
+      });
+
+      const dialog = container.querySelector<HTMLElement>(
+        '[data-testid="mobile-sidebar"]',
+      );
+      const focusable = Array.from(
+        dialog?.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ) ?? [],
+      );
+      const firstFocusable = focusable[0];
+      const lastFocusable = focusable[focusable.length - 1];
+
+      lastFocusable.focus();
+
+      await act(async () => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Tab", bubbles: true }),
+        );
+      });
+
+      expect(document.activeElement).toBe(firstFocusable);
+
+      await act(async () => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "Tab",
+            shiftKey: true,
+            bubbles: true,
+          }),
+        );
+      });
+
+      expect(document.activeElement).toBe(lastFocusable);
+
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    });
   });
 
   describe("Layout structure", () => {

--- a/tests/docs-toc-interaction.test.tsx
+++ b/tests/docs-toc-interaction.test.tsx
@@ -39,7 +39,7 @@ describe("DocsToc interactions", () => {
     vi.useFakeTimers();
     latestObserverCallback = null;
     document.body.innerHTML = `
-      <h2 id="create-a-project">Create a project</h2>
+      <h2 id="create-a-project"><a id="create-heading-anchor" href="#create-a-project">Create a project</a></h2>
       <h2 id="install-the-sdk">Install the SDK</h2>
       <h2 id="make-your-first-request">Make your first request</h2>
       <div id="toc-root"></div>
@@ -47,6 +47,67 @@ describe("DocsToc interactions", () => {
     vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
     Element.prototype.scrollIntoView = vi.fn();
     window.history.replaceState(null, "", "/docs/test-project/quickstart");
+  });
+
+  it("does not mark a ToC entry active before user or scroll selection", async () => {
+    const container = document.getElementById("toc-root");
+    if (!container) throw new Error("missing test container");
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<DocsToc entries={tocEntries} />);
+    });
+
+    const links = Array.from(
+      container.querySelectorAll<HTMLAnchorElement>(".docs-toc-link"),
+    );
+
+    expect(links).toHaveLength(3);
+    for (const link of links) {
+      expect(link.className).not.toContain("active");
+    }
+  });
+
+  it("keeps heading-anchor hash navigation from selecting a ToC entry", async () => {
+    const container = document.getElementById("toc-root");
+    if (!container) throw new Error("missing test container");
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<DocsToc entries={tocEntries} />);
+    });
+
+    const createLink = container.querySelector<HTMLAnchorElement>(
+      'a[href="#create-a-project"]',
+    );
+    if (!createLink) throw new Error("missing create ToC link");
+
+    const headingAnchor = document.getElementById("create-heading-anchor");
+    if (!headingAnchor) throw new Error("missing heading anchor");
+
+    await act(async () => {
+      headingAnchor.click();
+      window.history.pushState(null, "", "#create-a-project");
+      window.dispatchEvent(new HashChangeEvent("hashchange"));
+    });
+
+    const createHeading = document.getElementById("create-a-project");
+    if (!createHeading) throw new Error("missing create heading");
+
+    await act(async () => {
+      latestObserverCallback?.([
+        {
+          isIntersecting: true,
+          target: createHeading,
+        } as unknown as IntersectionObserverEntry,
+      ]);
+    });
+
+    expect(createLink.className).not.toContain("active");
+
+    await act(async () => {
+      vi.advanceTimersByTime(1500);
+    });
   });
 
   it("keeps the clicked ToC entry active while smooth scrolling settles", async () => {

--- a/tests/docs-toc-interaction.test.tsx
+++ b/tests/docs-toc-interaction.test.tsx
@@ -1,0 +1,95 @@
+import { DocsToc } from "@/components/docs/docs-toc";
+import type { TocEntry } from "@/lib/editor";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// React 19 requires this flag for act() in non-testing-library environments.
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+type ObserverCallback = (entries: IntersectionObserverEntry[]) => void;
+
+let latestObserverCallback: ObserverCallback | null = null;
+
+class MockIntersectionObserver {
+  readonly root = null;
+  readonly rootMargin = "";
+  readonly thresholds = [];
+
+  constructor(callback: ObserverCallback) {
+    latestObserverCallback = callback;
+  }
+
+  disconnect = vi.fn();
+  observe = vi.fn();
+  takeRecords = vi.fn(() => []);
+  unobserve = vi.fn();
+}
+
+const tocEntries: TocEntry[] = [
+  { level: 2, text: "Create a project", id: "create-a-project" },
+  { level: 2, text: "Install the SDK", id: "install-the-sdk" },
+  { level: 2, text: "Make your first request", id: "make-your-first-request" },
+];
+
+describe("DocsToc interactions", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    latestObserverCallback = null;
+    document.body.innerHTML = `
+      <h2 id="create-a-project">Create a project</h2>
+      <h2 id="install-the-sdk">Install the SDK</h2>
+      <h2 id="make-your-first-request">Make your first request</h2>
+      <div id="toc-root"></div>
+    `;
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+    Element.prototype.scrollIntoView = vi.fn();
+    window.history.replaceState(null, "", "/docs/test-project/quickstart");
+  });
+
+  it("keeps the clicked ToC entry active while smooth scrolling settles", async () => {
+    const container = document.getElementById("toc-root");
+    if (!container) throw new Error("missing test container");
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<DocsToc entries={tocEntries} />);
+    });
+
+    const createLink = container.querySelector<HTMLAnchorElement>(
+      'a[href="#create-a-project"]',
+    );
+    const installLink = container.querySelector<HTMLAnchorElement>(
+      'a[href="#install-the-sdk"]',
+    );
+    if (!createLink || !installLink) throw new Error("missing ToC links");
+
+    await act(async () => {
+      installLink.click();
+    });
+
+    expect(window.location.hash).toBe("#install-the-sdk");
+    expect(installLink.className).toContain("active");
+
+    const createHeading = document.getElementById("create-a-project");
+    if (!createHeading) throw new Error("missing create heading");
+
+    await act(async () => {
+      latestObserverCallback?.([
+        {
+          isIntersecting: true,
+          target: createHeading,
+        } as unknown as IntersectionObserverEntry,
+      ]);
+    });
+
+    expect(installLink.className).toContain("active");
+    expect(createLink.className).not.toContain("active");
+
+    await act(async () => {
+      vi.advanceTimersByTime(1500);
+    });
+  });
+});

--- a/tests/docs-topbar.test.ts
+++ b/tests/docs-topbar.test.ts
@@ -1,9 +1,20 @@
-import { describe, expect, it, vi } from "vitest";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // Mock next/navigation
 vi.mock("next/navigation", () => ({
   usePathname: () => "/docs/test-project/quickstart",
 }));
+
+// React 19 requires this flag for act() in non-testing-library environments.
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
 
 describe("Docs topbar — feature-014a", () => {
   describe("DocsTopbar component exports", () => {
@@ -96,6 +107,45 @@ describe("Docs topbar — feature-014a", () => {
       expect(events).toHaveLength(1);
 
       document.removeEventListener("toggle-ask-ai", handler);
+    });
+
+    it("renders Mintlify-parity labels for the topbar search and assistant buttons", async () => {
+      const { AskAiButton, DocsTopbar } = await import(
+        "@/components/docs/docs-topbar"
+      );
+
+      const container = document.createElement("div");
+      document.body.appendChild(container);
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          createElement(
+            "div",
+            null,
+            createElement(AskAiButton),
+            createElement(DocsTopbar, {
+              projectName: "Test Project",
+              subdomain: "test-project",
+            }),
+          ),
+        );
+      });
+
+      const askButton = container.querySelector<HTMLButtonElement>(
+        '[data-testid="ask-ai-btn"]',
+      );
+      const searchButton =
+        container.querySelector<HTMLButtonElement>(".docs-search-btn");
+
+      expect(askButton?.getAttribute("aria-label")).toBe(
+        "Toggle assistant panel",
+      );
+      expect(searchButton?.getAttribute("aria-label")).toBe("Open search");
+
+      await act(async () => {
+        root.unmount();
+      });
     });
   });
 

--- a/tests/docs-topbar.test.ts
+++ b/tests/docs-topbar.test.ts
@@ -1,3 +1,4 @@
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 // Mock next/navigation
@@ -7,6 +8,23 @@ vi.mock("next/navigation", () => ({
 
 describe("Docs topbar — feature-014a", () => {
   describe("DocsTopbar component exports", () => {
+    it("renders a skip link before docs navigation", async () => {
+      const { DocsTopbar } = await import("@/components/docs/docs-topbar");
+      const html = renderToStaticMarkup(
+        DocsTopbar({
+          projectName: "Test Project",
+          subdomain: "test-project",
+          settings: {},
+        }),
+      );
+
+      expect(html).toContain('href="#main-content"');
+      expect(html).toContain("Skip to main content");
+      expect(html.indexOf("Skip to main content")).toBeLessThan(
+        html.indexOf("docs-topbar"),
+      );
+    });
+
     it("exports DocsTopbar component", async () => {
       const mod = await import("@/components/docs/docs-topbar");
       expect(mod.DocsTopbar).toBeDefined();

--- a/tests/docs-topbar.test.ts
+++ b/tests/docs-topbar.test.ts
@@ -106,6 +106,63 @@ describe("Docs topbar — feature-014a", () => {
       const href = buildSupportHref(undefined);
       expect(href).toContain("mailto:");
     });
+
+    it("resolves configured docs logo path and link from docs config", async () => {
+      const { getConfiguredDocsLogo } = await import(
+        "@/components/docs/docs-topbar"
+      );
+      expect(
+        getConfiguredDocsLogo({
+          docsConfig: {
+            visualBranding: {
+              logoLink: "https://example.com",
+              logoDarkPath: "/dark.svg",
+            },
+            headerTopbar: {
+              logoPath: "/topbar.svg",
+            },
+          },
+        }),
+      ).toEqual({ path: "/topbar.svg", href: "https://example.com" });
+    });
+
+    it("renders the configured docs logo image and link", async () => {
+      const { DocsTopbar } = await import("@/components/docs/docs-topbar");
+      const html = renderToStaticMarkup(
+        DocsTopbar({
+          projectName: "Test Project",
+          subdomain: "test-project",
+          settings: {
+            docsConfig: {
+              visualBranding: {
+                logoLink: "https://example.com",
+              },
+              headerTopbar: {
+                logoPath: "/topbar.svg",
+              },
+            },
+          },
+        }),
+      );
+
+      expect(html).toContain('href="https://example.com"');
+      expect(html).toContain('src="/topbar.svg"');
+      expect(html).toContain('class="docs-topbar-logo-image"');
+    });
+
+    it("uses currentColor for the default logo mark", async () => {
+      const { DocsTopbar } = await import("@/components/docs/docs-topbar");
+      const html = renderToStaticMarkup(
+        DocsTopbar({
+          projectName: "Test Project",
+          subdomain: "test-project",
+          settings: {},
+        }),
+      );
+
+      expect(html).toContain('fill="currentColor"');
+      expect(html).toContain('stroke="currentColor"');
+    });
   });
 
   describe("Ask AI toggle", () => {

--- a/tests/e2e/dashboard-layout.spec.ts
+++ b/tests/e2e/dashboard-layout.spec.ts
@@ -18,20 +18,28 @@ test.describe("Dashboard Layout", () => {
     await expect(sidebar.getByText("Settings")).toBeVisible();
   });
 
-  test("sidebar shows Agents group with items", async ({ page }) => {
+  test("sidebar shows Agents group with Mintlify ordering", async ({
+    page,
+  }) => {
     await page.goto("/dashboard");
     const sidebar = page.getByTestId("sidebar");
     await expect(sidebar.getByText("Agents")).toBeVisible();
     await expect(
-      sidebar.getByRole("link", { name: "Agent New" }),
+      sidebar.getByRole("link", { name: "Workflows New" }),
+    ).toBeVisible();
+    await expect(
+      sidebar.getByRole("link", { name: "Agent", exact: true }),
     ).toBeVisible();
     await expect(
       sidebar.getByRole("link", { name: "Assistant" }),
     ).toBeVisible();
-    await expect(
-      sidebar.getByRole("link", { name: "Workflows" }),
-    ).toBeVisible();
     await expect(sidebar.getByRole("link", { name: "MCP" })).toBeVisible();
+
+    await expect(
+      sidebar
+        .locator("nav a")
+        .filter({ hasText: /Workflows|Agent|Assistant|MCP/ }),
+    ).toHaveText([/Workflows/, /Agent/, /Assistant/, /MCP/]);
   });
 
   test("sidebar has org switcher with org name", async ({ page }) => {

--- a/tests/e2e/dashboard-layout.spec.ts
+++ b/tests/e2e/dashboard-layout.spec.ts
@@ -118,6 +118,8 @@ test.describe("Dashboard Layout", () => {
     await page.goto("/dashboard");
     await expect(page.getByTestId("trial-banner")).toBeVisible();
     await expect(page.getByText("free trial")).toBeVisible();
+    await expect(page.getByText("May 18, 2026")).toBeVisible();
+    await expect(page.getByText("April 19, 2026")).toBeHidden();
   });
 
   test("trial banner dismissal persists after reload", async ({ page }) => {

--- a/tests/e2e/docs-site-layout.spec.ts
+++ b/tests/e2e/docs-site-layout.spec.ts
@@ -83,14 +83,14 @@ test.describe("Docs site layout — feature-014", () => {
     await expect(mobileSidebar).toBeVisible();
   });
 
-  test("TOC highlights current section on scroll", async ({ page }) => {
+  test("TOC waits for user or scroll selection before highlighting", async ({
+    page,
+  }) => {
     await page.goto("/docs/test-project/quickstart");
     const tocLinks = page.locator(".docs-toc-link");
-    // At least one TOC link should exist if page has headings
     const count = await tocLinks.count();
     if (count > 0) {
-      // First TOC link should be active by default (top of page)
-      await expect(tocLinks.first()).toHaveClass(/active/);
+      await expect(tocLinks.first()).not.toHaveClass(/active/);
     }
   });
 });

--- a/tests/e2e/openapi-autodocs.spec.ts
+++ b/tests/e2e/openapi-autodocs.spec.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "@playwright/test";
 
 test.describe("OpenAPI/AsyncAPI auto-documentation", () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
   test("openapi-spec API route returns 401 without auth", async ({
     request,
   }) => {

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -28,6 +28,16 @@ test.describe("Smoke tests", () => {
     expect(response?.status()).toBe(200);
   });
 
+  test("Mintlify-style workspace home route loads authenticated dashboard", async ({
+    page,
+  }) => {
+    const response = await page.goto("/namuhinc/namuhinc/home");
+    expect(response?.status()).toBe(200);
+    await expect(
+      page.getByText(/Good (morning|afternoon|evening)/),
+    ).toBeVisible();
+  });
+
   test("settings page loads (authenticated)", async ({ page }) => {
     const response = await page.goto("/settings/security/api-keys");
     expect(response?.status()).toBe(200);

--- a/tests/feedback-widget.test.ts
+++ b/tests/feedback-widget.test.ts
@@ -1,7 +1,7 @@
 import { FeedbackWidget } from "@/components/docs/feedback-widget";
 import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { validateFeedbackPayload } from "../src/lib/feedback";
 
 // React 19 requires this flag for act() in non-testing-library environments.
@@ -286,6 +286,52 @@ describe("Feedback widget visible choices", () => {
 
     expect(document.activeElement).toBe(textarea);
 
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("moves focus to the thank-you message after feedback submission", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+    } as Response);
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(FeedbackWidget, {
+          subdomain: "test-project",
+          pagePath: "introduction",
+        }),
+      );
+    });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="feedback-thumbs-down"]',
+        )
+        ?.click();
+    });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="feedback-skip"]')
+        ?.click();
+      await Promise.resolve();
+    });
+
+    const thanks = container.querySelector<HTMLElement>(
+      '[data-testid="feedback-thanks"]',
+    );
+
+    expect(thanks?.getAttribute("tabindex")).toBe("-1");
+    expect(document.activeElement).toBe(thanks);
+
+    fetchMock.mockRestore();
     await act(async () => {
       root.unmount();
     });

--- a/tests/feedback-widget.test.ts
+++ b/tests/feedback-widget.test.ts
@@ -257,4 +257,38 @@ describe("Feedback widget visible choices", () => {
     });
     container.remove();
   });
+
+  it("moves focus to the optional feedback comment textarea after rating", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(FeedbackWidget, {
+          subdomain: "test-project",
+          pagePath: "introduction",
+        }),
+      );
+    });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="feedback-thumbs-down"]',
+        )
+        ?.click();
+    });
+
+    const textarea = container.querySelector<HTMLTextAreaElement>(
+      '[data-testid="feedback-textarea"]',
+    );
+
+    expect(document.activeElement).toBe(textarea);
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
 });

--- a/tests/feedback-widget.test.ts
+++ b/tests/feedback-widget.test.ts
@@ -1,5 +1,13 @@
+import { FeedbackWidget } from "@/components/docs/feedback-widget";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
 import { describe, expect, it } from "vitest";
 import { validateFeedbackPayload } from "../src/lib/feedback";
+
+// React 19 requires this flag for act() in non-testing-library environments.
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
 
 // ── Feedback API validation logic ────────────────────────────────────────────
 
@@ -171,5 +179,43 @@ describe("Feedback widget state machine", () => {
     state = handleSubmitStart(state);
     state = handleSubmitSuccess(state);
     expect(state.rating).toBe("helpful");
+  });
+});
+
+describe("Feedback widget visible choices", () => {
+  it("renders explicit Yes and No labels while preserving accessible names", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(FeedbackWidget, {
+          subdomain: "test-project",
+          pagePath: "introduction",
+        }),
+      );
+    });
+
+    const helpful = container.querySelector<HTMLButtonElement>(
+      '[data-testid="feedback-thumbs-up"]',
+    );
+    const notHelpful = container.querySelector<HTMLButtonElement>(
+      '[data-testid="feedback-thumbs-down"]',
+    );
+
+    expect(helpful?.textContent).toContain("Yes");
+    expect(helpful?.getAttribute("aria-label")).toBe(
+      "Yes, this page was helpful",
+    );
+    expect(notHelpful?.textContent).toContain("No");
+    expect(notHelpful?.getAttribute("aria-label")).toBe(
+      "No, this page was not helpful",
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
   });
 });

--- a/tests/feedback-widget.test.ts
+++ b/tests/feedback-widget.test.ts
@@ -218,4 +218,43 @@ describe("Feedback widget visible choices", () => {
     });
     container.remove();
   });
+
+  it("labels the optional feedback comment textarea with the visible prompt", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(FeedbackWidget, {
+          subdomain: "test-project",
+          pagePath: "introduction",
+        }),
+      );
+    });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="feedback-thumbs-down"]',
+        )
+        ?.click();
+    });
+
+    const textarea = container.querySelector<HTMLTextAreaElement>(
+      '[data-testid="feedback-textarea"]',
+    );
+    const label = container.querySelector<HTMLElement>(
+      ".docs-feedback-comment-label",
+    );
+
+    expect(label?.textContent).toBe("Sorry to hear that. How can we improve?");
+    expect(label?.id).toBeTruthy();
+    expect(textarea?.getAttribute("aria-labelledby")).toBe(label?.id);
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
 });

--- a/tests/github-source.test.ts
+++ b/tests/github-source.test.ts
@@ -61,4 +61,34 @@ describe("github-source helpers", () => {
       },
     });
   });
+
+  it("preserves incoming docs config settings while refreshing github source", () => {
+    expect(
+      mergeProjectSettingsWithGitHubSource(
+        {
+          githubSource: { repoFullName: "old/repo" },
+          docsConfig: {
+            visualBranding: { primaryColor: "#16A34A" },
+          },
+        },
+        buildGitHubSourceSelection({
+          repoUrl: "https://github.com/acme/docs",
+          repoBranch: "main",
+        }),
+        {
+          docsConfig: {
+            visualBranding: { primaryColor: "#FF0000" },
+          },
+        },
+      ),
+    ).toMatchObject({
+      docsConfig: {
+        visualBranding: { primaryColor: "#FF0000" },
+      },
+      githubSource: {
+        repoFullName: "acme/docs",
+        branch: "main",
+      },
+    });
+  });
 });

--- a/tests/i18n.test.ts
+++ b/tests/i18n.test.ts
@@ -348,4 +348,14 @@ describe("getAvailableLocalesForPage", () => {
     );
     expect(locales).toEqual(["en"]);
   });
+
+  it("can expose all configured locales for generated routes", () => {
+    const locales = getAvailableLocalesForPage(
+      allPages,
+      "api-reference/get-plants",
+      config,
+      { includeConfiguredRoutes: true },
+    );
+    expect(locales).toEqual(["en", "fr", "es"]);
+  });
 });

--- a/tests/mdx-renderer.test.ts
+++ b/tests/mdx-renderer.test.ts
@@ -18,6 +18,13 @@ describe("MDX Renderer utilities", () => {
       expect(result).toContain("Hello World");
     });
 
+    it("labels heading permalink anchors for assistive technology", () => {
+      const result = parseMdxToHtml("## Getting Started");
+      expect(result).toContain('href="#getting-started"');
+      expect(result).toContain('class="heading-anchor"');
+      expect(result).toContain('aria-label="Navigate to header"');
+    });
+
     it("converts bold and italic text", () => {
       const result = parseMdxToHtml("**bold** and *italic*");
       expect(result).toContain("<strong>bold</strong>");

--- a/tests/page-header-actions.test.tsx
+++ b/tests/page-header-actions.test.tsx
@@ -49,4 +49,43 @@ describe("PageHeaderActions", () => {
     expect(copyButton?.textContent).toContain("Copied");
     expect(copyButton?.getAttribute("aria-label")).toBe("Copied page markdown");
   });
+
+  it("labels the more actions menu trigger and menu items", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <PageHeaderActions
+          title="Introduction"
+          content="Welcome to the docs."
+          pageUrl="/docs/test-project/introduction.md"
+        />,
+      );
+    });
+
+    const moreButton = container.querySelector<HTMLButtonElement>(
+      '[data-testid="page-actions-btn"]',
+    );
+
+    expect(moreButton?.getAttribute("aria-label")).toBe("More page actions");
+    expect(moreButton?.getAttribute("aria-haspopup")).toBe("menu");
+    expect(moreButton?.getAttribute("aria-expanded")).toBe("false");
+    expect(moreButton?.hasAttribute("aria-controls")).toBe(false);
+
+    await act(async () => {
+      moreButton?.click();
+    });
+
+    const menu = container.querySelector<HTMLElement>(".page-actions-menu");
+    expect(moreButton?.getAttribute("aria-expanded")).toBe("true");
+    expect(moreButton?.getAttribute("aria-controls")).toBe(menu?.id);
+    expect(menu?.getAttribute("role")).toBe("menu");
+    expect(
+      Array.from(
+        container.querySelectorAll<HTMLElement>(".page-actions-menu-item"),
+      ).map((item) => item.getAttribute("role")),
+    ).toEqual(["menuitem", "menuitem"]);
+  });
 });

--- a/tests/page-header-actions.test.tsx
+++ b/tests/page-header-actions.test.tsx
@@ -1,0 +1,52 @@
+import { PageHeaderActions } from "@/components/docs/page-chrome";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// React 19 requires this flag for act() in non-testing-library environments.
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("PageHeaderActions", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it("shows visible copied feedback after copying page markdown", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <PageHeaderActions
+          title="Introduction"
+          content="Welcome to the docs."
+          pageUrl="/docs/test-project/introduction.md"
+        />,
+      );
+    });
+
+    const copyButton = container.querySelector<HTMLButtonElement>(
+      '[data-testid="copy-page-btn"]',
+    );
+
+    expect(copyButton?.textContent).not.toContain("Copied");
+
+    await act(async () => {
+      copyButton?.click();
+    });
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "# Introduction\n\nWelcome to the docs.",
+    );
+    expect(copyButton?.textContent).toContain("Copied");
+    expect(copyButton?.getAttribute("aria-label")).toBe("Copied page markdown");
+  });
+});

--- a/tests/page-header-actions.test.tsx
+++ b/tests/page-header-actions.test.tsx
@@ -88,4 +88,40 @@ describe("PageHeaderActions", () => {
       ).map((item) => item.getAttribute("role")),
     ).toEqual(["menuitem", "menuitem"]);
   });
+
+  it("closes the more actions menu with Escape and restores trigger focus", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <PageHeaderActions
+          title="Introduction"
+          content="Welcome to the docs."
+          pageUrl="/docs/test-project/introduction.md"
+        />,
+      );
+    });
+
+    const moreButton = container.querySelector<HTMLButtonElement>(
+      '[data-testid="page-actions-btn"]',
+    );
+
+    await act(async () => {
+      moreButton?.click();
+    });
+
+    expect(container.querySelector(".page-actions-menu")).not.toBeNull();
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+
+    expect(container.querySelector(".page-actions-menu")).toBeNull();
+    expect(moreButton?.getAttribute("aria-expanded")).toBe("false");
+    expect(document.activeElement).toBe(moreButton);
+  });
 });

--- a/tests/public-docs-llms.test.ts
+++ b/tests/public-docs-llms.test.ts
@@ -1,0 +1,16 @@
+import { buildPublicDocsBaseUrl } from "@/lib/public-docs-llms";
+import { describe, expect, it } from "vitest";
+
+describe("buildPublicDocsBaseUrl", () => {
+  it("builds the docs-site base URL from the request origin", () => {
+    expect(buildPublicDocsBaseUrl("https://opendocs.namuh.co", "acme")).toBe(
+      "https://opendocs.namuh.co/docs/acme",
+    );
+  });
+
+  it("normalizes trailing slashes on the origin", () => {
+    expect(buildPublicDocsBaseUrl("https://example.com/", "docs")).toBe(
+      "https://example.com/docs/docs",
+    );
+  });
+});

--- a/tests/public-markdown-export.test.ts
+++ b/tests/public-markdown-export.test.ts
@@ -1,0 +1,27 @@
+import { parsePublicMarkdownExportPath } from "@/lib/public-markdown-export";
+import { describe, expect, it } from "vitest";
+
+describe("parsePublicMarkdownExportPath", () => {
+  it("parses a top-level docs markdown export path", () => {
+    expect(parsePublicMarkdownExportPath("/docs/acme/introduction.md")).toEqual(
+      {
+        subdomain: "acme",
+        pagePath: "introduction",
+      },
+    );
+  });
+
+  it("parses nested docs markdown export paths", () => {
+    expect(
+      parsePublicMarkdownExportPath("/docs/acme/guides/quickstart.md"),
+    ).toEqual({
+      subdomain: "acme",
+      pagePath: "guides/quickstart",
+    });
+  });
+
+  it("ignores normal docs pages and non-markdown assets", () => {
+    expect(parsePublicMarkdownExportPath("/docs/acme/introduction")).toBeNull();
+    expect(parsePublicMarkdownExportPath("/docs/acme/llms.txt")).toBeNull();
+  });
+});

--- a/tests/public-mcp.test.ts
+++ b/tests/public-mcp.test.ts
@@ -1,0 +1,40 @@
+import { buildPublicMcpDescriptor, toMcpToolLabel } from "@/lib/public-mcp";
+import { describe, expect, it } from "vitest";
+
+describe("toMcpToolLabel", () => {
+  it("converts docs subdomains to MCP-safe tool labels", () => {
+    expect(toMcpToolLabel("test-project")).toBe("test_project");
+    expect(toMcpToolLabel("docs.example")).toBe("docs_example");
+  });
+});
+
+describe("buildPublicMcpDescriptor", () => {
+  it("builds Mintlify-style server metadata and tools", () => {
+    const descriptor = buildPublicMcpDescriptor(
+      { name: "Test Project", subdomain: "test-project" },
+      "https://opendocs.namuh.co/",
+    );
+
+    expect(descriptor.server).toEqual({
+      name: "Test Project",
+      version: "1.0.0",
+      transport: "http",
+    });
+    expect(descriptor.capabilities.tools.search_test_project).toMatchObject({
+      name: "search_test_project",
+      operationId: "test_project_search",
+    });
+    expect(
+      descriptor.capabilities.tools.query_docs_filesystem_test_project,
+    ).toMatchObject({
+      name: "query_docs_filesystem_test_project",
+      operationId: "test_project_query_docs_filesystem",
+    });
+    expect(
+      descriptor.capabilities.tools.search_test_project.inputSchema.properties,
+    ).toHaveProperty("language");
+    expect(descriptor.capabilities.resources[0].uri).toBe(
+      "https://opendocs.namuh.co/docs/test-project/llms.txt",
+    );
+  });
+});

--- a/tests/versions.test.ts
+++ b/tests/versions.test.ts
@@ -391,4 +391,14 @@ describe("getAvailableVersionsForPage", () => {
     );
     expect(result).toEqual([]);
   });
+
+  it("can expose all configured versions for generated routes", () => {
+    const result = getAvailableVersionsForPage(
+      pages,
+      "api-reference/get-plants",
+      threeVersionConfig,
+      { includeConfiguredRoutes: true },
+    );
+    expect(result).toEqual(["v1", "v2", "v3"]);
+  });
 });


### PR DESCRIPTION
## Summary
- promote PR #67 so live docs no longer show stale queued/updating initial deployment rows
- hide stale deployment manual-handoff rows for projects that already have published live docs

## Verification
- npm test -- --run tests/dashboard.test.ts tests/deployments.test.ts
- npm run lint
- npm run typecheck