### PR TITLE
Show starter suggestions in docs AI assistant

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2603,6 +2603,42 @@ pre.mermaid svg {
   font-size: 13px;
 }
 
+.chat-widget-suggestions {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: stretch;
+  margin-top: 4px;
+}
+
+.chat-widget-suggestions-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: #9ca3af;
+  text-align: left;
+}
+
+.chat-widget-suggestion {
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: #d1d5db;
+  border-radius: 10px;
+  padding: 8px 10px;
+  font-size: 12px;
+  line-height: 1.3;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.chat-widget-suggestion:hover {
+  background: rgba(52, 211, 153, 0.1);
+  border-color: rgba(52, 211, 153, 0.3);
+  color: #ecfdf5;
+}
+
 .chat-message {
   display: flex;
   gap: 8px;
@@ -2826,6 +2862,22 @@ pre.mermaid svg {
 
 [data-theme="light"] .chat-widget-messages {
   background: #fafafa;
+}
+
+[data-theme="light"] .chat-widget-suggestions-label {
+  color: #6b7280;
+}
+
+[data-theme="light"] .chat-widget-suggestion {
+  border-color: #e5e7eb;
+  background: #ffffff;
+  color: #374151;
+}
+
+[data-theme="light"] .chat-widget-suggestion:hover {
+  background: #ecfdf5;
+  border-color: #86efac;
+  color: #166534;
 }
 
 [data-theme="light"] .chat-message-avatar {

--- a/src/components/docs/chat-widget.tsx
+++ b/src/components/docs/chat-widget.tsx
@@ -138,6 +138,12 @@ interface ChatWidgetProps {
   currentPath?: string;
 }
 
+const STARTER_SUGGESTIONS = [
+  "How do I get started?",
+  "What features does it offer?",
+  "What is this documentation about?",
+];
+
 export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
   const [state, dispatch] = useReducer(chatReducer, {
     messages: [],
@@ -314,6 +320,11 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
     }
   };
 
+  const applySuggestion = useCallback((suggestion: string) => {
+    setInput(suggestion);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }, []);
+
   if (!state.isOpen) return null;
 
   return (
@@ -402,6 +413,22 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
               <path d="M18 14l1 3 3 1-3 1-1 3-1-3-3-1 3-1 1-3z" />
             </svg>
             <p>Ask a question about the documentation</p>
+            <div
+              className="chat-widget-suggestions"
+              data-testid="chat-suggestions"
+            >
+              <span className="chat-widget-suggestions-label">Suggestions</span>
+              {STARTER_SUGGESTIONS.map((suggestion) => (
+                <button
+                  key={suggestion}
+                  type="button"
+                  className="chat-widget-suggestion"
+                  onClick={() => applySuggestion(suggestion)}
+                >
+                  {suggestion}
+                </button>
+              ))}
+            </div>
           </div>
         )}
 

--- a/tests/chat-widget.test.tsx
+++ b/tests/chat-widget.test.tsx
@@ -51,6 +51,48 @@ describe("Docs chat widget code context", () => {
     ).not.toBeNull();
   });
 
+  it("shows starter suggestions and applies one to the input", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <>
+          <AskAiButton />
+          <ChatWidget subdomain="feature004-qa" currentPath="introduction" />
+        </>,
+      );
+    });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="ask-ai-btn"]')
+        ?.click();
+    });
+
+    const suggestions = container.querySelector(
+      '[data-testid="chat-suggestions"]',
+    );
+    expect(suggestions?.textContent).toContain("Suggestions");
+    expect(suggestions?.textContent).toContain("How do I get started?");
+
+    await act(async () => {
+      Array.from(
+        container.querySelectorAll<HTMLButtonElement>(
+          ".chat-widget-suggestion",
+        ),
+      )
+        .find((button) => button.textContent === "How do I get started?")
+        ?.click();
+    });
+
+    expect(
+      container.querySelector<HTMLTextAreaElement>('[data-testid="chat-input"]')
+        ?.value,
+    ).toBe("How do I get started?");
+  });
+
   it("opens the chat panel with code context when a code-block Ask AI button is clicked", async () => {
     const html = renderMdxContent("```ts app.ts\nconst answer = 42;\n```");
     const container = document.createElement("div");


### PR DESCRIPTION
## Summary
- add Mintlify-style starter suggestions to the docs AI assistant empty state
- let suggestion buttons populate the assistant input
- add chat-widget regression coverage and light/dark styles

## Verification
- `make check`
- `make test`
- Ever primary browser QA: snapshot → act → snapshot
  - reference/deployed evidence: Mintlify assistant suggestions vs OpenDocs missing suggestions
  - local fix: `http://localhost:3015/docs/test-project` assistant shows `Suggestions` with three starter prompt buttons
  - evidence stored locally in ignored paths:
    - `private/browser-parity/20260506-212623-assistant-panel/`
    - `private/browser-parity/20260506-212657-opendocs-assistant-correct/`
    - `private/issue-82-ever/20260506-213110/`

## Notes
- Full Playwright E2E intentionally not run; Ashley directed Ever as the primary browser QA path and no targeted Playwright regression was needed.

Closes #82
