### PR TITLE
Keep API reference version and language controls

### DIFF
--- a/src/app/docs/[subdomain]/[...slug]/page.tsx
+++ b/src/app/docs/[subdomain]/[...slug]/page.tsx
@@ -492,12 +492,14 @@ export default async function DocsPage({
 
   // Build searchable pages list (DB + virtual)
   const searchablePages = allNavPaths;
+  const hasGeneratedApiRoute = Boolean(virtualPage || asyncPage);
 
   // Compute available locales for the language switcher
   const availableLocales = getAvailableLocalesForPage(
     allPagesRaw,
     pagePath,
     langConfig,
+    { includeConfiguredRoutes: hasGeneratedApiRoute },
   );
 
   // Compute available versions for the version switcher
@@ -505,6 +507,7 @@ export default async function DocsPage({
     allPagesRaw,
     pagePath,
     versionConfig,
+    { includeConfiguredRoutes: hasGeneratedApiRoute },
   );
 
   return (

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -289,8 +289,10 @@ export function getAvailableLocalesForPage(
   allPages: { path: string }[],
   pagePath: string,
   config: LanguagesConfig,
+  options?: { includeConfiguredRoutes?: boolean },
 ): string[] {
   if (!config.enabled) return [config.defaultLanguage];
+  if (options?.includeConfiguredRoutes) return config.supportedLanguages;
 
   const available: string[] = [];
 

--- a/src/lib/versions.ts
+++ b/src/lib/versions.ts
@@ -252,8 +252,12 @@ export function getAvailableVersionsForPage(
   allPages: { path: string }[],
   pagePath: string,
   config: VersionsConfig,
+  options?: { includeConfiguredRoutes?: boolean },
 ): string[] {
   if (!config.enabled || config.versions.length === 0) return [];
+  if (options?.includeConfiguredRoutes) {
+    return config.versions.map((v) => v.tag);
+  }
 
   const defaultTag = getDefaultVersion(config)?.tag ?? "";
   const available: string[] = [];

--- a/tests/i18n.test.ts
+++ b/tests/i18n.test.ts
@@ -348,4 +348,14 @@ describe("getAvailableLocalesForPage", () => {
     );
     expect(locales).toEqual(["en"]);
   });
+
+  it("can expose all configured locales for generated routes", () => {
+    const locales = getAvailableLocalesForPage(
+      allPages,
+      "api-reference/get-plants",
+      config,
+      { includeConfiguredRoutes: true },
+    );
+    expect(locales).toEqual(["en", "fr", "es"]);
+  });
 });

--- a/tests/versions.test.ts
+++ b/tests/versions.test.ts
@@ -391,4 +391,14 @@ describe("getAvailableVersionsForPage", () => {
     );
     expect(result).toEqual([]);
   });
+
+  it("can expose all configured versions for generated routes", () => {
+    const result = getAvailableVersionsForPage(
+      pages,
+      "api-reference/get-plants",
+      threeVersionConfig,
+      { includeConfiguredRoutes: true },
+    );
+    expect(result).toEqual(["v1", "v2", "v3"]);
+  });
 });


### PR DESCRIPTION
## Summary
- keep version and language switchers visible on generated OpenAPI/AsyncAPI reference pages
- add locale/version helper options for generated routes
- add regression coverage for generated-route switcher availability

## Verification
- `make check`
- `make test`
- Ever primary browser QA: snapshot → navigate → snapshot
  - deployed mismatch: `https://opendocs.namuh.co/docs/test-project/api-reference/get-plants` lacked version/language controls
  - local fix: `http://localhost:3015/docs/test-project/api-reference/get-plants` showed `Version 2.0` and `EN`
  - local dropdown verification showed `Version 2.0`/`Version 1.0` and `EN`/`FR`
  - evidence stored locally in ignored paths:
    - `private/issue-78-ever/20260506-211420-final/`
    - `private/issue-78-ever/20260506-211500-dropdowns/`

## Notes
- Full Playwright E2E intentionally not run; Ashley directed Ever as the primary browser QA path and no targeted Playwright regression was needed.

Closes #78
