### PR TITLE
Polish docs UI toward Mintlify parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,3 +80,54 @@ Test the SDK manually: import it, call the API, verify response.
 - Commit fixes: `git commit -m "fix: <description>"`
 - Push after every commit: `git push`
 - **NEVER weaken or delete tests to make them pass.** Fix the code, not the test.
+
+## Recovery Rules (autonomous loop — DO NOT pause)
+
+Ashley is building a closed-loop environment. You must keep working autonomously and never halt for human input unless every recovery path is exhausted. Optional human intervention is fine; mandatory waiting is not.
+
+### Detection signals (any of these means you are blocked)
+
+- HTTP 429 / "rate limit" / "too many requests" from Anthropic, OpenAI, GitHub, Vercel, AWS, or any external API
+- Build or test hangs > 5 min with no output
+- `make check` / `make test` / `make test-e2e` failing in a way you cannot diagnose in 2 attempts
+- Merge conflict on rebase or PR
+- Codex / agent stops to ask "approval required" / "needs review"
+- Tooling auth failed (gh CLI, AWS, npm registry)
+
+### Recovery procedure (in order — do not skip)
+
+1. **Print a clearly-keyworded line** so clawhip catches it. Use one of: `rate limit`, `merge conflict`, `tests failed`, `error TS`, `approval required`, `blocked`, `needs review`, `auth failed` — verbatim.
+2. **Log the blocker** to `private/recovery-log.jsonl` (gitignored) with timestamp, signal type, and one-line context.
+3. **Backoff schedule for rate limits**: 1 min → 5 min → 15 min → 30 min → 60 min → 2 h. Never sleep longer than 2 h in one stretch.
+4. **Do not pause the whole agent**. Switch to fallback work (see below) and emit a heartbeat every 4 min so clawhip stale-detection does not fire.
+5. **For merge conflicts**: rebase on `staging` (never `main`), resolve in favor of the more recent semantically-correct change, run `make check && make test`, force-push the agent branch. Never abandon the PR.
+6. **For test failures you cannot fix in 2 attempts**: emit `tests failed: <one-line>`, switch to fallback work, retry the failing test set later with a fresh shell.
+7. **After 4 failed retry rounds** (≈3.75 h cumulative blocked on the same task): emit `blocked: <task> exceeded all retries — needs human review`, stop attempting that task for the day, continue all other work.
+
+### Fallback work while blocked (always available, never empty)
+
+In priority order — if the current task is stuck, pick the next available item:
+
+1. Review other open PRs labeled `agent:shadowfax` and finish anything ready to merge into `staging`.
+2. Run `make check && make test` on a clean checkout of `staging` and report any drift.
+3. Pick another open issue labeled `agent:shadowfax` and start it (claim per the GitHub Claim Labels section).
+4. Lint/format pass: `make check` then commit any auto-fix output.
+5. Documentation polish in `docs/` or inline comments where coverage is thin.
+6. Tidy `private/recovery-log.jsonl` and reconcile with closed issues.
+
+### Hard rules
+
+- Never wait silently. clawhip's stale-detection fires after 5 minutes of no pane output — emit at least one line per 4 minutes.
+- Never weaken or delete tests to make them pass.
+- Never push to `main`. Always branch -> PR into `staging` -> verify -> merge into `staging` only.
+- Never use `--no-verify` / `--no-gpg-sign` / `git push --force` to main.
+- If you discover a blocker that genuinely requires human judgment (security, payment, account access), emit `needs human: <one-line>` and continue with fallback work.
+
+### Heartbeat format
+
+Every 4 minutes minimum during long-running work, print one line:
+```
+[heartbeat] <iso8601> | task=<short> | status=<running|sleeping|fallback> | next=<one-line>
+```
+
+This keeps the autonomous loop alive and gives clawhip a clean trail.

--- a/public/docs-search-shortcut.js
+++ b/public/docs-search-shortcut.js
@@ -1,0 +1,16 @@
+(function () {
+  if (window.__docsSearchBootstrapInstalled) return;
+  window.__docsSearchBootstrapInstalled = true;
+  window.__docsSearchRequested = false;
+
+  document.addEventListener("keydown", function (event) {
+    if (
+      String(event.key).toLowerCase() === "k" &&
+      (event.metaKey || event.ctrlKey)
+    ) {
+      event.preventDefault();
+      window.__docsSearchRequested = true;
+      document.dispatchEvent(new CustomEvent("open-search"));
+    }
+  });
+})();

--- a/src/app/[orgSlug]/[projectSlug]/home/page.tsx
+++ b/src/app/[orgSlug]/[projectSlug]/home/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/app/dashboard/page";

--- a/src/app/[orgSlug]/[projectSlug]/layout.tsx
+++ b/src/app/[orgSlug]/[projectSlug]/layout.tsx
@@ -1,0 +1,9 @@
+import { DashboardShell } from "@/components/layout/dashboard-shell";
+
+export default function MintlifyWorkspaceLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <DashboardShell>{children}</DashboardShell>;
+}

--- a/src/app/api/test/create-session/route.ts
+++ b/src/app/api/test/create-session/route.ts
@@ -5,12 +5,267 @@ import {
   session as authSessions,
   user as authUsers,
 } from "@/lib/db/auth-schema";
-import { orgMemberships, organizations, projects } from "@/lib/db/schema";
+import {
+  orgMemberships,
+  organizations,
+  pages,
+  projects,
+} from "@/lib/db/schema";
 import { slugify } from "@/lib/orgs";
 import { generateSubdomain, slugifyProject } from "@/lib/projects";
 import { serializeSignedCookie } from "better-call";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
