### PR TITLE
Brand public docs footer as Powered by OpenDocs

### DIFF
--- a/src/lib/docs-footer.ts
+++ b/src/lib/docs-footer.ts
@@ -46,12 +46,12 @@ export function getValidSocialLinks(
   );
 }
 
-/** Get the brand name, defaulting to project name or "Mintlify" */
+/** Get the brand name, defaulting to the OpenDocs platform brand */
 export function getBrandName(
   footerSettings: FooterSettings,
-  projectName?: string,
+  _projectName?: string,
 ): string {
-  return footerSettings.brandName || projectName || "Mintlify";
+  return footerSettings.brandName || "OpenDocs";
 }
 
 /** Get the brand URL, defaulting to "/" */

--- a/tests/docs-footer.test.ts
+++ b/tests/docs-footer.test.ts
@@ -106,12 +106,12 @@ describe("docs-footer utilities", () => {
       expect(getBrandName({ brandName: "Acme Docs" })).toBe("Acme Docs");
     });
 
-    it("falls back to projectName when brandName not set", () => {
-      expect(getBrandName({}, "My Project")).toBe("My Project");
+    it("falls back to OpenDocs when brandName not set", () => {
+      expect(getBrandName({}, "My Project")).toBe("OpenDocs");
     });
 
-    it("falls back to Mintlify when nothing set", () => {
-      expect(getBrandName({})).toBe("Mintlify");
+    it("falls back to OpenDocs when nothing set", () => {
+      expect(getBrandName({})).toBe("OpenDocs");
     });
 
     it("prefers brandName over projectName", () => {
@@ -138,9 +138,9 @@ describe("docs-footer utilities", () => {
       );
     });
 
-    it("generates tooltip with Mintlify default", () => {
-      expect(getPoweredByTooltip("Mintlify")).toBe(
-        "This documentation is built and hosted on Mintlify",
+    it("generates tooltip with OpenDocs default", () => {
+      expect(getPoweredByTooltip("OpenDocs")).toBe(
+        "This documentation is built and hosted on OpenDocs",
       );
     });
   });


### PR DESCRIPTION
## Summary
- default the public docs powered-by footer brand to `OpenDocs`
- preserve explicit footer brand overrides from project settings
- update footer utility coverage for the platform-brand default

## Ever verification
Evidence stored in ignored local path: `private/issue-94-ever/20260506-222515/`
- Reference: `01-mintlify-before-scroll.txt` -> `02-mintlify-scroll-bottom.txt` -> `03-mintlify-footer-after-scroll.txt` shows Mintlify footer/platform branding (`Mintlify home page`) and platform footer links.
- Deployed OpenDocs gap: `04-deployed-opendocs-before-scroll.txt` -> `05-deployed-opendocs-scroll-bottom.txt` -> `06-deployed-opendocs-footer-after-scroll.txt` shows `Powered by` `Test Project`.
- Local fixed branch: `08-local-before-scroll.txt` -> `09-local-scroll-bottom.txt` -> `10-local-footer-after-scroll.txt` shows `Powered by` `OpenDocs` while header/sidebar still show the project name.

## Regression verification
- `npm test -- tests/docs-footer.test.ts`
- `make check`
- `make test` (1743 passed)

## Not run
- full `make test-e2e`; Ashley explicitly directed Ever CLI as the primary browser QA path and no targeted Playwright regression was needed.

Closes #94
