### PR TITLE
Restore the public docs entry point

### DIFF
--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,0 +1,159 @@
+import { db } from "@/lib/db";
+import { pages, projects } from "@/lib/db/schema";
+import { buildDocsEntryProjects } from "@/lib/docs-entry";
+import { and, asc, eq, isNotNull } from "drizzle-orm";
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Docs - OpenDocs",
+  description: "Browse published OpenDocs documentation and API references.",
+};
+
+async function getPublishedDocsProjects() {
+  try {
+    const rows = await db
+      .select({
+        projectId: projects.id,
+        projectName: projects.name,
+        subdomain: projects.subdomain,
+        pagePath: pages.path,
+        pageTitle: pages.title,
+        pageDescription: pages.description,
+      })
+      .from(projects)
+      .innerJoin(pages, eq(pages.projectId, projects.id))
+      .where(and(isNotNull(projects.subdomain), eq(pages.isPublished, true)))
+      .orderBy(asc(projects.name), asc(pages.path));
+
+    return buildDocsEntryProjects(rows).slice(0, 6);
+  } catch {
+    return [];
+  }
+}
+
+const featureCards = [
+  {
+    title: "Searchable docs",
+    description:
+      "Publish MDX content with navigation, table of contents, keyboard search, and reader feedback.",
+  },
+  {
+    title: "API references",
+    description:
+      "Turn OpenAPI definitions into interactive endpoint pages with request examples and playgrounds.",
+  },
+  {
+    title: "AI-native help",
+    description:
+      "Give readers assistant workflows that can answer questions from your documentation.",
+  },
+];
+
+export default async function DocsLandingPage() {
+  const publishedProjects = await getPublishedDocsProjects();
+
+  return (
+    <main className="min-h-screen bg-[#0b0b0d] text-white">
+      <div className="mx-auto flex min-h-screen max-w-6xl flex-col px-6 py-10">
+        <header className="flex items-center justify-between gap-4">
+          <Link href="/" className="text-sm font-semibold tracking-tight">
+            OpenDocs
+          </Link>
+          <nav className="flex items-center gap-3 text-sm text-white/70">
+            <Link className="transition hover:text-white" href="/onboarding">
+              Start onboarding
+            </Link>
+            <Link className="transition hover:text-white" href="/dashboard">
+              Dashboard
+            </Link>
+          </nav>
+        </header>
+
+        <section className="grid flex-1 items-center gap-12 py-20 lg:grid-cols-[1fr_0.85fr]">
+          <div>
+            <div className="mb-6 inline-flex items-center rounded-full border border-white/10 bg-white/[0.03] px-3 py-1 text-xs text-white/70">
+              Documentation
+            </div>
+            <h1 className="text-4xl font-semibold tracking-tight sm:text-6xl">
+              Browse published docs and API references
+            </h1>
+            <p className="mt-6 max-w-2xl text-base leading-7 text-white/70 sm:text-lg">
+              OpenDocs gives every project a Mintlify-style public docs surface
+              with structured navigation, search, API playgrounds, and AI-ready
+              content.
+            </p>
+            <div className="mt-10 flex flex-wrap gap-3">
+              <Link
+                href={publishedProjects[0]?.href ?? "/onboarding"}
+                className="rounded-lg bg-emerald-500 px-4 py-2.5 text-sm font-medium text-black transition hover:bg-emerald-400"
+              >
+                Explore docs
+              </Link>
+              <Link
+                href="/dashboard"
+                className="rounded-lg border border-white/10 bg-white/5 px-4 py-2.5 text-sm font-medium text-white transition hover:bg-white/10"
+              >
+                Open dashboard
+              </Link>
+            </div>
+          </div>
+
+          <div className="rounded-3xl border border-white/10 bg-white/[0.03] p-5 shadow-2xl shadow-black/30">
+            <h2 className="text-sm font-medium text-white/80">
+              Published documentation
+            </h2>
+            <div className="mt-4 space-y-3">
+              {publishedProjects.length > 0 ? (
+                publishedProjects.map((project) => (
+                  <Link
+                    key={project.id}
+                    href={project.href}
+                    className="block rounded-2xl border border-white/10 bg-black/20 p-4 transition hover:border-emerald-400/50 hover:bg-emerald-500/10"
+                  >
+                    <div className="text-sm font-semibold text-white">
+                      {project.name}
+                    </div>
+                    <div className="mt-1 text-xs text-emerald-300">
+                      /docs/{project.subdomain}
+                    </div>
+                    <p className="mt-3 text-sm leading-6 text-white/65">
+                      {project.pageDescription ??
+                        `Start with ${project.pageTitle}.`}
+                    </p>
+                  </Link>
+                ))
+              ) : (
+                <div className="rounded-2xl border border-dashed border-white/15 bg-black/20 p-4">
+                  <div className="text-sm font-semibold text-white">
+                    No published docs yet
+                  </div>
+                  <p className="mt-2 text-sm leading-6 text-white/65">
+                    Create a project or publish a page to make it available from
+                    this docs entry point.
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+        </section>
+
+        <section className="grid gap-4 pb-16 md:grid-cols-3">
+          {featureCards.map((card) => (
+            <div
+              key={card.title}
+              className="rounded-2xl border border-white/10 bg-white/[0.03] p-5"
+            >
+              <h2 className="text-sm font-medium text-white">{card.title}</h2>
+              <p className="mt-2 text-sm leading-6 text-white/65">
+                {card.description}
+              </p>
+            </div>
+          ))}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/lib/docs-entry.ts
+++ b/src/lib/docs-entry.ts
@@ -1,0 +1,60 @@
+export interface DocsEntryRow {
+  projectId: string;
+  projectName: string;
+  subdomain: string | null;
+  pagePath: string;
+  pageTitle: string;
+  pageDescription: string | null;
+}
+
+export interface DocsEntryProject {
+  id: string;
+  name: string;
+  subdomain: string;
+  href: string;
+  pageTitle: string;
+  pageDescription: string | null;
+}
+
+function pagePriority(path: string): number {
+  if (path === "introduction") return 0;
+  if (path === "getting-started") return 1;
+  if (path === "quickstart") return 2;
+  return 3;
+}
+
+function docsHref(subdomain: string, pagePath: string): string {
+  return `/docs/${subdomain}/${pagePath.replace(/^\/+/, "")}`;
+}
+
+export function buildDocsEntryProjects(
+  rows: DocsEntryRow[],
+): DocsEntryProject[] {
+  const projects = new Map<
+    string,
+    DocsEntryProject & { selectedPriority: number }
+  >();
+
+  for (const row of rows) {
+    if (!row.subdomain || !row.pagePath) continue;
+
+    const candidate = {
+      id: row.projectId,
+      name: row.projectName,
+      subdomain: row.subdomain,
+      href: docsHref(row.subdomain, row.pagePath),
+      pageTitle: row.pageTitle,
+      pageDescription: row.pageDescription,
+      selectedPriority: pagePriority(row.pagePath),
+    };
+
+    const existing = projects.get(row.projectId);
+    if (!existing || candidate.selectedPriority < existing.selectedPriority) {
+      projects.set(row.projectId, candidate);
+    }
+  }
+
+  return Array.from(projects.values()).map(
+    ({ selectedPriority: _, ...p }) => p,
+  );
+}

--- a/tests/docs-entry.test.ts
+++ b/tests/docs-entry.test.ts
@@ -1,0 +1,51 @@
+import { buildDocsEntryProjects } from "@/lib/docs-entry";
+import { describe, expect, it } from "vitest";
+
+describe("buildDocsEntryProjects", () => {
+  it("selects introduction as the preferred public entry point", () => {
+    expect(
+      buildDocsEntryProjects([
+        {
+          projectId: "project-1",
+          projectName: "Test Project",
+          subdomain: "test-project",
+          pagePath: "quickstart",
+          pageTitle: "Quickstart",
+          pageDescription: null,
+        },
+        {
+          projectId: "project-1",
+          projectName: "Test Project",
+          subdomain: "test-project",
+          pagePath: "introduction",
+          pageTitle: "Introduction",
+          pageDescription: "Start here",
+        },
+      ]),
+    ).toEqual([
+      {
+        id: "project-1",
+        name: "Test Project",
+        subdomain: "test-project",
+        href: "/docs/test-project/introduction",
+        pageTitle: "Introduction",
+        pageDescription: "Start here",
+      },
+    ]);
+  });
+
+  it("omits projects without a public docs subdomain", () => {
+    expect(
+      buildDocsEntryProjects([
+        {
+          projectId: "project-1",
+          projectName: "Private Project",
+          subdomain: null,
+          pagePath: "introduction",
+          pageTitle: "Introduction",
+          pageDescription: null,
+        },
+      ]),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- fixes #70 by adding a usable public `/docs` landing page
- lists published docs projects and links into each preferred first page
- adds docs-entry selection helper with unit coverage

## Ever verification
Evidence stored in ignored local path: `private/issue-70-ever/20260506-214246/`
- Mintlify reference: `06b-mintlify-before-act.txt` then clicked Quickstart (`07-mintlify-click-quickstart.txt`) and confirmed the Quickstart docs page in `08-mintlify-after-click-quickstart.txt`.
- Deployed OpenDocs gap: `10-deployed-home-before-navigate.txt` then navigated to `https://opendocs.namuh.co/docs` (`11-deployed-navigate-docs.txt`) and confirmed the 404 in `12-deployed-docs-after-navigate.txt`.
- Local fixed branch: `22-local-chain-before-act.txt` showed a usable `/docs` entry point, then clicked Explore docs (`23-local-chain-click-explore-docs.txt`) and confirmed navigation into a public docs site in `24-local-chain-after-click-explore-docs.txt`.

## Regression verification
- `make check`
- `make test` (1745 passed)

## Not run
- full `make test-e2e`; Ashley explicitly directed Ever CLI as the primary browser QA path and no targeted Playwright regression was needed.

Closes #70