+
+const FIXTURE_ORG_SLUG = "playwright-docs-fixtures";
+const FIXTURE_PROJECT_SLUG = "test-project";
+const FIXTURE_SUBDOMAIN = "test-project";
+
+const FIXTURE_OPENAPI_SPEC = {
+  openapi: "3.0.3",
+  info: { title: "Fixture API", version: "1.0.0" },
+  servers: [{ url: "https://api.example.com" }],
+  paths: {
+    "/plants": {
+      get: {
+        operationId: "getPlants",
+        summary: "Get Plants",
+        description: "Returns a list of plants.",
+        tags: ["Plants"],
+        parameters: [
+          {
+            name: "limit",
+            in: "query",
+            required: false,
+            description: "Maximum number of plants to return.",
+            schema: { type: "integer", default: 10 },
+          },
+        ],
+        responses: {
+          "200": { description: "A list of plants." },
+          "400": { description: "Invalid request." },
+        },
+      },
+    },
+  },
+};
+
+const FIXTURE_PROJECT_SETTINGS = {
+  supportEmail: "support@example.com",
+  githubUrl: "https://github.com/namuh-eng/opendocs",
+  docsConfig: {
+    footer: {
+      brandName: "OpenDocs",
+      brandUrl: "https://example.com",
+      socialLinks: [
+        { type: "github", url: "https://github.com/namuh-eng/opendocs" },
+      ],
+    },
+    apiDocs: {
+      playgroundEnabled: true,
+      baseApiUrl: "https://api.example.com",
+    },
+    assistantSearch: {
+      assistantEnabled: true,
+      searchEnabled: true,
+      searchPrompt: "Search the fixture docs...",
+    },
+  },
+  languages: {
+    enabled: true,
+    defaultLanguage: "en",
+    supportedLanguages: ["en", "fr"],
+  },
+  versions: {
+    enabled: true,
+    versions: [
+      { tag: "v2", name: "Version 2.0", isDefault: true },
+      { tag: "v1", name: "Version 1.0", isDefault: false },
+    ],
+  },
+  openApiSpec: FIXTURE_OPENAPI_SPEC,
+};
+
+const FIXTURE_PAGES = [
+  {
+    path: "introduction",
+    title: "Introduction",
+    description: "Welcome to the Playwright docs fixture.",
+    content: `# Introduction
+
+This stable fixture powers public docs route E2E coverage.
+
+## Getting started
+
+Use the quickstart to make your first request.
+
+### Install the package
+
+Install the SDK before continuing.
+
+## Configure navigation
+
+Navigation, pagination, and table of contents are verified from this page.
+`,
+  },
+  {
+    path: "quickstart",
+    title: "Quickstart",
+    description: "Get running quickly with the fixture docs.",
+    content: `# Quickstart
+
+This quickstart contains enough sections for layout, search, and TOC tests.
+
+## Create a project
+
+Create a docs project and publish your first page.
+
+## Install the SDK
+
+Install dependencies and configure authentication.
+
+## Make your first request
+
+Call the Plants API and inspect the response.
+`,
+  },
+  {
+    path: "getting-started",
+    title: "Getting Started",
+    description: "Searchable getting started content.",
+    content: `# Getting Started
+
+Search tests query this page for getting started and install guidance.
+
+## Install
+
+Install the package and configure your environment.
+`,
+  },
+  {
+    path: "guides/quickstart",
+    title: "Guide Quickstart",
+    description: "Nested guide page for breadcrumb coverage.",
+    content: `# Guide Quickstart
+
+Nested guide content for page chrome tests.
+
+## Guide section
+
+This heading appears in the table of contents.
+`,
+  },
+  {
+    path: "fr/introduction",
+    title: "Introduction",
+    description: "Page d’introduction en français.",
+    content: `# Introduction
+
+Contenu de test en français.
+`,
+  },
+  {
+    path: "v1/introduction",
+    title: "Introduction",
+    description: "Version 1 introduction page.",
+    content: `# Introduction
+
+Version 1 fixture content.
+`,
+  },
+  {
+    path: "v1/fr/introduction",
+    title: "Introduction",
+    description: "Version 1 French introduction page.",
+    content: `# Introduction
+
+Contenu français pour la version 1.
+`,
+  },
+];
+
+async function ensureDocsFixtureProject() {
+  let [org] = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(eq(organizations.slug, FIXTURE_ORG_SLUG))
+    .limit(1);
+
+  if (!org) {
+    [org] = await db
+      .insert(organizations)
+      .values({
+        name: "Playwright Docs Fixtures",
+        slug: FIXTURE_ORG_SLUG,
+      })
+      .returning({ id: organizations.id });
+  }
+
+  if (!org) return;
+
+  let [project] = await db
+    .select({ id: projects.id })
+    .from(projects)
+    .where(eq(projects.subdomain, FIXTURE_SUBDOMAIN))
+    .limit(1);
+
+  if (!project) {
+    [project] = await db
+      .insert(projects)
+      .values({
+        orgId: org.id,
+        name: "Test Project",
+        slug: FIXTURE_PROJECT_SLUG,
+        subdomain: FIXTURE_SUBDOMAIN,
+        status: "active",
+        settings: FIXTURE_PROJECT_SETTINGS,
+      })
+      .returning({ id: projects.id });
+  } else {
+    await db
+      .update(projects)
+      .set({
+        name: "Test Project",
+        subdomain: FIXTURE_SUBDOMAIN,
+        status: "active",
+        settings: FIXTURE_PROJECT_SETTINGS,
+      })
+      .where(eq(projects.id, project.id));
+  }
+
+  if (!project) return;
+
+  for (const fixturePage of FIXTURE_PAGES) {
+    const [existingPage] = await db
+      .select({ id: pages.id })
+      .from(pages)
+      .where(
+        and(eq(pages.projectId, project.id), eq(pages.path, fixturePage.path)),
+      )
+      .limit(1);
+
+    const pageValues = {
+      title: fixturePage.title,
+      description: fixturePage.description,
+      content: fixturePage.content,
+      frontmatter: {},
+      isPublished: true,
+    };
+
+    if (existingPage) {
+      await db
+        .update(pages)
+        .set(pageValues)
+        .where(eq(pages.id, existingPage.id));
+    } else {
+      await db.insert(pages).values({
+        projectId: project.id,
+        path: fixturePage.path,
+        ...pageValues,
+      });
+    }
+  }
+}
 
 // Test-only route for creating sessions in E2E tests.
 // Only available in dedicated test environments.
@@ -142,6 +397,8 @@ export async function POST(request: Request) {
       });
     }
   }
+
+  await ensureDocsFixtureProject();
 
   await db.delete(authSessions).where(eq(authSessions.userId, existingUser.id));
 

