### PR TITLE
Expose docs sidebar group toggle state

### DIFF
--- a/src/components/docs/docs-sidebar.tsx
+++ b/src/components/docs/docs-sidebar.tsx
@@ -8,7 +8,7 @@ import {
 import type { DocsNavEntry } from "@/lib/mdx-renderer";
 import { ChevronDown, FileText } from "lucide-react";
 import Link from "next/link";
-import { useState } from "react";
+import { useId, useState } from "react";
 
 interface DocsSidebarProps {
   nav: DocsNavEntry[];
@@ -132,14 +132,17 @@ function NavGroup({
   activePath: string;
   subdomain: string;
 }) {
-  const isGroupActive = entry.items.some((item) => item.path === activePath);
   const [isOpen, setIsOpen] = useState(true);
+  const groupItemsId = useId();
 
   return (
     <div className="docs-nav-group">
       <button
         type="button"
         className="docs-nav-group-label"
+        aria-label={`Toggle ${entry.label} section`}
+        aria-expanded={isOpen}
+        aria-controls={groupItemsId}
         onClick={() => setIsOpen(!isOpen)}
       >
         <span>{entry.label}</span>
@@ -149,7 +152,7 @@ function NavGroup({
         />
       </button>
       {isOpen && (
-        <div className="docs-nav-group-items">
+        <div className="docs-nav-group-items" id={groupItemsId}>
           {entry.items.map((item) => (
             <NavItem
               key={item.pageId}

--- a/tests/docs-sidebar.test.tsx
+++ b/tests/docs-sidebar.test.tsx
@@ -1,0 +1,62 @@
+import { DocsSidebar } from "@/components/docs/docs-sidebar";
+import type { DocsNavEntry } from "@/lib/mdx-renderer";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it } from "vitest";
+
+// React 19 requires this flag for act() in non-testing-library environments.
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const nav: DocsNavEntry[] = [
+  {
+    type: "group",
+    label: "Guides",
+    items: [
+      {
+        type: "item",
+        label: "Quickstart",
+        path: "guides/quickstart",
+        pageId: "page-1",
+      },
+    ],
+  },
+];
+
+describe("DocsSidebar", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("labels sidebar group toggles and exposes expanded state", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <DocsSidebar
+          nav={nav}
+          activePath="introduction"
+          subdomain="test-project"
+          projectName="Test Project"
+        />,
+      );
+    });
+
+    const toggle = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Toggle Guides section"]',
+    );
+
+    expect(toggle).not.toBeNull();
+    expect(toggle?.getAttribute("aria-expanded")).toBe("true");
+    expect(toggle?.getAttribute("aria-controls")).toBeTruthy();
+
+    await act(async () => {
+      toggle?.click();
+    });
+
+    expect(toggle?.getAttribute("aria-expanded")).toBe("false");
+  });
+});


### PR DESCRIPTION
## Summary
- add accessible labels to collapsible docs sidebar group buttons
- expose `aria-expanded` and `aria-controls` so group state is visible to assistive tech
- add regression coverage for the sidebar group toggle state transition

## Ever verification
Evidence stored in ignored local path: `private/issue-90-ever/20260506-221309/`
- Reference: `01-mintlify-sidebar-before.txt` -> `02-mintlify-click-cli-toggle.txt` -> `03-mintlify-sidebar-after-cli-toggle.txt` shows Mintlify sidebar groups expose `aria-label=Toggle CLI section` and change `expanded=false` to `expanded=true`.
- Deployed OpenDocs gap: `04-deployed-opendocs-sidebar-before.txt` -> `05-deployed-opendocs-click-guides-toggle.txt` -> `06-deployed-opendocs-sidebar-after-guides-toggle.txt` shows `Guides`/`Api reference` as bare `<BUTTON />` controls.
- Local fixed branch: `08-local-sidebar-before.txt` -> `09-local-click-guides-toggle.txt` -> `10-local-sidebar-after-guides-toggle.txt` shows `aria-label=Toggle Guides section expanded=true` toggling to `expanded=false`.

## Regression verification
- `npm test -- tests/docs-sidebar.test.tsx`
- `make check`
- `make test` (1744 passed)

## Not run
- full `make test-e2e`; Ashley explicitly directed Ever CLI as the primary browser QA path and no targeted Playwright regression was needed.

Closes #90
