### PR TITLE
Label docs heading permalink anchors

### DIFF
--- a/src/lib/mdx-renderer.ts
+++ b/src/lib/mdx-renderer.ts
@@ -310,7 +310,7 @@ export function parseMdxToHtml(content: string): string {
       const text = headingMatch[2].trim();
       const id = slugify(text);
       output.push(
-        `<h${level} id="${id}"><a href="#${id}" class="heading-anchor">${renderInline(text)}</a></h${level}>`,
+        `<h${level} id="${id}"><a href="#${id}" class="heading-anchor" aria-label="Navigate to header">${renderInline(text)}</a></h${level}>`,
       );
       i++;
       continue;

--- a/tests/mdx-renderer.test.ts
+++ b/tests/mdx-renderer.test.ts
@@ -18,6 +18,13 @@ describe("MDX Renderer utilities", () => {
       expect(result).toContain("Hello World");
     });
 
+    it("labels heading permalink anchors for assistive technology", () => {
+      const result = parseMdxToHtml("## Getting Started");
+      expect(result).toContain('href="#getting-started"');
+      expect(result).toContain('class="heading-anchor"');
+      expect(result).toContain('aria-label="Navigate to header"');
+    });
+
     it("converts bold and italic text", () => {
       const result = parseMdxToHtml("**bold** and *italic*");
       expect(result).toContain("<strong>bold</strong>");


### PR DESCRIPTION
## Summary
- add a Mintlify-like `aria-label="Navigate to header"` to generated MDX heading permalink anchors
- preserve existing heading text, hash links, and table-of-contents behavior
- add regression coverage for labeled heading anchors

## Ever verification
Evidence stored in ignored local path: `private/issue-92-ever/20260506-221901/`
- Reference: `01-mintlify-heading-anchors-before.txt` -> `02-mintlify-click-heading-anchor.txt` -> `03-mintlify-after-heading-anchor.txt` shows Mintlify heading permalinks exposed as `A aria-label=Navigate to header`.
- Deployed OpenDocs gap: `04-deployed-opendocs-heading-anchors-before.txt` -> `05-deployed-opendocs-click-heading-link.txt` -> `06-deployed-opendocs-after-heading-link.txt` shows OpenDocs headings exposed as plain `<A />` links.
- Local fixed branch: `08-local-heading-anchors-before.txt` -> `09-local-click-heading-anchor.txt` -> `10-local-after-heading-anchor.txt` shows OpenDocs generated headings now expose `A aria-label=Navigate to header` and remain clickable.

## Regression verification
- `npm test -- tests/mdx-renderer.test.ts`
- `make check`
- `make test` (1744 passed)

## Not run
- full `make test-e2e`; Ashley explicitly directed Ever CLI as the primary browser QA path and no targeted Playwright regression was needed.

Closes #92