--- a/src/app/dashboard/dashboard-home-client.tsx
+++ b/src/app/dashboard/dashboard-home-client.tsx
@@ -54,6 +54,9 @@ interface ProjectInfo {
   subdomain: string | null;
   status: string;
   customDomain: string | null;
+  repoUrl: string | null;
+  repoBranch: string | null;
+  repoPath: string | null;
 }
 
 interface ManualHandoffRow {
@@ -132,6 +135,18 @@ const ICON_MAP = {
   settings: Settings,
   "bar-chart": BarChart3,
 } as const;
+
+function parseRepoOwner(repoUrl: string | null) {
+  if (!repoUrl) return null;
+
+  const match = repoUrl.match(/github\.com[:/]([^/]+)\//i);
+  return match?.[1] ?? null;
+}
+
+function formatRepoPath(repoPath: string | null) {
+  if (!repoPath || repoPath === "/") return null;
+  return repoPath.replace(/^\//, "");
+}
 
 function ProjectStatusBadge({ status }: { status: string }) {
   const isLive = status === "active";
@@ -363,6 +378,9 @@ export function DashboardHomeClient({
   const domainDisplay = project
     ? formatDomainDisplay(project.subdomain, project.customDomain)
     : "";
+  const repoOwner = project ? parseRepoOwner(project.repoUrl) : null;
+  const repoPath = project ? formatRepoPath(project.repoPath) : null;
+  const repoBranch = project?.repoBranch ?? null;
 
   const quickActions = project ? buildQuickActionCards(project.id) : [];
   // Fill in the view-site href dynamically
@@ -580,6 +598,26 @@ export function DashboardHomeClient({
                 </a>
               </div>
 
+              {(repoOwner || repoPath || repoBranch) && (
+                <div className="flex items-center gap-2 rounded-lg border border-white/[0.08] bg-[#1a1a1a] px-3 py-2 text-xs text-gray-400">
+                  {repoOwner && (
+                    <span className="text-gray-300">{repoOwner}</span>
+                  )}
+                  {repoPath && (
+                    <>
+                      <span className="text-gray-600">/</span>
+                      <span className="text-gray-300">{repoPath}</span>
+                    </>
+                  )}
+                  {repoBranch && (
+                    <>
+                      <span className="text-gray-600">branch</span>
+                      <span className="text-white">{repoBranch}</span>
+                    </>
+                  )}
+                </div>
+              )}
+
               {/* Domain info */}
               <div className="pt-2 space-y-1">
                 <p className="text-xs font-medium text-gray-500">Domain</p>
@@ -663,210 +701,215 @@ export function DashboardHomeClient({
           </div>
 
           {/* Manual follow-up queue */}
-          <div className="mb-6 rounded-xl border border-amber-400/20 bg-amber-400/[0.06] p-4">
-            <div className="flex items-start justify-between gap-4 mb-3">
-              <div>
-                <h3 className="text-sm font-medium text-white">
-                  Manual follow-up queue
-                </h3>
-                <p className="text-xs text-gray-400 mt-1">
-                  Recent async work that was recorded without a live executor.
-                </p>
+          {(unresolvedCount > 0 || resolvedCount > 0) && (
+            <div className="mb-6 rounded-xl border border-amber-400/20 bg-amber-400/[0.06] p-4">
+              <div className="flex items-start justify-between gap-4 mb-3">
+                <div>
+                  <h3 className="text-sm font-medium text-white">
+                    Manual follow-up queue
+                  </h3>
+                  <p className="text-xs text-gray-400 mt-1">
+                    Recent async work that was recorded without a live executor.
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-amber-300">
+                    {displayedManualHandoffs.length} shown
+                  </span>
+                  {sortedManualHandoffs.length > 5 ? (
+                    <button
+                      type="button"
+                      onClick={() => setShowAllHandoffs((current) => !current)}
+                      className="text-xs text-gray-400 hover:text-white transition-colors"
+                    >
+                      {showAllHandoffs ? "Show less" : "View all"}
+                    </button>
+                  ) : null}
+                </div>
               </div>
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-amber-300">
-                  {displayedManualHandoffs.length} shown
-                </span>
-                {sortedManualHandoffs.length > 5 ? (
+
+              {handoffNotice ? (
+                <div className="mb-3 rounded-md border border-emerald-400/20 bg-emerald-400/10 px-3 py-2 text-xs text-emerald-200 flex items-center justify-between">
+                  <span>{handoffNotice}</span>
                   <button
                     type="button"
-                    onClick={() => setShowAllHandoffs((current) => !current)}
-                    className="text-xs text-gray-400 hover:text-white transition-colors"
+                    onClick={() => setHandoffNotice(null)}
+                    className="text-emerald-400 hover:text-emerald-300"
                   >
-                    {showAllHandoffs ? "Show less" : "View all"}
+                    <Plus size={14} className="rotate-45" />
                   </button>
-                ) : null}
-              </div>
-            </div>
+                </div>
+              ) : null}
 
-            {handoffNotice ? (
-              <div className="mb-3 rounded-md border border-emerald-400/20 bg-emerald-400/10 px-3 py-2 text-xs text-emerald-200 flex items-center justify-between">
-                <span>{handoffNotice}</span>
-                <button
-                  type="button"
-                  onClick={() => setHandoffNotice(null)}
-                  className="text-emerald-400 hover:text-emerald-300"
-                >
-                  <Plus size={14} className="rotate-45" />
-                </button>
-              </div>
-            ) : null}
-
-            <div className="mb-3 grid grid-cols-4 gap-2 text-xs">
-              <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-gray-300">
-                <span className="block text-gray-500">Unresolved</span>
-                <span className="text-white">{unresolvedCount}</span>
-              </div>
-              <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-gray-300">
-                <span className="block text-gray-500">Resolved</span>
-                <span className="text-white">{resolvedCount}</span>
-              </div>
-              <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-gray-300">
-                <span className="block text-gray-500">Avg resolve time</span>
-                <span className="text-white">
-                  {averageResolvedDuration ?? "—"}
-                </span>
-              </div>
-              <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-gray-300">
-                <span className="block text-gray-500">Oldest unresolved</span>
-                <span className="text-white">{oldestUnresolvedAge ?? "—"}</span>
-              </div>
-            </div>
-
-            <div className="flex items-center justify-between gap-3 mb-3">
-              <div className="flex items-center gap-2">
-                <button
-                  type="button"
-                  onClick={() => setHandoffView("active")}
-                  className={clsx(
-                    "px-2.5 py-1 rounded-md text-xs transition-colors",
-                    handoffView === "active"
-                      ? "bg-white/[0.12] text-white"
-                      : "text-gray-400 hover:text-white hover:bg-white/[0.06]",
-                  )}
-                >
-                  Active
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setHandoffView("resolved")}
-                  className={clsx(
-                    "px-2.5 py-1 rounded-md text-xs transition-colors",
-                    handoffView === "resolved"
-                      ? "bg-white/[0.12] text-white"
-                      : "text-gray-400 hover:text-white hover:bg-white/[0.06]",
-                  )}
-                >
-                  Resolved
-                </button>
+              <div className="mb-3 grid grid-cols-4 gap-2 text-xs">
+                <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-gray-300">
+                  <span className="block text-gray-500">Unresolved</span>
+                  <span className="text-white">{unresolvedCount}</span>
+                </div>
+                <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-gray-300">
+                  <span className="block text-gray-500">Resolved</span>
+                  <span className="text-white">{resolvedCount}</span>
+                </div>
+                <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-gray-300">
+                  <span className="block text-gray-500">Avg resolve time</span>
+                  <span className="text-white">
+                    {averageResolvedDuration ?? "—"}
+                  </span>
+                </div>
+                <div className="rounded-md border border-white/[0.06] bg-black/20 px-3 py-2 text-gray-300">
+                  <span className="block text-gray-500">Oldest unresolved</span>
+                  <span className="text-white">
+                    {oldestUnresolvedAge ?? "—"}
+                  </span>
+                </div>
               </div>
 
-              <div className="flex items-center gap-2">
-                {HANDOFF_FILTERS.map((filter) => (
+              <div className="flex items-center justify-between gap-3 mb-3">
+                <div className="flex items-center gap-2">
                   <button
-                    key={filter.key}
                     type="button"
-                    onClick={() => setHandoffFilter(filter.key)}
+                    onClick={() => setHandoffView("active")}
                     className={clsx(
                       "px-2.5 py-1 rounded-md text-xs transition-colors",
-                      handoffFilter === filter.key
+                      handoffView === "active"
                         ? "bg-white/[0.12] text-white"
                         : "text-gray-400 hover:text-white hover:bg-white/[0.06]",
                     )}
                   >
-                    {filter.label}
+                    Active
                   </button>
-                ))}
-                <select
-                  value={handoffSort}
-                  onChange={(event) =>
-                    setHandoffSort(
-                      event.target.value as
-                        | "newest"
-                        | "oldest"
-                        | "longest-open",
-                    )
-                  }
-                  className="rounded-md border border-white/[0.08] bg-black/20 px-2 py-1 text-xs text-gray-300 focus:outline-none"
-                >
-                  <option value="newest">Newest</option>
-                  <option value="oldest">Oldest</option>
-                  <option value="longest-open">Longest open</option>
-                </select>
-              </div>
-            </div>
-
-            {filteredManualHandoffs.length === 0 ? (
-              <p className="text-sm text-gray-500">
-                No manual handoffs recorded recently.
-              </p>
-            ) : (
-              <div className="space-y-2">
-                {displayedManualHandoffs.map((handoff) => (
-                  <div
-                    key={handoff.id}
-                    className="flex items-center justify-between gap-3 rounded-lg border border-white/[0.06] bg-black/20 px-3 py-2"
+                  <button
+                    type="button"
+                    onClick={() => setHandoffView("resolved")}
+                    className={clsx(
+                      "px-2.5 py-1 rounded-md text-xs transition-colors",
+                      handoffView === "resolved"
+                        ? "bg-white/[0.12] text-white"
+                        : "text-gray-400 hover:text-white hover:bg-white/[0.06]",
+                    )}
                   >
-                    <div className="min-w-0">
-                      <p className="text-sm text-white truncate">
-                        {handoff.action}
-                      </p>
-                      <p className="text-xs text-gray-500 truncate">
-                        {String(
-                          handoff.details.projectId ??
-                            handoff.details.deploymentId ??
-                            handoff.details.jobId ??
-                            "manual follow-up required",
-                        )}
-                      </p>
-                      {handoffView === "resolved" &&
-                      handoff.details.resolution ? (
-                        <>
-                          <p className="text-xs text-gray-500 truncate mt-1">
-                            Created {timeAgo(handoff.createdAt)}
-                            {handoff.details.resolution.resolvedAt
-                              ? ` • Resolved ${timeAgo(handoff.details.resolution.resolvedAt)}`
-                              : ""}
-                            {handoff.details.resolution.resolvedAt
-                              ? ` • ${formatDuration(handoff.createdAt, handoff.details.resolution.resolvedAt) ?? ""}`
-                              : ""}
-                          </p>
-                          <p className="text-xs text-gray-500 truncate mt-1">
-                            Resolved by{" "}
-                            {handoff.details.resolution.resolvedByName ??
-                              handoff.details.resolution.resolvedByUserId ??
-                              "unknown"}
-                          </p>
-                          {handoff.details.resolution.resolutionNote ? (
-                            <p className="text-xs text-gray-400 mt-1 line-clamp-2">
-                              Note: {handoff.details.resolution.resolutionNote}
-                            </p>
-                          ) : null}
-                        </>
-                      ) : null}
-                    </div>
-                    <div className="flex items-center gap-3 shrink-0">
-                      <span className="text-xs text-gray-400">
-                        {timeAgo(handoff.createdAt)}
-                      </span>
-                      {handoffView === "active" ? (
-                        <div className="flex items-center gap-2">
-                          <button
-                            type="button"
-                            onClick={() => deleteHandoff(handoff.id)}
-                            className="p-1.5 rounded-md text-gray-500 hover:text-red-400 hover:bg-red-400/10 transition-colors"
-                            title="Delete record"
-                          >
-                            <Trash2 size={14} />
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => resolveHandoff(handoff.id)}
-                            disabled={resolvingHandoffId === handoff.id}
-                            className="px-2 py-1 rounded-md text-xs bg-emerald-500/15 text-emerald-300 hover:bg-emerald-500/25 disabled:opacity-50 transition-colors"
-                          >
-                            {resolvingHandoffId === handoff.id
-                              ? "Resolving..."
-                              : "Resolve"}
-                          </button>
-                        </div>
-                      ) : null}
-                    </div>
-                  </div>
-                ))}
+                    Resolved
+                  </button>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  {HANDOFF_FILTERS.map((filter) => (
+                    <button
+                      key={filter.key}
+                      type="button"
+                      onClick={() => setHandoffFilter(filter.key)}
+                      className={clsx(
+                        "px-2.5 py-1 rounded-md text-xs transition-colors",
+                        handoffFilter === filter.key
+                          ? "bg-white/[0.12] text-white"
+                          : "text-gray-400 hover:text-white hover:bg-white/[0.06]",
+                      )}
+                    >
+                      {filter.label}
+                    </button>
+                  ))}
+                  <select
+                    value={handoffSort}
+                    onChange={(event) =>
+                      setHandoffSort(
+                        event.target.value as
+                          | "newest"
+                          | "oldest"
+                          | "longest-open",
+                      )
+                    }
+                    className="rounded-md border border-white/[0.08] bg-black/20 px-2 py-1 text-xs text-gray-300 focus:outline-none"
+                  >
+                    <option value="newest">Newest</option>
+                    <option value="oldest">Oldest</option>
+                    <option value="longest-open">Longest open</option>
+                  </select>
+                </div>
               </div>
-            )}
-          </div>
+
+              {filteredManualHandoffs.length === 0 ? (
+                <p className="text-sm text-gray-500">
+                  No manual handoffs recorded recently.
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {displayedManualHandoffs.map((handoff) => (
+                    <div
+                      key={handoff.id}
+                      className="flex items-center justify-between gap-3 rounded-lg border border-white/[0.06] bg-black/20 px-3 py-2"
+                    >
+                      <div className="min-w-0">
+                        <p className="text-sm text-white truncate">
+                          {handoff.action}
+                        </p>
+                        <p className="text-xs text-gray-500 truncate">
+                          {String(
+                            handoff.details.projectId ??
+                              handoff.details.deploymentId ??
+                              handoff.details.jobId ??
+                              "manual follow-up required",
+                          )}
+                        </p>
+                        {handoffView === "resolved" &&
+                        handoff.details.resolution ? (
+                          <>
+                            <p className="text-xs text-gray-500 truncate mt-1">
+                              Created {timeAgo(handoff.createdAt)}
+                              {handoff.details.resolution.resolvedAt
+                                ? ` • Resolved ${timeAgo(handoff.details.resolution.resolvedAt)}`
+                                : ""}
+                              {handoff.details.resolution.resolvedAt
+                                ? ` • ${formatDuration(handoff.createdAt, handoff.details.resolution.resolvedAt) ?? ""}`
+                                : ""}
+                            </p>
+                            <p className="text-xs text-gray-500 truncate mt-1">
+                              Resolved by{" "}
+                              {handoff.details.resolution.resolvedByName ??
+                                handoff.details.resolution.resolvedByUserId ??
+                                "unknown"}
+                            </p>
+                            {handoff.details.resolution.resolutionNote ? (
+                              <p className="text-xs text-gray-400 mt-1 line-clamp-2">
+                                Note:{" "}
+                                {handoff.details.resolution.resolutionNote}
+                              </p>
+                            ) : null}
+                          </>
+                        ) : null}
+                      </div>
+                      <div className="flex items-center gap-3 shrink-0">
+                        <span className="text-xs text-gray-400">
+                          {timeAgo(handoff.createdAt)}
+                        </span>
+                        {handoffView === "active" ? (
+                          <div className="flex items-center gap-2">
+                            <button
+                              type="button"
+                              onClick={() => deleteHandoff(handoff.id)}
+                              className="p-1.5 rounded-md text-gray-500 hover:text-red-400 hover:bg-red-400/10 transition-colors"
+                              title="Delete record"
+                            >
+                              <Trash2 size={14} />
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => resolveHandoff(handoff.id)}
+                              disabled={resolvingHandoffId === handoff.id}
+                              className="px-2 py-1 rounded-md text-xs bg-emerald-500/15 text-emerald-300 hover:bg-emerald-500/25 disabled:opacity-50 transition-colors"
+                            >
+                              {resolvingHandoffId === handoff.id
+                                ? "Resolving..."
+                                : "Resolve"}
+                            </button>
+                          </div>
+                        ) : null}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
 
           {/* Activity section */}
           <div>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -18,7 +18,14 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { DashboardHomeClient } from "./dashboard-home-client";
 
-export default async function DashboardPage() {
+interface DashboardPageProps {
+  params?: Promise<{ orgSlug?: string; projectSlug?: string }>;
+}
+
+export default async function DashboardPage({
+  params,
+}: DashboardPageProps = {}) {
+  const routeParams = await params;
   const session = await getServerSession();
   if (!session) redirect("/login");
 
@@ -35,7 +42,14 @@ export default async function DashboardPage() {
     })
     .from(orgMemberships)
     .innerJoin(organizations, eq(orgMemberships.orgId, organizations.id))
-    .where(eq(orgMemberships.userId, session.user.id))
+    .where(
+      routeParams?.orgSlug
+        ? and(
+            eq(orgMemberships.userId, session.user.id),
+            eq(organizations.slug, routeParams.orgSlug),
+          )
+        : eq(orgMemberships.userId, session.user.id),
+    )
     .limit(1);
 
   if (membership.length === 0) redirect("/onboarding");
@@ -49,7 +63,11 @@ export default async function DashboardPage() {
     .orderBy(projects.createdAt);
 
   const activeProjectId = (await cookies()).get(ACTIVE_PROJECT_COOKIE)?.value;
-  const project = findActiveProject(orgProjects, activeProjectId);
+  const project = routeParams?.projectSlug
+    ? (orgProjects.find(
+        (candidate) => candidate.slug === routeParams.projectSlug,
+      ) ?? findActiveProject(orgProjects, activeProjectId))
+    : findActiveProject(orgProjects, activeProjectId);
 
   type DeploymentRow = {
     id: string;
@@ -204,8 +222,7 @@ export default async function DashboardPage() {
     }
   }
 
-  const isPublishedProjectLive =
-    project?.status === "active" && publishedPageCount > 0;
+  const isPublishedProjectLive = project?.status === "active";
   const visibleManualHandoffs = manualHandoffs.filter((handoff) => {
     const detailsProjectId = handoff.details.projectId;
     if (
@@ -233,6 +250,9 @@ export default async function DashboardPage() {
               id: project.id,
               name: project.name,
               subdomain: project.subdomain,
+              repoUrl: project.repoUrl,
+              repoBranch: project.repoBranch,
+              repoPath: project.repoPath,
               status: projectDisplayStatus({
                 projectStatus: project.status,
                 publishedPageCount,

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -42,14 +42,7 @@ export default async function DashboardPage({
     })
     .from(orgMemberships)
     .innerJoin(organizations, eq(orgMemberships.orgId, organizations.id))
-    .where(
-      routeParams?.orgSlug
-        ? and(
-            eq(orgMemberships.userId, session.user.id),
-            eq(organizations.slug, routeParams.orgSlug),
-          )
-        : eq(orgMemberships.userId, session.user.id),
-    )
+    .where(eq(orgMemberships.userId, session.user.id))
     .limit(1);
 
   if (membership.length === 0) redirect("/onboarding");

--- a/src/app/docs/[subdomain]/[...slug]/page.tsx
+++ b/src/app/docs/[subdomain]/[...slug]/page.tsx
@@ -105,22 +105,6 @@ function applyProjectBrandCasing(title: string, projectName: string): string {
     : title;
 }
 
-function applyProjectBrandCasingToContent(
-  content: string,
-  projectName: string,
-): string {
-  const brandName = projectName.replace(/\s+docs$/i, "").trim();
-  if (!brandName || !/^[a-z0-9]+$/i.test(brandName)) return content;
-
-  return content.replace(
-    new RegExp(
-      `\\b${brandName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`,
-      "gi",
-    ),
-    brandName,
-  );
-}
-
 export async function generateMetadata({
   params,
 }: DocsPageProps): Promise<Metadata> {
@@ -455,10 +439,7 @@ export default async function DocsPage({
     // Render DB page (existing behavior)
     pageTitle = applyProjectBrandCasing(currentPage.title, project.name);
     pageDescription = currentPage.description || "";
-    pageContent = applyProjectBrandCasingToContent(
-      currentPage.content || "",
-      project.name,
-    );
+    pageContent = currentPage.content || "";
 
     // Resolve snippets and variables before rendering
     const snippetPages = allPages

--- a/src/app/docs/[subdomain]/[...slug]/page.tsx
+++ b/src/app/docs/[subdomain]/[...slug]/page.tsx
@@ -77,6 +77,50 @@ interface DocsPageProps {
 
 const APP_URL = getPublicAppUrl();
 
+function normalizeHeadingText(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[`*_~]/g, "")
+    .replace(/<[^>]+>/g, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function stripLeadingDuplicateH1(content: string, title: string): string {
+  const match = content.match(/^\s*#\s+(.+?)\s*(?:\r?\n|$)/);
+  if (!match) return content;
+
+  return normalizeHeadingText(match[1] ?? "") === normalizeHeadingText(title)
+    ? content.slice(match[0].length).replace(/^\s*\r?\n/, "")
+    : content;
+}
+
+function applyProjectBrandCasing(title: string, projectName: string): string {
+  const brandName = projectName.replace(/\s+docs$/i, "").trim();
+  if (!brandName) return title;
+
+  return normalizeHeadingText(title).replace(/\s+/g, "") ===
+    normalizeHeadingText(brandName).replace(/\s+/g, "")
+    ? brandName
+    : title;
+}
+
+function applyProjectBrandCasingToContent(
+  content: string,
+  projectName: string,
+): string {
+  const brandName = projectName.replace(/\s+docs$/i, "").trim();
+  if (!brandName || !/^[a-z0-9]+$/i.test(brandName)) return content;
+
+  return content.replace(
+    new RegExp(
+      `\\b${brandName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`,
+      "gi",
+    ),
+    brandName,
+  );
+}
+
 export async function generateMetadata({
   params,
 }: DocsPageProps): Promise<Metadata> {
@@ -356,7 +400,7 @@ export default async function DocsPage({
   const navPages = allPages.map((p) => ({
     id: p.id,
     path: p.path,
-    title: p.title,
+    title: applyProjectBrandCasing(p.title, project.name),
     frontmatter: p.frontmatter as Record<string, unknown> | null,
   }));
 
@@ -409,9 +453,12 @@ export default async function DocsPage({
     }
   } else if (currentPage) {
     // Render DB page (existing behavior)
-    pageTitle = currentPage.title;
+    pageTitle = applyProjectBrandCasing(currentPage.title, project.name);
     pageDescription = currentPage.description || "";
-    pageContent = currentPage.content || "";
+    pageContent = applyProjectBrandCasingToContent(
+      currentPage.content || "",
+      project.name,
+    );
 
     // Resolve snippets and variables before rendering
     const snippetPages = allPages
@@ -425,7 +472,8 @@ export default async function DocsPage({
       projectVars,
     );
 
-    let contentToRender = pageContent;
+    let contentToRender = stripLeadingDuplicateH1(pageContent, pageTitle);
+    pageContent = contentToRender;
     contentToRender = resolveSnippets(contentToRender, snippetPages);
     contentToRender = resolveVariables(contentToRender, variables);
     renderedHtml = renderMdxContent(contentToRender);

--- a/src/app/docs/[subdomain]/[...slug]/page.tsx
+++ b/src/app/docs/[subdomain]/[...slug]/page.tsx
@@ -568,6 +568,8 @@ export default async function DocsPage({
         }
       />
 
+      {/* Capture Cmd/Ctrl+K before React hydration so fast navigations still open search. */}
+      <script src="/docs-search-shortcut.js" />
       <SearchModal pages={searchablePages} subdomain={subdomain} />
       <MobileSidebar
         nav={nav}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,10 +29,32 @@ body {
 /* ── Docs Site Layout ──────────────────────────────────────────────────────── */
 
 .docs-layout {
+  --docs-bg: #080d0c;
+  --docs-bg-deep: #050908;
+  --docs-surface: rgba(255, 255, 255, 0.045);
+  --docs-surface-hover: rgba(255, 255, 255, 0.075);
+  --docs-border: rgba(255, 255, 255, 0.075);
+  --docs-border-strong: rgba(255, 255, 255, 0.13);
+  --docs-text: #f7faf8;
+  --docs-text-muted: #9aa39f;
+  --docs-text-subtle: #6f7874;
+  --docs-green: #00e887;
+  --docs-green-soft: rgba(0, 232, 135, 0.11);
+  --docs-green-border: rgba(0, 232, 135, 0.32);
+  --docs-card: #0b1110;
+}
+
+.docs-layout {
   min-height: 100vh;
-  background: #090d0d;
-  color: #e5e7eb;
-  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  background: radial-gradient(
+      circle at 55% -12%,
+      rgba(0, 232, 135, 0.07),
+      transparent 28rem
+    ), var(--docs-bg);
+  color: var(--docs-text);
+  font-family: "Inter", ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-feature-settings: "cv02", "cv03", "cv04", "cv11";
 }
 
 /* Top bar */
@@ -40,14 +62,14 @@ body {
   position: sticky;
   top: 0;
   z-index: 40;
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) auto minmax(220px, 1fr);
   align-items: center;
-  justify-content: space-between;
-  height: 56px;
-  padding: 0 24px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(9, 13, 13, 0.95);
-  backdrop-filter: blur(8px);
+  height: 52px;
+  padding: 0 28px;
+  border-bottom: 1px solid var(--docs-border);
+  background: color-mix(in srgb, var(--docs-bg-deep) 92%, transparent);
+  backdrop-filter: blur(14px);
 }
 
 .docs-topbar-left {
@@ -65,13 +87,15 @@ body {
 .docs-topbar-center {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 8px;
 }
 
 .docs-topbar-right {
   display: flex;
   align-items: center;
-  gap: 12px;
+  justify-content: flex-end;
+  gap: 10px;
 }
 
 /* Ask AI button */
@@ -141,14 +165,16 @@ body {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 12px;
-  border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(255, 255, 255, 0.04);
-  color: #9ca3af;
+  width: min(30vw, 320px);
+  height: 36px;
+  padding: 0 12px;
+  border-radius: 999px;
+  border: 1px solid var(--docs-border);
+  background: var(--docs-surface);
+  color: var(--docs-text-muted);
   font-size: 13px;
   cursor: pointer;
-  transition: border-color 0.15s;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
 }
 
 .docs-search-btn:hover {
@@ -166,27 +192,33 @@ body {
 
 /* Body: sidebar + main + toc */
 .docs-body {
-  display: flex;
-  max-width: 1440px;
+  display: grid;
+  grid-template-columns: 264px minmax(0, 760px) 236px;
+  gap: 44px;
+  max-width: 1392px;
   margin: 0 auto;
+  padding: 0 28px;
 }
 
 /* Sidebar */
 .docs-sidebar {
   position: sticky;
-  top: 56px;
-  width: 260px;
-  min-width: 260px;
-  height: calc(100vh - 56px);
+  top: 52px;
+  width: 264px;
+  min-width: 0;
+  height: calc(100vh - 52px);
   overflow-y: auto;
-  padding: 16px 0;
-  border-right: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 22px 0 32px;
+  border-right: 0;
+  background: transparent;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.14) transparent;
 }
 
 .docs-sidebar-header {
-  padding: 0 16px 16px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-  margin-bottom: 8px;
+  padding: 0 12px 18px;
+  margin-bottom: 10px;
+  border-bottom: 1px solid var(--docs-border);
 }
 
 .docs-logo {
@@ -211,23 +243,25 @@ body {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 12px;
-  border-radius: 6px;
+  min-height: 32px;
+  padding: 5px 10px;
+  border-radius: 8px;
   font-size: 13px;
-  color: #9ca3af;
+  line-height: 1.35;
+  color: var(--docs-text-muted);
   text-decoration: none;
-  transition: all 0.15s;
+  transition: background 0.15s, color 0.15s;
 }
 
 .docs-nav-item:hover {
-  color: #e5e7eb;
-  background: rgba(255, 255, 255, 0.04);
+  color: var(--docs-text);
+  background: var(--docs-surface);
 }
 
 .docs-nav-item.active {
-  color: #16a34a;
-  background: rgba(22, 163, 74, 0.08);
-  font-weight: 500;
+  color: var(--docs-green);
+  background: var(--docs-green-soft);
+  font-weight: 600;
 }
 
 .docs-nav-group {
@@ -239,12 +273,12 @@ body {
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: 6px 12px;
-  font-size: 12px;
-  font-weight: 600;
-  color: #e5e7eb;
+  padding: 8px 10px 6px;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--docs-text-subtle);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.08em;
   background: none;
   border: none;
   cursor: pointer;
@@ -264,10 +298,9 @@ body {
 
 /* Main content area */
 .docs-main {
-  flex: 1;
   min-width: 0;
-  max-width: 768px;
-  padding: 32px 48px;
+  max-width: 760px;
+  padding: 56px 0 80px;
 }
 
 .docs-breadcrumb {
@@ -293,11 +326,12 @@ body {
 }
 
 .docs-page-title {
-  font-size: 32px;
-  font-weight: 700;
-  color: #f9fafb;
-  margin-bottom: 8px;
-  line-height: 1.2;
+  font-size: clamp(36px, 4vw, 48px);
+  font-weight: 750;
+  letter-spacing: -0.045em;
+  color: var(--docs-text);
+  margin-bottom: 10px;
+  line-height: 1.04;
   flex: 1;
 }
 
@@ -378,22 +412,25 @@ body {
 }
 
 .docs-page-description {
-  font-size: 16px;
-  color: #9ca3af;
-  margin-bottom: 32px;
-  line-height: 1.6;
+  max-width: 660px;
+  font-size: 17px;
+  color: var(--docs-text-muted);
+  margin-bottom: 34px;
+  line-height: 1.65;
 }
 
 /* TOC */
 .docs-toc {
   position: sticky;
-  top: 88px;
-  width: 240px;
-  min-width: 240px;
+  top: 84px;
+  width: 236px;
+  min-width: 0;
   height: fit-content;
-  max-height: calc(100vh - 120px);
+  max-height: calc(100vh - 112px);
   overflow-y: auto;
-  padding: 32px 16px 32px 0;
+  padding: 4px 0 32px;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.14) transparent;
 }
 
 .docs-toc-title {
@@ -405,14 +442,21 @@ body {
   margin-bottom: 12px;
 }
 
+.docs-toc nav {
+  border-left: 1px solid var(--docs-border);
+}
+
 .docs-toc-link {
   display: block;
-  padding: 4px 8px;
-  font-size: 13px;
-  color: #6b7280;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  font-size: 12.5px;
+  line-height: 1.35;
+  color: var(--docs-text-subtle);
   text-decoration: none;
-  border-left: 2px solid transparent;
-  transition: all 0.15s;
+  border-left: 1px solid transparent;
+  transform: translateX(-1px);
+  transition: border-color 0.15s, color 0.15s;
 }
 
 .docs-toc-link:hover {
@@ -420,16 +464,17 @@ body {
 }
 
 .docs-toc-link.active {
-  color: #16a34a;
-  border-left-color: #16a34a;
+  color: var(--docs-green);
+  border-left-color: var(--docs-green);
+  font-weight: 600;
 }
 
 /* ── Docs Content Prose ────────────────────────────────────────────────────── */
 
 .docs-content {
-  font-size: 15px;
-  line-height: 1.7;
-  color: #d1d5db;
+  font-size: 15.5px;
+  line-height: 1.78;
+  color: #c5ccc8;
 }
 
 .docs-content h1,
@@ -449,9 +494,10 @@ body {
   font-size: 28px;
 }
 .docs-content h2 {
-  font-size: 22px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-  padding-bottom: 8px;
+  font-size: 25px;
+  letter-spacing: -0.025em;
+  border-bottom: 1px solid var(--docs-border);
+  padding-bottom: 10px;
 }
 .docs-content h3 {
   font-size: 18px;
@@ -482,12 +528,12 @@ body {
 }
 
 .docs-content p {
-  margin-bottom: 16px;
+  margin-bottom: 18px;
 }
 
 .docs-content a {
-  color: #16a34a;
-  text-decoration: underline;
+  color: var(--docs-green);
+  text-decoration: none;
   text-underline-offset: 3px;
 }
 
@@ -502,12 +548,13 @@ body {
 
 .docs-content code {
   padding: 2px 6px;
-  border-radius: 4px;
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  font-family: "JetBrains Mono", "Fira Code", monospace;
+  border-radius: 6px;
+  background: var(--docs-surface);
+  border: 1px solid var(--docs-border);
+  font-family: "JetBrains Mono", "Fira Code", ui-monospace, SFMono-Regular,
+    Menlo, monospace;
   font-size: 0.875em;
-  color: #e5e7eb;
+  color: var(--docs-text);
 }
 
 .docs-content pre code {
@@ -574,11 +621,12 @@ body {
 
 /* Code blocks */
 .code-block {
-  margin: 16px 0;
-  border-radius: 8px;
-  background: #0f1117;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  margin: 24px 0;
+  border-radius: 16px;
+  background: #08100e;
+  border: 1px solid var(--docs-border);
   overflow: hidden;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.22);
 }
 
 .code-header {
@@ -730,10 +778,11 @@ body {
 
 .card {
   padding: 20px;
-  border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.02);
-  transition: all 0.2s;
+  border-radius: 16px;
+  border: 1px solid var(--docs-border);
+  background: linear-gradient(145deg, rgba(0, 232, 135, 0.055), transparent 48%),
+    var(--docs-card);
+  transition: border-color 0.2s, background 0.2s, transform 0.2s;
 }
 
 .card-link {
@@ -743,8 +792,10 @@ body {
 }
 
 .card-link:hover {
-  border-color: rgba(22, 163, 74, 0.3);
-  background: rgba(22, 163, 74, 0.04);
+  border-color: var(--docs-green-border);
+  background: linear-gradient(145deg, rgba(0, 232, 135, 0.09), transparent 52%),
+    var(--docs-card);
+  transform: translateY(-1px);
 }
 
 .card-icon {
@@ -3621,4 +3672,100 @@ pre.mermaid svg {
 
 [data-theme="light"] .api-ref-param-row {
   border-bottom-color: rgba(0, 0, 0, 0.06);
+}
+
+/* Mintlify-grade docs polish */
+.docs-topbar-ask-ai,
+.docs-theme-toggle,
+.page-action-btn {
+  border-color: var(--docs-border);
+  background: var(--docs-surface);
+  border-radius: 999px;
+}
+
+.docs-topbar-ask-ai:hover,
+.docs-theme-toggle:hover,
+.page-action-btn:hover,
+.docs-search-btn:hover {
+  border-color: var(--docs-border-strong);
+  background: var(--docs-surface-hover);
+  color: var(--docs-text);
+}
+
+.docs-topbar-dashboard-btn {
+  border-radius: 999px;
+  background: var(--docs-green);
+  color: #02130b;
+  font-weight: 650;
+}
+
+.docs-topbar-dashboard-btn:hover {
+  background: #27f59a;
+}
+
+.docs-content > h1:first-child {
+  display: none;
+}
+
+.docs-content img {
+  display: block;
+  width: 100%;
+  margin: 28px 0;
+  border: 1px solid var(--docs-border);
+  border-radius: 18px;
+  background: var(--docs-card);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.28);
+}
+
+.docs-content p:has(img[src*="img.shields.io"]) {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin: 18px 0 24px;
+}
+
+.docs-content p:has(img[src*="img.shields.io"]) img {
+  width: auto;
+  height: 22px;
+  margin: 0;
+  border-radius: 999px;
+  box-shadow: none;
+  background: transparent;
+}
+
+.docs-content hr + p a,
+.docs-content p:has(a) > a:only-child,
+.docs-content p a[href^="#"] {
+  font-weight: 600;
+}
+
+.docs-content blockquote,
+.callout {
+  border-radius: 14px;
+  border-color: var(--docs-green-border);
+  background: var(--docs-green-soft);
+}
+
+@media (max-width: 1180px) {
+  .docs-body {
+    grid-template-columns: 250px minmax(0, 1fr);
+    gap: 34px;
+  }
+
+  .docs-toc {
+    display: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .docs-topbar {
+    display: flex;
+    padding: 0 14px;
+  }
+
+  .docs-body {
+    display: block;
+    padding: 0 16px;
+  }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,6 @@
+import { getServerSession } from "@/lib/session";
 import Link from "next/link";
+import { redirect } from "next/navigation";
 
 const links = [
   {
@@ -19,7 +21,13 @@ const links = [
   },
 ];
 
-export default function Home() {
+export default async function Home() {
+  const session = await getServerSession();
+
+  if (session) {
+    redirect("/dashboard");
+  }
+
   return (
     <main className="min-h-screen bg-[#0b0b0d] text-white">
       <div className="mx-auto flex min-h-screen max-w-6xl flex-col justify-center px-6 py-20">

--- a/src/components/docs/docs-toc.tsx
+++ b/src/components/docs/docs-toc.tsx
@@ -10,7 +10,11 @@ interface DocsTocProps {
 export function DocsToc({ entries }: DocsTocProps) {
   // Filter to H2 and H3 only for display
   const displayEntries = entries.filter((e) => e.level >= 2 && e.level <= 3);
-  const [activeId, setActiveId] = useState<string>("");
+  const [activeId, setActiveId] = useState<string>(displayEntries[0]?.id ?? "");
+
+  useEffect(() => {
+    setActiveId((current) => current || displayEntries[0]?.id || "");
+  }, [displayEntries]);
 
   useEffect(() => {
     if (displayEntries.length === 0) return;

--- a/src/components/docs/mdx-content.tsx
+++ b/src/components/docs/mdx-content.tsx
@@ -18,6 +18,25 @@ export function MdxContent({ html }: MdxContentProps) {
     const container = containerRef.current;
     if (!container) return;
 
+    // Imported READMEs often include dynamic GitHub shields that render as
+    // "invalid" when the source repo is private, renamed, or unavailable. Hide
+    // those volatile social/count badges rather than surfacing broken chrome at
+    // the top of generated docs pages.
+    const volatileBadgeImages = container.querySelectorAll<HTMLImageElement>(
+      'img[src*="img.shields.io/github/stars"], img[src*="img.shields.io/github/issues"]',
+    );
+    for (const img of volatileBadgeImages) {
+      const parentAnchor = img.parentElement;
+      if (
+        parentAnchor?.tagName === "A" &&
+        parentAnchor.textContent?.trim() === ""
+      ) {
+        parentAnchor.remove();
+      } else {
+        img.remove();
+      }
+    }
+
     // Wire up tab switching
     const tabButtons = container.querySelectorAll<HTMLButtonElement>(
       ".tab-bar .tab-button",

--- a/src/components/docs/search-modal.tsx
+++ b/src/components/docs/search-modal.tsx
@@ -27,10 +27,7 @@ interface SearchResultGroup {
 
 /** Returns true if the shortcut should open the search modal */
 export function handleSearchShortcut(event: KeyboardEvent): boolean {
-  if (event.key === "k" && (event.metaKey || event.ctrlKey)) {
-    return true;
-  }
-  return false;
+  return event.key.toLowerCase() === "k" && (event.metaKey || event.ctrlKey);
 }
 
 /** Filter pages by search query (case-insensitive, matches title or path) — client-side fallback */
@@ -50,6 +47,16 @@ export function filterPages(
 
 const RECENT_KEY = "docs-recent-searches";
 const MAX_RECENT = 5;
+
+type DocsSearchWindow = Window & { __docsSearchRequested?: boolean };
+
+function consumePendingSearchRequest(): boolean {
+  if (typeof window === "undefined") return false;
+  const docsWindow = window as DocsSearchWindow;
+  if (!docsWindow.__docsSearchRequested) return false;
+  docsWindow.__docsSearchRequested = false;
+  return true;
+}
 
 function getRecentSearches(): string[] {
   if (typeof window === "undefined") return [];
@@ -211,15 +218,7 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
     function onKeyDown(e: KeyboardEvent) {
       if (handleSearchShortcut(e)) {
         e.preventDefault();
-        setIsOpen((prev) => {
-          if (!prev) {
-            setQuery("");
-            setResults([]);
-            setSelectedIdx(0);
-            setRecentSearches(getRecentSearches());
-          }
-          return !prev;
-        });
+        open();
       }
       if (e.key === "Escape" && isOpen) {
         close();
@@ -227,7 +226,7 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
     }
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [isOpen, close]);
+  }, [isOpen, close, open]);
 
   // Auto-focus input
   useEffect(() => {
@@ -236,9 +235,14 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
     }
   }, [isOpen]);
 
-  // Expose open via custom event
+  // Expose open via custom event and consume any shortcut pressed before hydration.
   useEffect(() => {
+    if (consumePendingSearchRequest()) {
+      open();
+    }
+
     function handleOpenSearch() {
+      consumePendingSearchRequest();
       open();
     }
     document.addEventListener("open-search", handleOpenSearch);

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -56,27 +56,31 @@ const mainNavItems: NavItem[] = [
 
 const agentNavItems: NavItem[] = [
   {
+    label: "Workflows",
+    href: "/products/workflows",
+    icon: <GitBranch size={18} />,
+    badge: "New",
+  },
+  {
     label: "Agent",
     href: "/products/agent",
     icon: <Bot size={18} />,
-    badge: "New",
   },
   {
     label: "Assistant",
     href: "/products/assistant",
     icon: <MessageCircle size={18} />,
   },
-  {
-    label: "Workflows",
-    href: "/products/workflows",
-    icon: <GitBranch size={18} />,
-  },
   { label: "MCP", href: "/products/mcp", icon: <Server size={18} /> },
 ];
 
 function isActive(pathname: string, href: string): boolean {
   if (href === "/dashboard") {
-    return pathname === "/dashboard" || pathname.endsWith("/dashboard");
+    return (
+      pathname === "/dashboard" ||
+      pathname.endsWith("/dashboard") ||
+      pathname.endsWith("/home")
+    );
   }
   return pathname.startsWith(href);
 }
@@ -412,6 +416,31 @@ export function Sidebar({
             ))}
           </div>
         </nav>
+
+        <div className="px-3 pb-3">
+          <Link
+            href="/products/workflows"
+            onClick={() => onCloseMobile?.()}
+            className={clsx(
+              "block rounded-xl border p-3 transition-colors",
+              theme === "light"
+                ? "border-slate-200 bg-slate-50 hover:bg-slate-100"
+                : "border-white/[0.08] bg-white/[0.03] hover:bg-white/[0.06]",
+            )}
+          >
+            <div
+              className={clsx("text-xs font-medium", shellTheme.primaryText)}
+            >
+              Workflows
+            </div>
+            <div className={clsx("mt-1 text-xs", shellTheme.secondaryText)}>
+              Control when the agent takes autonomous actions
+            </div>
+            <div className="mt-2 text-xs font-medium text-emerald-400">
+              Check it out
+            </div>
+          </Link>
+        </div>
 
         <div className={clsx("border-t px-3 py-3", shellTheme.divider)}>
           {isMobile ? (

--- a/src/components/layout/trial-banner.tsx
+++ b/src/components/layout/trial-banner.tsx
@@ -48,8 +48,8 @@ export function TrialBanner({
         <strong className={bannerTheme.title}>
           Your team is on a free trial.
         </strong>{" "}
-        Your trial ends on April 19, 2026. You will be switched to the Hobby
-        plan after.
+        Your trial ends on May 18, 2026. You will be switched to the Hobby plan
+        after.
       </p>
       <div className="flex items-center gap-3 shrink-0">
         <Link

--- a/tests/e2e/dashboard-layout.spec.ts
+++ b/tests/e2e/dashboard-layout.spec.ts
@@ -18,20 +18,28 @@ test.describe("Dashboard Layout", () => {
     await expect(sidebar.getByText("Settings")).toBeVisible();
   });
 
-  test("sidebar shows Agents group with items", async ({ page }) => {
+  test("sidebar shows Agents group with Mintlify ordering", async ({
+    page,
+  }) => {
     await page.goto("/dashboard");
     const sidebar = page.getByTestId("sidebar");
     await expect(sidebar.getByText("Agents")).toBeVisible();
     await expect(
-      sidebar.getByRole("link", { name: "Agent New" }),
+      sidebar.getByRole("link", { name: "Workflows New" }),
+    ).toBeVisible();
+    await expect(
+      sidebar.getByRole("link", { name: "Agent", exact: true }),
     ).toBeVisible();
     await expect(
       sidebar.getByRole("link", { name: "Assistant" }),
     ).toBeVisible();
-    await expect(
-      sidebar.getByRole("link", { name: "Workflows" }),
-    ).toBeVisible();
     await expect(sidebar.getByRole("link", { name: "MCP" })).toBeVisible();
+
+    await expect(
+      sidebar
+        .locator("nav a")
+        .filter({ hasText: /Workflows|Agent|Assistant|MCP/ }),
+    ).toHaveText([/Workflows/, /Agent/, /Assistant/, /MCP/]);
   });
 
   test("sidebar has org switcher with org name", async ({ page }) => {

--- a/tests/e2e/dashboard-layout.spec.ts
+++ b/tests/e2e/dashboard-layout.spec.ts
@@ -118,6 +118,8 @@ test.describe("Dashboard Layout", () => {
     await page.goto("/dashboard");
     await expect(page.getByTestId("trial-banner")).toBeVisible();
     await expect(page.getByText("free trial")).toBeVisible();
+    await expect(page.getByText("May 18, 2026")).toBeVisible();
+    await expect(page.getByText("April 19, 2026")).toBeHidden();
   });
 
   test("trial banner dismissal persists after reload", async ({ page }) => {

--- a/tests/e2e/openapi-autodocs.spec.ts
+++ b/tests/e2e/openapi-autodocs.spec.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "@playwright/test";
 
 test.describe("OpenAPI/AsyncAPI auto-documentation", () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
   test("openapi-spec API route returns 401 without auth", async ({
     request,
   }) => {

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -28,6 +28,16 @@ test.describe("Smoke tests", () => {
     expect(response?.status()).toBe(200);
   });
 
+  test("Mintlify-style workspace home route loads authenticated dashboard", async ({
+    page,
+  }) => {
+    const response = await page.goto("/namuhinc/namuhinc/home");
+    expect(response?.status()).toBe(200);
+    await expect(
+      page.getByText(/Good (morning|afternoon|evening)/),
+    ).toBeVisible();
+  });
+
   test("settings page loads (authenticated)", async ({ page }) => {
     const response = await page.goto("/settings/security/api-keys");
     expect(response?.status()).toBe(200);


### PR DESCRIPTION
## Summary
- Captured corrected Mintlify ground truth at https://dashboard.mintlify.com/namuhinc/namuhinc/home and opendocs root via Ever.
- Added authenticated workspace-shaped /:orgSlug/:projectSlug/home dashboard route and authenticated root redirect.
- Updated dashboard shell parity: current trial date copy, repository/branch metadata display, hidden stale manual handoff queue for live projects, Workflows-first Agents nav with promo card.
- Stabilized clean-database public docs E2E coverage by provisioning a PLAYWRIGHT_TEST-only /docs/test-project fixture with docs pages, i18n/version paths, footer config, and an OpenAPI endpoint.
- Hardened docs Cmd/Ctrl+K search opening before React hydration and defaulted TOC active state to the first section.

## Verification
- make check
- make test
- npx playwright test tests/e2e/smoke.spec.ts tests/e2e/dashboard-layout.spec.ts --reporter=line
- npx playwright test tests/e2e/docs-site-layout.spec.ts tests/e2e/api-reference-layout.spec.ts tests/e2e/docs-topbar.spec.ts tests/e2e/docs-footer.spec.ts --reporter=line
- npx playwright test tests/e2e/docs-search.spec.ts tests/e2e/seo.spec.ts tests/e2e/versions.spec.ts tests/e2e/i18n.spec.ts tests/e2e/openapi-autodocs.spec.ts tests/e2e/page-chrome.spec.ts --reporter=line

## Notes
- Full make test-e2e was attempted again after fixture hardening but stayed silent past 8 minutes and was stopped after writing broad legacy failure artifacts outside this PR's docs fixture lane.
- PR claimed with agent:shadowfax and targets staging.