### PR TITLE
Label docs version and language selectors

### DIFF
--- a/src/components/docs/language-switcher.tsx
+++ b/src/components/docs/language-switcher.tsx
@@ -60,6 +60,7 @@ export function LanguageSwitcher({
         type="button"
         className="lang-switcher-btn"
         onClick={() => setOpen((v) => !v)}
+        aria-label={`Select docs language, current language ${currentInfo?.name ?? currentLocale}`}
         aria-expanded={open}
         aria-haspopup="listbox"
         data-testid="language-switcher-btn"
@@ -109,6 +110,7 @@ export function LanguageSwitcher({
               <button
                 key={locale}
                 type="button"
+                aria-label={`Switch to ${info?.name ?? locale}`}
                 aria-current={isActive ? "true" : undefined}
                 className={`lang-switcher-option ${isActive ? "lang-switcher-option-active" : ""}`}
                 onClick={() => handleSelect(locale)}

--- a/src/components/docs/version-switcher.tsx
+++ b/src/components/docs/version-switcher.tsx
@@ -69,6 +69,7 @@ export function VersionSwitcher({
         type="button"
         className="version-switcher-btn"
         onClick={() => setOpen((v) => !v)}
+        aria-label={`Select docs version, current version ${currentInfo?.name ?? currentVersion}`}
         aria-expanded={open}
         aria-haspopup="listbox"
         data-testid="version-switcher-btn"
@@ -118,6 +119,7 @@ export function VersionSwitcher({
               <button
                 key={tag}
                 type="button"
+                aria-label={`Switch to docs version ${info?.name ?? tag}${isDefault ? " (default)" : ""}`}
                 aria-current={isActive ? "true" : undefined}
                 className={`version-switcher-option ${isActive ? "version-switcher-option-active" : ""}`}
                 onClick={() => handleSelect(tag)}

--- a/tests/docs-selector-a11y.test.tsx
+++ b/tests/docs-selector-a11y.test.tsx
@@ -1,0 +1,118 @@
+import { LanguageSwitcher } from "@/components/docs/language-switcher";
+import { VersionSwitcher } from "@/components/docs/version-switcher";
+import type { VersionsConfig } from "@/lib/versions";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const push = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+// React 19 requires this flag for act() in non-testing-library environments.
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("docs selector accessibility", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    push.mockClear();
+    document.body.innerHTML = "";
+  });
+
+  it("labels the version selector and version options", async () => {
+    const versionsConfig: VersionsConfig = {
+      enabled: true,
+      versions: [
+        { tag: "v1", name: "Version 1.0", isDefault: false },
+        { tag: "v2", name: "Version 2.0", isDefault: true },
+      ],
+    };
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <VersionSwitcher
+          currentVersion="v2"
+          availableVersions={["v1", "v2"]}
+          versionsConfig={versionsConfig}
+          subdomain="test-project"
+          pagePath="introduction"
+        />,
+      );
+    });
+
+    const trigger = container.querySelector<HTMLButtonElement>(
+      '[data-testid="version-switcher-btn"]',
+    );
+
+    expect(trigger?.getAttribute("aria-label")).toBe(
+      "Select docs version, current version Version 2.0",
+    );
+    expect(trigger?.getAttribute("aria-expanded")).toBe("false");
+
+    await act(async () => {
+      trigger?.click();
+    });
+
+    expect(trigger?.getAttribute("aria-expanded")).toBe("true");
+    expect(
+      container
+        .querySelector('[data-testid="version-option-v1"]')
+        ?.getAttribute("aria-label"),
+    ).toBe("Switch to docs version Version 1.0");
+    expect(
+      container
+        .querySelector('[data-testid="version-option-v2"]')
+        ?.getAttribute("aria-label"),
+    ).toBe("Switch to docs version Version 2.0 (default)");
+  });
+
+  it("labels the language selector and language options", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <LanguageSwitcher
+          currentLocale="en"
+          availableLocales={["en", "ko"]}
+          subdomain="test-project"
+          pagePath="introduction"
+          defaultLanguage="en"
+        />,
+      );
+    });
+
+    const trigger = container.querySelector<HTMLButtonElement>(
+      '[data-testid="language-switcher-btn"]',
+    );
+
+    expect(trigger?.getAttribute("aria-label")).toBe(
+      "Select docs language, current language English",
+    );
+    expect(trigger?.getAttribute("aria-expanded")).toBe("false");
+
+    await act(async () => {
+      trigger?.click();
+    });
+
+    expect(trigger?.getAttribute("aria-expanded")).toBe("true");
+    expect(
+      container
+        .querySelector('[data-testid="lang-option-en"]')
+        ?.getAttribute("aria-label"),
+    ).toBe("Switch to English");
+    expect(
+      container
+        .querySelector('[data-testid="lang-option-ko"]')
+        ?.getAttribute("aria-label"),
+    ).toBe("Switch to Korean");
+  });
+});


### PR DESCRIPTION
## Summary
- add accessible labels to docs version and language selector triggers
- add action labels to version/language menu options
- add regression coverage for selector labels and expanded state

## Ever verification
Evidence stored in ignored local path: `private/issue-96-ever/20260506-223235/`
- Reference: `01-mintlify-selectors-before.txt` -> `02-mintlify-click-language.txt` -> `03-mintlify-selectors-after-language.txt` shows Mintlify's named localization selector opening with expanded state.
- Deployed OpenDocs gap: `04-deployed-opendocs-selectors-before.txt` -> `05-deployed-opendocs-click-language.txt` -> `06-deployed-opendocs-selectors-after-language.txt` shows the OpenDocs version/language selector controls and options as bare buttons.
- Local fixed branch: `08-local-selectors-before.txt` -> `09-local-click-language.txt` -> `10-local-selectors-after-language.txt` shows labeled controls (`Select docs version`, `Select docs language`) and labeled language options (`Switch to English`, `Switch to French`).

## Regression verification
- `npm test -- tests/docs-selector-a11y.test.tsx`
- `make check`
- `make test` (1745 passed)

## Not run
- full `make test-e2e`; Ashley explicitly directed Ever CLI as the primary browser QA path and no targeted Playwright regression was needed.

Closes #96
