### PR TITLE
Add attachment affordance to docs AI assistant

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2740,11 +2740,49 @@ pre.mermaid svg {
 
 .chat-widget-input-area {
   display: flex;
+  flex-wrap: wrap;
   align-items: flex-end;
   gap: 8px;
   padding: 8px 12px 12px;
   border-top: 1px solid rgba(255, 255, 255, 0.06);
   flex-shrink: 0;
+}
+
+.chat-attachments {
+  display: flex;
+  flex-basis: 100%;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+}
+
+.chat-attachment-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 220px;
+  border: 1px solid rgba(16, 185, 129, 0.35);
+  border-radius: 999px;
+  padding: 3px 7px;
+  color: #d1fae5;
+  background: rgba(16, 185, 129, 0.1);
+}
+
+.chat-attachment-chip button {
+  border: 0;
+  padding: 0;
+  color: inherit;
+  background: transparent;
+  cursor: pointer;
+}
+
+.chat-attachment-note {
+  color: #9ca3af;
+}
+
+.chat-attachment-input {
+  display: none;
 }
 
 .chat-widget-textarea {
@@ -2776,6 +2814,7 @@ pre.mermaid svg {
   opacity: 0.5;
 }
 
+.chat-widget-attachment-btn,
 .chat-widget-send-btn {
   display: flex;
   align-items: center;
@@ -2791,10 +2830,22 @@ pre.mermaid svg {
   transition: background 0.15s, opacity 0.15s;
 }
 
+.chat-widget-attachment-btn {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: #9ca3af;
+}
+
+.chat-widget-attachment-btn:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.1);
+  color: #e5e7eb;
+}
+
 .chat-widget-send-btn:hover:not(:disabled) {
   background: #15803d;
 }
 
+.chat-widget-attachment-btn:disabled,
 .chat-widget-send-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
@@ -2842,6 +2893,27 @@ pre.mermaid svg {
   background: #f3f4f6;
   border-color: rgba(0, 0, 0, 0.1);
   color: #111827;
+}
+
+[data-theme="light"] .chat-attachment-chip {
+  color: #047857;
+  border-color: rgba(16, 185, 129, 0.4);
+  background: #ecfdf5;
+}
+
+[data-theme="light"] .chat-attachment-note {
+  color: #6b7280;
+}
+
+[data-theme="light"] .chat-widget-attachment-btn {
+  color: #6b7280;
+  background: #f9fafb;
+  border-color: #e5e7eb;
+}
+
+[data-theme="light"] .chat-widget-attachment-btn:hover:not(:disabled) {
+  color: #111827;
+  background: #f3f4f6;
 }
 
 [data-theme="light"] .chat-widget-disclaimer {

--- a/src/components/docs/chat-widget.tsx
+++ b/src/components/docs/chat-widget.tsx
@@ -18,6 +18,13 @@ interface ChatState {
   threadId: string | null;
 }
 
+interface ChatAttachment {
+  id: string;
+  name: string;
+  size: number;
+  type: string;
+}
+
 type ChatAction =
   | { type: "TOGGLE" }
   | { type: "OPEN" }
@@ -147,8 +154,10 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
   });
 
   const [input, setInput] = useState("");
+  const [attachments, setAttachments] = useState<ChatAttachment[]>([]);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const abortRef = useRef<AbortController | null>(null);
 
   // Listen for toggle-ask-ai custom event from topbar button
@@ -199,10 +208,22 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
 
   const sendMessage = useCallback(async () => {
     const trimmed = input.trim();
-    if (!trimmed || state.isStreaming) return;
+    if ((!trimmed && attachments.length === 0) || state.isStreaming) return;
+
+    const attachmentSummary =
+      attachments.length > 0
+        ? `\n\nAttachments selected (metadata only): ${attachments
+            .map((file) => `${file.name} (${file.type || "unknown type"})`)
+            .join(", ")}`
+        : "";
+    const messageContent =
+      trimmed || "Please review the selected attachment metadata.";
+    const contentWithAttachments = `${messageContent}${attachmentSummary}`;
 
     setInput("");
-    dispatch({ type: "ADD_USER_MESSAGE", content: trimmed });
+    setAttachments([]);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+    dispatch({ type: "ADD_USER_MESSAGE", content: contentWithAttachments });
     dispatch({ type: "START_STREAMING" });
 
     // Build messages for request (current messages + new user message)
@@ -215,7 +236,7 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
       {
         id: `msg-${Date.now()}`,
         role: "user",
-        content: trimmed,
+        content: contentWithAttachments,
       },
     ];
 
@@ -300,6 +321,7 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
     }
   }, [
     input,
+    attachments,
     state.isStreaming,
     state.messages,
     state.threadId,
@@ -312,6 +334,21 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
       e.preventDefault();
       sendMessage();
     }
+  };
+
+  const handleAttachmentChange = (files: FileList | null) => {
+    const selected = Array.from(files ?? []).map((file) => ({
+      id: `${file.name}-${file.size}-${file.lastModified}`,
+      name: file.name,
+      size: file.size,
+      type: file.type,
+    }));
+    setAttachments(selected);
+  };
+
+  const removeAttachment = (id: string) => {
+    setAttachments((current) => current.filter((file) => file.id !== id));
+    if (fileInputRef.current) fileInputRef.current.value = "";
   };
 
   if (!state.isOpen) return null;
