### PR TITLE
Show copied feedback after copying docs page markdown

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -330,6 +330,15 @@ body {
   border-color: #4b5563;
 }
 
+.page-copy-btn.copied {
+  width: auto;
+  gap: 6px;
+  padding: 0 10px;
+  color: #d1fae5;
+  border-color: rgba(16, 185, 129, 0.45);
+  background: rgba(16, 185, 129, 0.12);
+}
+
 .page-actions-dropdown {
   position: relative;
 }
@@ -2273,6 +2282,12 @@ pre.mermaid svg {
   background: #f3f4f6;
   color: #111827;
   border-color: #9ca3af;
+}
+
+[data-theme="light"] .page-copy-btn.copied {
+  color: #047857;
+  border-color: rgba(16, 185, 129, 0.5);
+  background: #ecfdf5;
 }
 
 [data-theme="light"] .page-actions-menu {

--- a/src/components/docs/page-chrome.tsx
+++ b/src/components/docs/page-chrome.tsx
@@ -68,11 +68,13 @@ export function PageHeaderActions({
       <button
         type="button"
         data-testid="copy-page-btn"
-        className="page-action-btn"
+        className={`page-action-btn page-copy-btn${copied ? " copied" : ""}`}
         onClick={handleCopy}
-        title="Copy page as markdown"
+        aria-label={copied ? "Copied page markdown" : "Copy page as markdown"}
+        title={copied ? "Copied" : "Copy page as markdown"}
       >
         {copied ? <Check size={16} /> : <Copy size={16} />}
+        {copied && <span>Copied</span>}
       </button>
 
       <div className="page-actions-dropdown" ref={menuRef}>

--- a/tests/page-header-actions.test.tsx
+++ b/tests/page-header-actions.test.tsx
@@ -1,0 +1,52 @@
+import { PageHeaderActions } from "@/components/docs/page-chrome";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// React 19 requires this flag for act() in non-testing-library environments.
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("PageHeaderActions", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it("shows visible copied feedback after copying page markdown", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <PageHeaderActions
+          title="Introduction"
+          content="Welcome to the docs."
+          pageUrl="/docs/test-project/introduction.md"
+        />,
+      );
+    });
+
+    const copyButton = container.querySelector<HTMLButtonElement>(
+      '[data-testid="copy-page-btn"]',
+    );
+
+    expect(copyButton?.textContent).not.toContain("Copied");
+
+    await act(async () => {
+      copyButton?.click();
+    });
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "# Introduction\n\nWelcome to the docs.",
+    );
+    expect(copyButton?.textContent).toContain("Copied");
+    expect(copyButton?.getAttribute("aria-label")).toBe("Copied page markdown");
+  });
+});


### PR DESCRIPTION
## Summary
- show visible `Copied` feedback after the docs page markdown copy action
- update the button title and accessible label while the copied state is active
- add regression coverage for the copied feedback state

## Ever verification
Evidence stored in ignored local path: `private/issue-86-ever/20260506-215636/`
- Reference: `01-mintlify-copy-before.txt` -> `02-mintlify-click-copy.txt` -> `03-mintlify-copy-after.txt` shows Mintlify changes the page copy button to `Copied`.
- Deployed OpenDocs gap: `04-deployed-opendocs-copy-before.txt` -> `05-deployed-opendocs-click-copy.txt` -> `06-deployed-opendocs-copy-after.txt` keeps the icon-only `Copy page as markdown` button with no visible success state.
- Local fixed branch: `22-local-final-copy-before.txt` -> `23-local-final-click-copy.txt` -> `24-local-final-copy-after.txt` shows `title=Copied`, `aria-label=Copied page markdown`, and visible `Copied` text.

## Regression verification
- `npm test -- tests/page-header-actions.test.tsx`
- `make check`
- `make test` (1744 passed)

## Not run
- full `make test-e2e`; Ashley explicitly directed Ever CLI as the primary browser QA path and no targeted Playwright regression was needed.

Closes #86
