### PR TITLE
Expose API response status controls as tabs

### DIFF
--- a/src/components/docs/api-reference-layout.tsx
+++ b/src/components/docs/api-reference-layout.tsx
@@ -96,13 +96,25 @@ export function ApiReferenceLayout({ html }: ApiReferenceLayoutProps) {
     for (const tab of statusTabs) {
       tab.addEventListener("click", () => {
         const status = tab.dataset.status;
-        for (const t of statusTabs) t.classList.remove("active");
-        for (const p of statusPanels) p.classList.remove("active");
+        for (const t of statusTabs) {
+          t.classList.remove("active");
+          t.setAttribute("aria-selected", "false");
+          t.tabIndex = -1;
+        }
+        for (const p of statusPanels) {
+          p.classList.remove("active");
+          p.hidden = true;
+        }
         tab.classList.add("active");
+        tab.setAttribute("aria-selected", "true");
+        tab.tabIndex = 0;
         const target = container.querySelector<HTMLDivElement>(
           `.api-ref-status-panel[data-status="${status}"]`,
         );
-        if (target) target.classList.add("active");
+        if (target) {
+          target.classList.add("active");
+          target.hidden = false;
+        }
       });
     }
 

--- a/src/lib/api-reference.ts
+++ b/src/lib/api-reference.ts
@@ -324,24 +324,24 @@ export function renderApiReferencePage(endpoint: OpenApiEndpoint): string {
   let responseSection = "";
   if (responseTabs.length > 0) {
     const tabs = responseTabs
-      .map(
-        (tab, i) =>
-          `<button class="api-ref-status-tab${i === 0 ? " active" : ""}" data-status="${escapeHtml(tab.statusCode)}">${escapeHtml(tab.statusCode)}</button>`,
-      )
+      .map((tab, i) => {
+        const status = escapeHtml(tab.statusCode);
+        return `<button id="api-response-tab-${status}" class="api-ref-status-tab${i === 0 ? " active" : ""}" data-status="${status}" role="tab" aria-selected="${i === 0 ? "true" : "false"}" aria-controls="api-response-panel-${status}" tabindex="${i === 0 ? "0" : "-1"}">${status}</button>`;
+      })
       .join("\n    ");
 
     const panels = responseTabs
-      .map(
-        (tab, i) =>
-          `<div class="api-ref-status-panel${i === 0 ? " active" : ""}" data-status="${escapeHtml(tab.statusCode)}">
+      .map((tab, i) => {
+        const status = escapeHtml(tab.statusCode);
+        return `<div id="api-response-panel-${status}" class="api-ref-status-panel${i === 0 ? " active" : ""}" data-status="${status}" role="tabpanel" aria-labelledby="api-response-tab-${status}"${i === 0 ? "" : " hidden"}>
       ${tab.description ? `<p class="api-ref-status-desc">${escapeHtml(tab.description)}</p>` : ""}
       <pre><code class="api-ref-response-example">${escapeHtml(getExampleResponse(tab.statusCode))}</code></pre>
-    </div>`,
-      )
+    </div>`;
+      })
       .join("\n");
 
     responseSection = `<div class="api-ref-responses" data-testid="response-tabs">
-  <div class="api-ref-status-tabs">
+  <div class="api-ref-status-tabs" role="tablist" aria-label="Response status codes">
     ${tabs}
   </div>
   ${panels}

--- a/tests/api-reference.test.ts
+++ b/tests/api-reference.test.ts
@@ -314,10 +314,16 @@ describe("renderApiReferencePage", () => {
     expect(html).toContain("JavaScript");
   });
 
-  it("renders response status tabs 200 and 400", () => {
+  it("renders response status controls with tab semantics", () => {
     const html = renderApiReferencePage(endpoint);
+    expect(html).toContain('role="tablist"');
+    expect(html).toContain('aria-label="Response status codes"');
     expect(html).toContain('data-status="200"');
+    expect(html).toContain('role="tab"');
+    expect(html).toContain('aria-selected="true"');
+    expect(html).toContain('role="tabpanel"');
     expect(html).toContain('data-status="400"');
+    expect(html).toContain('aria-selected="false"');
   });
 
   it("renders auth section for bearer token", () => {


### PR DESCRIPTION
## Summary
- render generated API response status controls as a labeled tablist
- add `role=tab`, `aria-selected`, `aria-controls`, and tabpanel relationships for response examples
- keep client-side status switching in sync with the active selected state

## Verification
- `npm test -- tests/api-reference.test.ts` (38 passed)
- `make check`
- `make test` (1743 passed)
- Ever browser snapshot -> act -> snapshot evidence:
  - Mintlify endpoint page exposes response status controls as tabs with selected state
  - deployed OpenDocs endpoint showed bare `200`/`400` buttons
  - local OpenDocs endpoint shows `BUTTON ... role=tab selected=true/false`
  - clicking the local `400` tab moves selected state from `200` to `400` and shows the 400 response body

Closes #103
