### PR TITLE
Expose public docs MCP descriptor

### DIFF
--- a/src/app/docs/[subdomain]/mcp/route.ts
+++ b/src/app/docs/[subdomain]/mcp/route.ts
@@ -1,0 +1,57 @@
+import { db } from "@/lib/db";
+import { projects } from "@/lib/db/schema";
+import {
+  getDocsAccessCookieName,
+  hasValidDocsAccess,
+} from "@/lib/project-docs-access";
+import { buildPublicMcpDescriptor } from "@/lib/public-mcp";
+import { eq } from "drizzle-orm";
+import { type NextRequest, NextResponse } from "next/server";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ subdomain: string }> },
+) {
+  const { subdomain } = await params;
+  const [project] = await db
+    .select({
+      name: projects.name,
+      subdomain: projects.subdomain,
+      settings: projects.settings,
+    })
+    .from(projects)
+    .where(eq(projects.subdomain, subdomain))
+    .limit(1);
+
+  if (!project?.subdomain) {
+    return NextResponse.json(
+      { error: "Documentation site not found" },
+      { status: 404 },
+    );
+  }
+
+  if (
+    !hasValidDocsAccess(
+      project.settings,
+      subdomain,
+      request.cookies.get(getDocsAccessCookieName(subdomain))?.value,
+    )
+  ) {
+    return NextResponse.json(
+      { error: "Docs password required" },
+      { status: 401 },
+    );
+  }
+
+  return NextResponse.json(
+    buildPublicMcpDescriptor(
+      { name: project.name, subdomain: project.subdomain },
+      new URL(request.url).origin,
+    ),
+    {
+      headers: {
+        "Cache-Control": "public, max-age=3600, s-maxage=3600",
+      },
+    },
+  );
+}

--- a/src/lib/public-mcp.ts
+++ b/src/lib/public-mcp.ts
@@ -1,0 +1,83 @@
+import { slugToTitle } from "@/lib/mcp";
+
+export interface PublicMcpDescriptorProject {
+  name: string;
+  subdomain: string;
+}
+
+export function toMcpToolLabel(subdomain: string) {
+  return subdomain.replace(/[^a-zA-Z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+}
+
+export function buildPublicMcpDescriptor(
+  project: PublicMcpDescriptorProject,
+  origin: string,
+) {
+  const toolLabel = toMcpToolLabel(project.subdomain) || "docs";
+  const title = project.name || slugToTitle(project.subdomain);
+  const docsBaseUrl = `${origin.replace(/\/+$/, "")}/docs/${project.subdomain}`;
+
+  return {
+    server: {
+      name: title,
+      version: "1.0.0",
+      transport: "http",
+    },
+    capabilities: {
+      tools: {
+        [`search_${toolLabel}`]: {
+          name: `search_${toolLabel}`,
+          description: `Search across the ${title} documentation knowledge base to find relevant pages, code examples, API references, and guides. Results should link back to ${docsBaseUrl}. Use query_docs_filesystem_${toolLabel} when full Markdown page content is needed.`,
+          inputSchema: {
+            type: "object",
+            properties: {
+              query: {
+                type: "string",
+                description:
+                  "A query to search the documentation content with.",
+              },
+              language: {
+                type: "string",
+                description:
+                  "Filter to a specific language code, such as 'en'. Defaults to 'en'.",
+              },
+            },
+            required: ["query"],
+          },
+          operationId: `${toolLabel}_search`,
+        },
+        [`query_docs_filesystem_${toolLabel}`]: {
+          name: `query_docs_filesystem_${toolLabel}`,
+          description: `Run a read-only shell-like query against the ${title} documentation content. Use this tool for exact keyword matches, docs structure exploration, or reading full page content from ${docsBaseUrl} Markdown exports. Supported commands include rg, grep, find, tree, ls, cat, head, tail, stat, wc, sort, uniq, cut, sed, awk, and jq.`,
+          inputSchema: {
+            type: "object",
+            properties: {
+              command: {
+                type: "string",
+                description:
+                  'A shell-like read-only command for the documentation content, such as `rg -il "keyword" /`, `tree / -L 2`, or `head -80 /introduction.md`.',
+              },
+            },
+            required: ["command"],
+          },
+          operationId: `${toolLabel}_query_docs_filesystem`,
+        },
+      },
+      resources: [
+        {
+          uri: `${docsBaseUrl}/llms.txt`,
+          name: `${title} llms.txt`,
+          description: `Machine-readable index for ${title} documentation pages.`,
+          mimeType: "text/markdown",
+        },
+        {
+          uri: `${docsBaseUrl}/llms-full.txt`,
+          name: `${title} llms-full.txt`,
+          description: `Full Markdown export for ${title} documentation pages.`,
+          mimeType: "text/markdown",
+        },
+      ],
+      prompts: [],
+    },
+  };
+}

--- a/tests/public-mcp.test.ts
+++ b/tests/public-mcp.test.ts
@@ -1,0 +1,40 @@
+import { buildPublicMcpDescriptor, toMcpToolLabel } from "@/lib/public-mcp";
+import { describe, expect, it } from "vitest";
+
+describe("toMcpToolLabel", () => {
+  it("converts docs subdomains to MCP-safe tool labels", () => {
+    expect(toMcpToolLabel("test-project")).toBe("test_project");
+    expect(toMcpToolLabel("docs.example")).toBe("docs_example");
+  });
+});
+
+describe("buildPublicMcpDescriptor", () => {
+  it("builds Mintlify-style server metadata and tools", () => {
+    const descriptor = buildPublicMcpDescriptor(
+      { name: "Test Project", subdomain: "test-project" },
+      "https://opendocs.namuh.co/",
+    );
+
+    expect(descriptor.server).toEqual({
+      name: "Test Project",
+      version: "1.0.0",
+      transport: "http",
+    });
+    expect(descriptor.capabilities.tools.search_test_project).toMatchObject({
+      name: "search_test_project",
+      operationId: "test_project_search",
+    });
+    expect(
+      descriptor.capabilities.tools.query_docs_filesystem_test_project,
+    ).toMatchObject({
+      name: "query_docs_filesystem_test_project",
+      operationId: "test_project_query_docs_filesystem",
+    });
+    expect(
+      descriptor.capabilities.tools.search_test_project.inputSchema.properties,
+    ).toHaveProperty("language");
+    expect(descriptor.capabilities.resources[0].uri).toBe(
+      "https://opendocs.namuh.co/docs/test-project/llms.txt",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `/docs/:subdomain/mcp` public docs route
- emit Mintlify-style MCP descriptor with server metadata, search tool, docs-filesystem query tool, resources, and prompts
- preserve existing docs password-gate behavior for protected docs sites

## Verification
- `make check`
- `make test`
- Ever primary browser QA: snapshot → navigate → snapshot comparing `https://mintlify.com/docs/mcp` with local `http://localhost:3015/docs/test-project/mcp?shadowfax=1778069099`
  - evidence stored locally in ignored path `private/issue-76-ever/20260506-210459-final-cachebust/`

## Notes
- Full Playwright E2E intentionally not run; Ashley directed Ever as the primary browser QA path and no targeted Playwright regression was needed.

Closes #76
