### PR TITLE
Add skip-to-main-content link on docs pages

### DIFF
--- a/src/app/docs/[subdomain]/[...slug]/page.tsx
+++ b/src/app/docs/[subdomain]/[...slug]/page.tsx
@@ -555,7 +555,7 @@ export default async function DocsPage({
           projectName={project.name}
         />
 
-        <main className="docs-main">
+        <main id="main-content" className="docs-main" tabIndex={-1}>
           {groupName && (
             <div className="docs-breadcrumb" data-testid="breadcrumb-group">
               {groupName}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -36,6 +36,29 @@ body {
 }
 
 /* Top bar */
+.docs-skip-link {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  z-index: 100;
+  transform: translateY(-150%);
+  border-radius: 8px;
+  background: #16a34a;
+  color: #ffffff;
+  padding: 8px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.24);
+  transition: transform 0.15s ease;
+}
+
+.docs-skip-link:focus {
+  transform: translateY(0);
+  outline: 2px solid #bbf7d0;
+  outline-offset: 2px;
+}
+
 .docs-topbar {
   position: sticky;
   top: 0;

--- a/src/components/docs/docs-topbar.tsx
+++ b/src/components/docs/docs-topbar.tsx
@@ -99,144 +99,153 @@ export function DocsTopbar({
   const dashboardUrl = buildDashboardUrl(subdomain);
 
   return (
-    <div className="docs-topbar">
-      <div className="docs-topbar-left">
-        <MobileMenuButton />
-        <Link href={`/docs/${subdomain}`} className="docs-topbar-logo">
-          <svg
-            width="28"
-            height="28"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            aria-label="Logo"
-            className="docs-topbar-logo-icon"
-          >
-            <title>Logo</title>
-            <path d="M12 2L2 7l10 5 10-5-10-5Z" fill="#16A34A" opacity="0.8" />
-            <path
-              d="M2 17l10 5 10-5"
-              stroke="#16A34A"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-            <path
-              d="M2 12l10 5 10-5"
-              stroke="#16A34A"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-          <span className="docs-topbar-title">{projectName}</span>
-        </Link>
-      </div>
+    <>
+      <a className="docs-skip-link" href="#main-content">
+        Skip to main content
+      </a>
+      <div className="docs-topbar">
+        <div className="docs-topbar-left">
+          <MobileMenuButton />
+          <Link href={`/docs/${subdomain}`} className="docs-topbar-logo">
+            <svg
+              width="28"
+              height="28"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              aria-label="Logo"
+              className="docs-topbar-logo-icon"
+            >
+              <title>Logo</title>
+              <path
+                d="M12 2L2 7l10 5 10-5-10-5Z"
+                fill="#16A34A"
+                opacity="0.8"
+              />
+              <path
+                d="M2 17l10 5 10-5"
+                stroke="#16A34A"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M2 12l10 5 10-5"
+                stroke="#16A34A"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+            <span className="docs-topbar-title">{projectName}</span>
+          </Link>
+        </div>
 
-      <div className="docs-topbar-center">
-        <button
-          type="button"
-          className="docs-search-btn"
-          onClick={() => {
-            document.dispatchEvent(new CustomEvent("open-search"));
-          }}
-        >
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            aria-label="Search"
-          >
-            <title>Search</title>
-            <circle cx="11" cy="11" r="8" />
-            <path d="m21 21-4.35-4.35" />
-          </svg>
-          <span className="docs-search-text">Search...</span>
-          <kbd>&#8984;K</kbd>
-        </button>
-        <AskAiButton />
-      </div>
-
-      <div className="docs-topbar-right">
-        <a
-          data-testid="topbar-support-link"
-          href={supportHref}
-          className="docs-topbar-link"
-        >
-          Support
-        </a>
-
-        {githubProps && (
-          <a
-            data-testid="topbar-github-link"
-            href={githubProps.href}
-            target={githubProps.target}
-            rel={githubProps.rel}
-            className="docs-topbar-icon-link"
-            aria-label="GitHub repository"
+        <div className="docs-topbar-center">
+          <button
+            type="button"
+            className="docs-search-btn"
+            onClick={() => {
+              document.dispatchEvent(new CustomEvent("open-search"));
+            }}
           >
             <svg
-              width="20"
-              height="20"
+              width="16"
+              height="16"
               viewBox="0 0 24 24"
-              fill="currentColor"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              aria-label="Search"
+            >
+              <title>Search</title>
+              <circle cx="11" cy="11" r="8" />
+              <path d="m21 21-4.35-4.35" />
+            </svg>
+            <span className="docs-search-text">Search...</span>
+            <kbd>&#8984;K</kbd>
+          </button>
+          <AskAiButton />
+        </div>
+
+        <div className="docs-topbar-right">
+          <a
+            data-testid="topbar-support-link"
+            href={supportHref}
+            className="docs-topbar-link"
+          >
+            Support
+          </a>
+
+          {githubProps && (
+            <a
+              data-testid="topbar-github-link"
+              href={githubProps.href}
+              target={githubProps.target}
+              rel={githubProps.rel}
+              className="docs-topbar-icon-link"
+              aria-label="GitHub repository"
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+              </svg>
+              <span className="sr-only">GitHub</span>
+            </a>
+          )}
+
+          <Link
+            data-testid="topbar-dashboard-link"
+            href={dashboardUrl}
+            className="docs-topbar-dashboard-btn"
+          >
+            Dashboard
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
               aria-hidden="true"
             >
-              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+              <path d="M7 17L17 7" />
+              <path d="M7 7h10v10" />
             </svg>
-            <span className="sr-only">GitHub</span>
-          </a>
-        )}
+          </Link>
 
-        <Link
-          data-testid="topbar-dashboard-link"
-          href={dashboardUrl}
-          className="docs-topbar-dashboard-btn"
-        >
-          Dashboard
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <path d="M7 17L17 7" />
-            <path d="M7 7h10v10" />
-          </svg>
-        </Link>
+          {version && version.availableVersions.length > 1 && (
+            <VersionSwitcher
+              currentVersion={version.currentVersion}
+              availableVersions={version.availableVersions}
+              versionsConfig={version.versionsConfig}
+              subdomain={subdomain}
+              pagePath={version.pagePath}
+              locale={version.locale}
+              defaultLanguage={version.defaultLanguage}
+            />
+          )}
 
-        {version && version.availableVersions.length > 1 && (
-          <VersionSwitcher
-            currentVersion={version.currentVersion}
-            availableVersions={version.availableVersions}
-            versionsConfig={version.versionsConfig}
-            subdomain={subdomain}
-            pagePath={version.pagePath}
-            locale={version.locale}
-            defaultLanguage={version.defaultLanguage}
-          />
-        )}
+          {i18n && i18n.availableLocales.length > 1 && (
+            <LanguageSwitcher
+              currentLocale={i18n.currentLocale}
+              availableLocales={i18n.availableLocales}
+              subdomain={subdomain}
+              pagePath={i18n.pagePath}
+              defaultLanguage={i18n.defaultLanguage}
+            />
+          )}
 
-        {i18n && i18n.availableLocales.length > 1 && (
-          <LanguageSwitcher
-            currentLocale={i18n.currentLocale}
-            availableLocales={i18n.availableLocales}
-            subdomain={subdomain}
-            pagePath={i18n.pagePath}
-            defaultLanguage={i18n.defaultLanguage}
-          />
-        )}
-
-        <ThemeToggle />
+          <ThemeToggle />
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/tests/docs-topbar.test.ts
+++ b/tests/docs-topbar.test.ts
@@ -1,3 +1,4 @@
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 // Mock next/navigation
@@ -7,6 +8,23 @@ vi.mock("next/navigation", () => ({
 
 describe("Docs topbar — feature-014a", () => {
   describe("DocsTopbar component exports", () => {
+    it("renders a skip link before docs navigation", async () => {
+      const { DocsTopbar } = await import("@/components/docs/docs-topbar");
+      const html = renderToStaticMarkup(
+        DocsTopbar({
+          projectName: "Test Project",
+          subdomain: "test-project",
+          settings: {},
+        }),
+      );
+
+      expect(html).toContain('href="#main-content"');
+      expect(html).toContain("Skip to main content");
+      expect(html.indexOf("Skip to main content")).toBeLessThan(
+        html.indexOf("docs-topbar"),
+      );
+    });
+
     it("exports DocsTopbar component", async () => {
       const mod = await import("@/components/docs/docs-topbar");
       expect(mod.DocsTopbar).toBeDefined();


### PR DESCRIPTION
## Summary
- add a keyboard-accessible skip-to-main-content link before docs navigation
- target the main docs content region from public docs pages
- add regression coverage for the skip link

## Verification
- make check
- make test
- Ever browser snapshot -> act -> snapshot evidence for Mintlify skip link and deployed OpenDocs missing-state gap

Closes #84