### PR TITLE
Label API code block action buttons

### DIFF
--- a/src/lib/api-reference.ts
+++ b/src/lib/api-reference.ts
@@ -306,11 +306,11 @@ export function renderApiReferencePage(endpoint: OpenApiEndpoint): string {
       ${langTabs}
     </div>
     <div class="api-ref-code-actions">
-      <button class="api-ref-copy-btn" data-testid="copy-btn" title="Copy code">
+      <button class="api-ref-copy-btn" data-testid="copy-btn" title="Copy code" aria-label="Copy the contents from the code block">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
         <span>cURL</span>
       </button>
-      <button class="api-ref-askai-btn" data-testid="askai-btn" title="Ask AI">
+      <button class="api-ref-askai-btn" data-testid="askai-btn" title="Ask AI" aria-label="Ask AI">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
         Ask AI
       </button>

--- a/tests/api-reference.test.ts
+++ b/tests/api-reference.test.ts
@@ -306,12 +306,16 @@ describe("renderApiReferencePage", () => {
     expect(html).toContain("tryit-btn");
   });
 
-  it("renders code section with language tabs", () => {
+  it("renders code section with language tabs and labeled actions", () => {
     const html = renderApiReferencePage(endpoint);
     expect(html).toContain("api-ref-lang-tab");
     expect(html).toContain("cURL");
     expect(html).toContain("Python");
     expect(html).toContain("JavaScript");
+    expect(html).toContain(
+      'aria-label="Copy the contents from the code block"',
+    );
+    expect(html).toContain('aria-label="Ask AI"');
   });
 
   it("renders response status tabs 200 and 400", () => {


### PR DESCRIPTION
## Summary
- add explicit accessible labels to generated API code-copy and Ask AI actions
- preserve existing titles and visible compact code toolbar UI
- add regression coverage for generated code action labels

## Verification
- `npm test -- tests/api-reference.test.ts` (38 passed)
- `make check`
- `make test` (1743 passed)
- Ever browser snapshot -> act -> snapshot evidence:
  - Mintlify API code actions expose `aria-label=Copy the contents from the code block` and `aria-label=Ask AI`
  - deployed OpenDocs showed title-only code actions
  - local OpenDocs shows both aria labels
  - clicking local code copy keeps `Copied!` feedback working

Closes #105
