### PR TITLE
Include generated API pages in docs search

### DIFF
--- a/src/app/api/docs/[subdomain]/search/route.ts
+++ b/src/app/api/docs/[subdomain]/search/route.ts
@@ -16,6 +16,11 @@ import { buildSearchQuery } from "@/lib/assistant";
 import { db } from "@/lib/db";
 import { pages, projects } from "@/lib/db/schema";
 import {
+  generateAsyncApiPages,
+  generateVirtualPages,
+  isAsyncApiSpec,
+} from "@/lib/openapi";
+import {
   getDocsAccessCookieName,
   hasValidDocsAccess,
 } from "@/lib/project-docs-access";
@@ -25,6 +30,101 @@ import { type NextRequest, NextResponse } from "next/server";
 
 interface RouteContext {
   params: Promise<{ subdomain: string }>;
+}
+
+interface RankedSearchResult {
+  path: string;
+  title: string;
+  description: string | null;
+  snippet: string;
+  breadcrumb: string[];
+  rank: number;
+}
+
+function matchesQuery(query: string, values: Array<string | null | undefined>) {
+  const haystack = values.filter(Boolean).join(" ").toLowerCase();
+  const tokens = query.toLowerCase().split(/\s+/).filter(Boolean);
+  return tokens.every((token) => haystack.includes(token));
+}
+
+function rankMatch(
+  query: string,
+  fields: {
+    title: string;
+    path: string;
+    description?: string | null;
+    content?: string | null;
+  },
+) {
+  const q = query.toLowerCase();
+  if (fields.title.toLowerCase().includes(q)) return 0;
+  if (fields.path.toLowerCase().includes(q)) return 1;
+  if (fields.description?.toLowerCase().includes(q)) return 2;
+  if (fields.content?.toLowerCase().includes(q)) return 3;
+  return 4;
+}
+
+function getGeneratedApiSearchResults(
+  spec: Record<string, unknown> | undefined,
+  query: string,
+): RankedSearchResult[] {
+  if (!spec || typeof spec !== "object") return [];
+
+  if (isAsyncApiSpec(spec)) {
+    return generateAsyncApiPages(spec)
+      .filter((page) =>
+        matchesQuery(query, [
+          page.title,
+          page.path,
+          page.description,
+          page.channel.name,
+          page.group,
+        ]),
+      )
+      .map((page) => ({
+        path: page.path,
+        title: page.title,
+        description: page.description || null,
+        snippet: page.description,
+        breadcrumb: getBreadcrumb(page.path),
+        rank: rankMatch(query, {
+          title: page.title,
+          path: page.path,
+          description: page.description,
+        }),
+      }));
+  }
+
+  return generateVirtualPages(spec)
+    .filter((page) =>
+      matchesQuery(query, [
+        page.title,
+        page.path,
+        page.description,
+        page.method,
+        page.endpoint.path,
+        page.endpoint.operationId,
+        page.group,
+      ]),
+    )
+    .map((page) => {
+      const endpointLabel = `${page.method} ${page.endpoint.path}`;
+      return {
+        path: page.path,
+        title: page.title,
+        description: page.description || null,
+        snippet: page.description
+          ? `${endpointLabel} — ${page.description}`
+          : endpointLabel,
+        breadcrumb: getBreadcrumb(page.path),
+        rank: rankMatch(query, {
+          title: page.title,
+          path: page.path,
+          description: page.description,
+          content: endpointLabel,
+        }),
+      };
+    });
 }
 
 export async function GET(request: NextRequest, context: RouteContext) {
@@ -73,6 +173,10 @@ export async function GET(request: NextRequest, context: RouteContext) {
   }
 
   const projectId = projectResult[0].id;
+  const docsSettings = (projectResult[0].settings || {}) as Record<
+    string,
+    unknown
+  >;
   const pattern = buildSearchQuery(query);
 
   // Search with relevance ordering: title > description > content
@@ -107,13 +211,39 @@ export async function GET(request: NextRequest, context: RouteContext) {
     )
     .limit(limit);
 
-  const formatted = results.map((r) => ({
+  const formatted: RankedSearchResult[] = results.map((r) => ({
     path: r.path,
     title: r.title,
     description: r.description,
     snippet: extractSnippet(r.content, query),
     breadcrumb: getBreadcrumb(r.path),
+    rank: rankMatch(query, {
+      title: r.title,
+      path: r.path,
+      description: r.description,
+      content: r.content,
+    }),
   }));
 
-  return NextResponse.json(formatted, { status: 200 });
+  const generatedResults = getGeneratedApiSearchResults(
+    docsSettings.openApiSpec as Record<string, unknown> | undefined,
+    query,
+  );
+  const seenPaths = new Set<string>();
+  const combined = [...formatted, ...generatedResults]
+    .filter((result) => {
+      if (seenPaths.has(result.path)) return false;
+      seenPaths.add(result.path);
+      return true;
+    })
+    .sort(
+      (a, b) =>
+        a.rank - b.rank ||
+        a.title.localeCompare(b.title) ||
+        a.path.localeCompare(b.path),
+    )
+    .slice(0, limit)
+    .map(({ rank: _rank, ...result }) => result);
+
+  return NextResponse.json(combined, { status: 200 });
 }

--- a/tests/docs-search-route.test.ts
+++ b/tests/docs-search-route.test.ts
@@ -1,0 +1,104 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { hasValidDocsAccessMock, selectMock } = vi.hoisted(() => ({
+  hasValidDocsAccessMock: vi.fn(),
+  selectMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: selectMock,
+  },
+}));
+
+vi.mock("@/lib/project-docs-access", () => ({
+  getDocsAccessCookieName: (subdomain: string) => `docs_access_${subdomain}`,
+  hasValidDocsAccess: hasValidDocsAccessMock,
+}));
+
+function makeRequest(url: string): NextRequest {
+  const request = new Request(url) as NextRequest;
+  Object.defineProperty(request, "cookies", {
+    value: { get: vi.fn().mockReturnValue(undefined) },
+    configurable: true,
+  });
+  return request;
+}
+
+function mockProjectLookup(settings: Record<string, unknown>) {
+  return {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue([{ id: "project-1", settings }]),
+  };
+}
+
+function mockPageSearch(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    orderBy: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(rows),
+  };
+}
+
+describe("GET /api/docs/[subdomain]/search", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    hasValidDocsAccessMock.mockReturnValue(true);
+  });
+
+  it("includes generated OpenAPI pages when the query matches endpoint metadata", async () => {
+    const openApiSpec = {
+      openapi: "3.0.0",
+      info: { title: "Plants API", version: "1.0.0" },
+      paths: {
+        "/plants": {
+          get: {
+            operationId: "getPlants",
+            summary: "Get Plants",
+            description: "Returns a list of plants.",
+            responses: { "200": { description: "OK" } },
+          },
+        },
+      },
+    };
+
+    selectMock
+      .mockReturnValueOnce(mockProjectLookup({ openApiSpec }))
+      .mockReturnValueOnce(
+        mockPageSearch([
+          {
+            path: "quickstart",
+            title: "Quickstart",
+            description: null,
+            content: "Make your first request to the Plants API.",
+          },
+        ]),
+      );
+
+    const { GET } = await import("@/app/api/docs/[subdomain]/search/route");
+    const response = await GET(
+      makeRequest("http://localhost/api/docs/test-project/search?q=plants"),
+      { params: Promise.resolve({ subdomain: "test-project" }) },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "api-reference/get-plants",
+          title: "Get Plants",
+          snippet: expect.stringContaining("GET /plants"),
+        }),
+      ]),
+    );
+    expect(body[0]).toMatchObject({
+      path: "api-reference/get-plants",
+      title: "Get Plants",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- merge generated OpenAPI/AsyncAPI pages into public docs search results
- rank generated endpoint title/path matches alongside persisted page matches
- add route-level regression coverage for searching a generated `Get Plants` endpoint

## Verification
- `make check`
- `make test`
- Ever primary browser QA: snapshot → keyboard act → snapshot
  - deployed mismatch: `plants` search omitted `Get Plants` and showed only `Quickstart`
  - local fix: Meta+K then `plants` returned `Get Plants` (`GET /plants — Returns a list of plants.`) above `Quickstart`
  - evidence stored locally in ignored paths:
    - deployed mismatch/local attempt: `private/issue-80-ever/20260506-212225-final/`
    - final local pass: `private/issue-80-ever/20260506-212430-local-keyboard-query/`

## Notes
- Full Playwright E2E intentionally not run; Ashley directed Ever as the primary browser QA path and no targeted Playwright regression was needed.

Closes #80
