### PR TITLE
Support public Markdown exports for docs pages

### DIFF
--- a/src/app/api/docs/[subdomain]/markdown/[...slug]/route.ts
+++ b/src/app/api/docs/[subdomain]/markdown/[...slug]/route.ts
@@ -1,0 +1,68 @@
+import { db } from "@/lib/db";
+import { pages, projects } from "@/lib/db/schema";
+import { pageToMarkdown } from "@/lib/page-chrome";
+import {
+  getDocsAccessCookieName,
+  hasValidDocsAccess,
+} from "@/lib/project-docs-access";
+import { and, eq } from "drizzle-orm";
+import { type NextRequest, NextResponse } from "next/server";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ subdomain: string; slug: string[] }> },
+) {
+  const { subdomain, slug } = await params;
+  const pagePath = slug.join("/").trim();
+
+  if (!pagePath) {
+    return new NextResponse("Page path required", { status: 400 });
+  }
+
+  const [project] = await db
+    .select({
+      id: projects.id,
+      settings: projects.settings,
+    })
+    .from(projects)
+    .where(eq(projects.subdomain, subdomain))
+    .limit(1);
+
+  if (!project) {
+    return new NextResponse("Documentation site not found", { status: 404 });
+  }
+
+  if (
+    !hasValidDocsAccess(
+      project.settings,
+      subdomain,
+      request.cookies.get(getDocsAccessCookieName(subdomain))?.value,
+    )
+  ) {
+    return new NextResponse("Docs password required", { status: 401 });
+  }
+
+  const [page] = await db
+    .select({ title: pages.title, content: pages.content })
+    .from(pages)
+    .where(
+      and(
+        eq(pages.projectId, project.id),
+        eq(pages.path, pagePath),
+        eq(pages.isPublished, true),
+      ),
+    )
+    .limit(1);
+
+  if (!page) {
+    return new NextResponse("Page not found", { status: 404 });
+  }
+
+  return new NextResponse(pageToMarkdown(page.title, page.content ?? ""), {
+    status: 200,
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=3600, s-maxage=3600",
+    },
+  });
+}

--- a/src/lib/public-markdown-export.ts
+++ b/src/lib/public-markdown-export.ts
@@ -1,0 +1,19 @@
+export interface PublicMarkdownExportPath {
+  subdomain: string;
+  pagePath: string;
+}
+
+export function parsePublicMarkdownExportPath(
+  pathname: string,
+): PublicMarkdownExportPath | null {
+  const match = pathname.match(/^\/docs\/([^/]+)\/(.+)\.md$/);
+  if (!match) return null;
+
+  const [, rawSubdomain, rawPagePath] = match;
+  if (!rawSubdomain || !rawPagePath) return null;
+
+  return {
+    subdomain: decodeURIComponent(rawSubdomain),
+    pagePath: decodeURIComponent(rawPagePath).replace(/^\/+/, ""),
+  };
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,3 +1,4 @@
+import { parsePublicMarkdownExportPath } from "@/lib/public-markdown-export";
 import { getSessionCookie } from "better-auth/cookies";
 import { type NextRequest, NextResponse } from "next/server";
 
@@ -12,6 +13,17 @@ export async function proxy(request: NextRequest) {
   const start = Date.now();
   const sessionCookie = getSessionCookie(request);
   const { pathname, search } = request.nextUrl;
+
+  const markdownExport = parsePublicMarkdownExportPath(pathname);
+  if (markdownExport) {
+    const markdownUrl = new URL(
+      `/api/docs/${markdownExport.subdomain}/markdown/${markdownExport.pagePath}`,
+      request.url,
+    );
+    const response = NextResponse.rewrite(markdownUrl);
+    response.headers.set("Server-Timing", `proxy;dur=${Date.now() - start}`);
+    return response;
+  }
 
   // Unauthenticated users visiting protected routes or onboarding → redirect to login
   if (
@@ -40,5 +52,6 @@ export const config = {
     "/products/:path*",
     "/analytics/:path*",
     "/onboarding",
+    "/docs/:path*",
   ],
 };

--- a/tests/public-markdown-export.test.ts
+++ b/tests/public-markdown-export.test.ts
@@ -1,0 +1,27 @@
+import { parsePublicMarkdownExportPath } from "@/lib/public-markdown-export";
+import { describe, expect, it } from "vitest";
+
+describe("parsePublicMarkdownExportPath", () => {
+  it("parses a top-level docs markdown export path", () => {
+    expect(parsePublicMarkdownExportPath("/docs/acme/introduction.md")).toEqual(
+      {
+        subdomain: "acme",
+        pagePath: "introduction",
+      },
+    );
+  });
+
+  it("parses nested docs markdown export paths", () => {
+    expect(
+      parsePublicMarkdownExportPath("/docs/acme/guides/quickstart.md"),
+    ).toEqual({
+      subdomain: "acme",
+      pagePath: "guides/quickstart",
+    });
+  });
+
+  it("ignores normal docs pages and non-markdown assets", () => {
+    expect(parsePublicMarkdownExportPath("/docs/acme/introduction")).toBeNull();
+    expect(parsePublicMarkdownExportPath("/docs/acme/llms.txt")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- fixes #74 by rewriting public /docs/:subdomain/**/*.md requests to a Markdown export route
- adds a text/markdown API route that respects docs password access and published-page visibility
- adds parser coverage for top-level and nested docs markdown export paths

## Verification
- Ever: Mintlify https://mintlify.com/docs/quickstart.md returns raw Markdown
- Ever: deployed https://opendocs.namuh.co/docs/test-project/introduction.md returns 404 before fix
- Ever: local http://localhost:3015/docs/test-project/introduction.md returns Markdown
- Ever: local http://localhost:3015/docs/test-project/guides/quickstart.md returns Markdown
- make check
- make test (1746 passed)

## Not run
- full Playwright suite; Ever is the requested primary browser QA path and no targeted Playwright regression was required