### PR TITLE
Expose docs search dialog combobox semantics

### DIFF
--- a/src/components/docs/search-modal.tsx
+++ b/src/components/docs/search-modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -114,6 +114,11 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const abortRef = useRef<AbortController | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const listboxId = useId();
+  const optionIdForIndex = useCallback(
+    (index: number) => `${listboxId}-option-${index}`,
+    [listboxId],
+  );
 
   const open = useCallback(() => {
     setIsOpen(true);
@@ -267,6 +272,19 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
   const grouped = groupResults(results);
   const hasQuery = query.trim().length > 0;
   const showRecent = !hasQuery && recentSearches.length > 0;
+  const activeDescendant = allResults[selectedIdx]
+    ? optionIdForIndex(selectedIdx)
+    : undefined;
+  const listboxProps = {
+    role: "listbox",
+    tabIndex: -1,
+    "aria-label": "Search results",
+  } as const;
+  const optionProps = (selected: boolean) =>
+    ({
+      role: "option",
+      "aria-selected": selected,
+    }) as const;
 
   return (
     <div
@@ -302,6 +320,12 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
             ref={inputRef}
             data-testid="search-input"
             type="text"
+            role="combobox"
+            aria-label="Search documentation"
+            aria-autocomplete="list"
+            aria-expanded="true"
+            aria-controls={listboxId}
+            aria-activedescendant={activeDescendant}
             className="search-modal-input"
             placeholder="Search documentation..."
             value={query}
@@ -310,7 +334,12 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
           <kbd className="search-modal-esc">Esc</kbd>
         </div>
 
-        <div className="search-modal-results" data-testid="search-results">
+        <div
+          id={listboxId}
+          className="search-modal-results"
+          data-testid="search-results"
+          {...listboxProps}
+        >
           {/* Loading indicator */}
           {loading && hasQuery && (
             <div className="search-modal-loading">Searching...</div>
@@ -320,31 +349,35 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
           {showRecent && (
             <div data-testid="recent-searches" className="search-modal-section">
               <div className="search-modal-section-title">Recent searches</div>
-              {recentSearches.map((q) => (
-                <button
-                  key={q}
-                  type="button"
-                  className="search-modal-result search-modal-recent"
-                  onClick={() => {
-                    setQuery(q);
-                    fetchResults(q);
-                  }}
-                >
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    aria-hidden="true"
+              {recentSearches.map((q, index) => {
+                return (
+                  <button
+                    key={q}
+                    id={optionIdForIndex(index)}
+                    type="button"
+                    {...optionProps(false)}
+                    className="search-modal-result search-modal-recent"
+                    onClick={() => {
+                      setQuery(q);
+                      fetchResults(q);
+                    }}
                   >
-                    <circle cx="12" cy="12" r="10" />
-                    <polyline points="12 6 12 12 16 14" />
-                  </svg>
-                  <span>{q}</span>
-                </button>
-              ))}
+                    <svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      aria-hidden="true"
+                    >
+                      <circle cx="12" cy="12" r="10" />
+                      <polyline points="12 6 12 12 16 14" />
+                    </svg>
+                    <span>{q}</span>
+                  </button>
+                );
+              })}
             </div>
           )}
 
@@ -367,7 +400,9 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
                   return (
                     <Link
                       key={result.path}
+                      id={optionIdForIndex(flatIdx)}
                       href={`/docs/${subdomain}/${result.path}`}
+                      {...optionProps(flatIdx === selectedIdx)}
                       className={`search-modal-result ${flatIdx === selectedIdx ? "search-modal-result-active" : ""}`}
                       onClick={() => {
                         saveRecentSearch(query);
@@ -410,29 +445,33 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
           {/* Default: show all pages when no query */}
           {!hasQuery &&
             !showRecent &&
-            pages.slice(0, 10).map((page) => (
-              <Link
-                key={page.path}
-                href={`/docs/${subdomain}/${page.path}`}
-                className="search-modal-result"
-                onClick={close}
-              >
-                <svg
-                  width="16"
-                  height="16"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  aria-hidden="true"
+            pages.slice(0, 10).map((page, index) => {
+              return (
+                <Link
+                  key={page.path}
+                  id={optionIdForIndex(index)}
+                  href={`/docs/${subdomain}/${page.path}`}
+                  {...optionProps(false)}
+                  className="search-modal-result"
+                  onClick={close}
                 >
-                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-                  <polyline points="14 2 14 8 20 8" />
-                </svg>
-                <span>{page.title}</span>
-                <span className="search-modal-result-path">{page.path}</span>
-              </Link>
-            ))}
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    aria-hidden="true"
+                  >
+                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                    <polyline points="14 2 14 8 20 8" />
+                  </svg>
+                  <span>{page.title}</span>
+                  <span className="search-modal-result-path">{page.path}</span>
+                </Link>
+              );
+            })}
         </div>
 
         {/* Footer with keyboard hints */}

--- a/tests/docs-site-layout.test.ts
+++ b/tests/docs-site-layout.test.ts
@@ -1,9 +1,16 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock next/navigation
 vi.mock("next/navigation", () => ({
   usePathname: () => "/docs/test-project/quickstart",
 }));
+
+// React 19 requires this flag for act() in non-testing-library environments.
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
 
 describe("Docs site layout — feature-014", () => {
   describe("ThemeProvider", () => {
@@ -108,6 +115,47 @@ describe("Docs site layout — feature-014", () => {
       const pages = [{ path: "quickstart", title: "Quickstart Guide" }];
       expect(filterPages(pages, "QUICK")).toHaveLength(1);
       expect(filterPages(pages, "quick")).toHaveLength(1);
+    });
+
+    it("renders search dialog with combobox and listbox semantics", async () => {
+      const { SearchModal } = await import("@/components/docs/search-modal");
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          createElement(SearchModal, {
+            subdomain: "test-project",
+            pages: [
+              { path: "introduction", title: "Introduction" },
+              { path: "quickstart", title: "Quickstart" },
+            ],
+          }),
+        );
+      });
+
+      await act(async () => {
+        document.dispatchEvent(new CustomEvent("open-search"));
+      });
+
+      const input = container.querySelector<HTMLInputElement>(
+        '[data-testid="search-input"]',
+      );
+      const results = container.querySelector<HTMLElement>(
+        '[data-testid="search-results"]',
+      );
+      const firstOption =
+        container.querySelector<HTMLElement>('[role="option"]');
+
+      expect(input?.getAttribute("role")).toBe("combobox");
+      expect(input?.getAttribute("aria-autocomplete")).toBe("list");
+      expect(input?.getAttribute("aria-expanded")).toBe("true");
+      expect(input?.getAttribute("aria-controls")).toBe(results?.id);
+      expect(results?.getAttribute("role")).toBe("listbox");
+      expect(firstOption?.getAttribute("aria-selected")).toBe("false");
+
+      await act(async () => {
+        root.unmount();
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- expose the docs search dialog input as a combobox
- expose search results/default pages as a labeled listbox with options and selected state
- preserve the existing visible search UI and Cmd+K behavior

## Verification
- `npm test -- tests/docs-site-layout.test.ts` (13 passed)
- `make check`
- `make test` (1744 passed)
- Ever browser snapshot -> act -> snapshot evidence:
  - Mintlify `Cmd+K` search shows `INPUT role=combobox` and `DIV role=listbox`
  - deployed OpenDocs `Cmd+K` search showed a plain input/result list
  - local OpenDocs `Meta+K` search shows `role=combobox`, `role=listbox`, and `role=option`
  - typing `quick` shows selected query results inside the listbox

Closes #107
