### PR TITLE
Label API Try it controls for screen readers

### DIFF
--- a/src/lib/api-reference.ts
+++ b/src/lib/api-reference.ts
@@ -279,7 +279,7 @@ export function renderApiReferencePage(endpoint: OpenApiEndpoint): string {
     <span class="method-badge ${badge.colorClass}">${escapeHtml(badge.label)}</span>
     <span class="api-ref-path">${escapeHtml(endpoint.path)}</span>
   </div>
-  <button class="api-ref-tryit-btn" data-testid="tryit-btn">Try it ▶</button>
+  <button class="api-ref-tryit-btn" data-testid="tryit-btn" aria-label="Try it">Try it ▶</button>
 </div>`;
 
   // Code examples with language selector

--- a/tests/api-reference.test.ts
+++ b/tests/api-reference.test.ts
@@ -300,10 +300,11 @@ describe("renderApiReferencePage", () => {
     expect(html).toContain("/plants");
   });
 
-  it("renders Try it button", () => {
+  it("renders Try it button with Mintlify-parity accessible label", () => {
     const html = renderApiReferencePage(endpoint);
     expect(html).toContain("Try it");
     expect(html).toContain("tryit-btn");
+    expect(html).toContain('aria-label="Try it"');
   });
 
   it("renders code section with language tabs", () => {


### PR DESCRIPTION
## Summary
- add an explicit `aria-label="Try it"` to generated API reference Try it controls
- keep the visible `Try it ▶` UI unchanged
- add regression coverage for the generated API reference markup

## Verification
- `npm test -- tests/api-reference.test.ts` (38 passed)
- `make check`
- `make test` (1743 passed)
- Ever browser snapshot -> act -> snapshot evidence:
  - Mintlify endpoint page exposes `BUTTON aria-label=Try it`
  - deployed OpenDocs endpoint showed a bare visible `Try it ▶` button
  - local OpenDocs endpoint shows `BUTTON aria-label=Try it`
  - clicking the labeled local button keeps the request builder reachable

Closes #101