@@ -474,6 +511,25 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
 
       {/* Input */}
       <div className="chat-widget-input-area">
+        {attachments.length > 0 && (
+          <div className="chat-attachments" data-testid="chat-attachments">
+            {attachments.map((file) => (
+              <span className="chat-attachment-chip" key={file.id}>
+                {file.name}
+                <button
+                  type="button"
+                  aria-label={`Remove attachment ${file.name}`}
+                  onClick={() => removeAttachment(file.id)}
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+            <span className="chat-attachment-note">
+              File contents are not uploaded yet.
+            </span>
+          </div>
+        )}
         <textarea
           ref={inputRef}
           data-testid="chat-input"
@@ -485,11 +541,45 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
           rows={1}
           disabled={state.isStreaming}
         />
+        <input
+          ref={fileInputRef}
+          data-testid="chat-attachment-input"
+          className="chat-attachment-input"
+          type="file"
+          multiple
+          accept="image/*,.pdf,.js,.jsx,.ts,.tsx,.mjs,.cjs,.md,.mdx,.json,.html,.css,.py,.csv,.txt,.yaml,.yml,.xml"
+          onChange={(e) => handleAttachmentChange(e.target.files)}
+        />
+        <button
+          type="button"
+          data-testid="chat-attachment-btn"
+          className="chat-widget-attachment-btn"
+          aria-label="Add attachment"
+          title="Add attachment"
+          disabled={state.isStreaming}
+          onClick={() => fileInputRef.current?.click()}
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M21.44 11.05 12.25 20.24a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+          </svg>
+        </button>
         <button
           type="button"
           data-testid="chat-send-btn"
           className="chat-widget-send-btn"
-          disabled={!input.trim() || state.isStreaming}
+          disabled={
+            (!input.trim() && attachments.length === 0) || state.isStreaming
+          }
           onClick={sendMessage}
           title="Send message"
         >

--- a/tests/chat-widget.test.tsx
+++ b/tests/chat-widget.test.tsx
@@ -51,6 +51,53 @@ describe("Docs chat widget code context", () => {
     ).not.toBeNull();
   });
 
+  it("shows an attachment picker and selected file feedback", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <>
+          <AskAiButton />
+          <ChatWidget subdomain="feature004-qa" currentPath="introduction" />
+        </>,
+      );
+    });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="ask-ai-btn"]')
+        ?.click();
+    });
+
+    expect(
+      container.querySelector<HTMLButtonElement>(
+        '[data-testid="chat-attachment-btn"][aria-label="Add attachment"]',
+      ),
+    ).not.toBeNull();
+
+    const fileInput = container.querySelector<HTMLInputElement>(
+      '[data-testid="chat-attachment-input"]',
+    );
+    const file = new File(["hello"], "notes.md", { type: "text/markdown" });
+    Object.defineProperty(fileInput, "files", {
+      configurable: true,
+      value: [file],
+    });
+
+    await act(async () => {
+      fileInput?.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    expect(
+      container.querySelector('[data-testid="chat-attachments"]')?.textContent,
+    ).toContain("notes.md");
+    expect(
+      container.querySelector('[data-testid="chat-attachments"]')?.textContent,
+    ).toContain("File contents are not uploaded yet.");
+  });
+
   it("opens the chat panel with code context when a code-block Ask AI button is clicked", async () => {
     const html = renderMdxContent("```ts app.ts\nconst answer = 42;\n```");
     const container = document.createElement("div");


### PR DESCRIPTION
## Summary
- add an `Add attachment` affordance and hidden file input to the docs AI assistant composer
- show selected-file feedback with removal and a clear limitation note that contents are not uploaded yet
- add regression coverage for attachment selection feedback

## Ever verification
Evidence stored in ignored local path: `private/issue-88-ever/20260506-220559/`
- Reference: `01-mintlify-before-assistant.txt` -> `02-mintlify-click-assistant.txt` -> `03-mintlify-after-assistant.txt` shows Mintlify exposes `INPUT type=file` and `BUTTON aria-label=Add attachment`.
- Deployed OpenDocs gap: `04-deployed-opendocs-before-assistant.txt` -> `05-deployed-opendocs-click-assistant.txt` -> `06-deployed-opendocs-after-assistant.txt` shows only the assistant textarea, with no attachment affordance.
- Local fixed branch: `08-local-before-assistant.txt` -> `09-local-click-assistant.txt` -> `10-local-after-assistant.txt` shows the local assistant exposes `INPUT type=file` and `BUTTON title=Add attachment aria-label=Add attachment`.

## Regression verification
- `npm test -- tests/chat-widget.test.tsx`
- `make check`
- `make test` (1744 passed)

## Not run
- full `make test-e2e`; Ashley explicitly directed Ever CLI as the primary browser QA path and no targeted Playwright regression was needed.

Closes #88
