### PR TITLE
Label docs topbar search and assistant controls

### DIFF
--- a/src/components/docs/docs-topbar.tsx
+++ b/src/components/docs/docs-topbar.tsx
@@ -63,6 +63,7 @@ export function AskAiButton() {
       type="button"
       data-testid="ask-ai-btn"
       className="docs-topbar-ask-ai"
+      aria-label="Toggle assistant panel"
       onClick={() => {
         document.dispatchEvent(new CustomEvent("toggle-ask-ai"));
       }}
@@ -137,6 +138,7 @@ export function DocsTopbar({
         <button
           type="button"
           className="docs-search-btn"
+          aria-label="Open search"
           onClick={() => {
             document.dispatchEvent(new CustomEvent("open-search"));
           }}
@@ -148,9 +150,8 @@ export function DocsTopbar({
             fill="none"
             stroke="currentColor"
             strokeWidth="2"
-            aria-label="Search"
+            aria-hidden="true"
           >
-            <title>Search</title>
             <circle cx="11" cy="11" r="8" />
             <path d="m21 21-4.35-4.35" />
           </svg>

--- a/tests/docs-topbar.test.ts
+++ b/tests/docs-topbar.test.ts
@@ -1,9 +1,20 @@
-import { describe, expect, it, vi } from "vitest";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // Mock next/navigation
 vi.mock("next/navigation", () => ({
   usePathname: () => "/docs/test-project/quickstart",
 }));
+
+// React 19 requires this flag for act() in non-testing-library environments.
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
 
 describe("Docs topbar — feature-014a", () => {
   describe("DocsTopbar component exports", () => {
@@ -96,6 +107,45 @@ describe("Docs topbar — feature-014a", () => {
       expect(events).toHaveLength(1);
 
       document.removeEventListener("toggle-ask-ai", handler);
+    });
+
+    it("renders Mintlify-parity labels for the topbar search and assistant buttons", async () => {
+      const { AskAiButton, DocsTopbar } = await import(
+        "@/components/docs/docs-topbar"
+      );
+
+      const container = document.createElement("div");
+      document.body.appendChild(container);
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          createElement(
+            "div",
+            null,
+            createElement(AskAiButton),
+            createElement(DocsTopbar, {
+              projectName: "Test Project",
+              subdomain: "test-project",
+            }),
+          ),
+        );
+      });
+
+      const askButton = container.querySelector<HTMLButtonElement>(
+        '[data-testid="ask-ai-btn"]',
+      );
+      const searchButton =
+        container.querySelector<HTMLButtonElement>(".docs-search-btn");
+
+      expect(askButton?.getAttribute("aria-label")).toBe(
+        "Toggle assistant panel",
+      );
+      expect(searchButton?.getAttribute("aria-label")).toBe("Open search");
+
+      await act(async () => {
+        root.unmount();
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- add accessible labels to the docs topbar search and assistant controls
- preserve existing compact visible topbar UI
- add regression coverage for topbar control labels

## Verification
- `npm test -- tests/docs-topbar.test.ts` (14 passed)
- `make check`
- `make test` (1744 passed)
- Ever browser snapshot -> act -> snapshot evidence:
  - reference/deployed gap captured before fix
  - local `/docs/test-project/introduction` shows `aria-label=Open search` and `aria-label=Toggle assistant panel`
  - clicking labeled search opens the search dialog
  - clicking labeled assistant opens the AI Assistant panel

Closes #99
