### PR TITLE
Label API playground parameter inputs

### DIFF
--- a/src/lib/openapi-parser.ts
+++ b/src/lib/openapi-parser.ts
@@ -246,6 +246,22 @@ function methodClass(method: string): string {
   return HTTP_METHODS.has(normalized) ? normalized : "unknown";
 }
 
+function apiPlaygroundInputLabel(
+  name: string,
+  location: OpenApiParameter["in"],
+): string {
+  switch (location) {
+    case "header":
+      return `Enter ${name} header`;
+    case "path":
+      return `Enter ${name} path parameter`;
+    case "query":
+      return `Enter ${name} query parameter`;
+    case "cookie":
+      return `Enter ${name} cookie parameter`;
+  }
+}
+
 /** Escape for textarea content — only & and < need escaping, not quotes. */
 function escapeTextarea(str: string): string {
   return str.replace(/&/g, "&amp;").replace(/</g, "&lt;");
@@ -280,7 +296,7 @@ export function renderApiPlaygroundHtml(endpoint: OpenApiEndpoint): string {
   <h4 class="api-section-title">Authorization</h4>
   <div class="api-param-row auth-header-input">
     <label class="api-param-label">Authorization</label>
-    <input type="text" class="api-param-input" data-param-name="Authorization" data-param-in="header" placeholder="${escapeAttribute(placeholder)}" value="${endpoint.auth.scheme === "bearer" ? "Bearer " : ""}" />
+    <input type="text" class="api-param-input" data-param-name="Authorization" data-param-in="header" aria-label="${escapeAttribute(apiPlaygroundInputLabel("Authorization", "header"))}" placeholder="${escapeAttribute(placeholder)}" value="${endpoint.auth.scheme === "bearer" ? "Bearer " : ""}" />
   </div>
 </div>`;
   }
@@ -295,7 +311,7 @@ export function renderApiPlaygroundHtml(endpoint: OpenApiEndpoint): string {
           `<div class="api-param-row">
     <label class="api-param-label">${escapeHtml(p.name)} <span class="param-required">required</span></label>
     ${p.description ? `<span class="param-description">${escapeHtml(p.description)}</span>` : ""}
-    <input type="text" class="api-param-input" data-param-name="${escapeAttribute(p.name)}" data-param-in="path" placeholder="${escapeAttribute(p.schema?.type || "string")}" />
+    <input type="text" class="api-param-input" data-param-name="${escapeAttribute(p.name)}" data-param-in="path" aria-label="${escapeAttribute(apiPlaygroundInputLabel(p.name, "path"))}" placeholder="${escapeAttribute(p.schema?.type || "string")}" />
   </div>`,
       )
       .join("\n");
@@ -315,7 +331,7 @@ export function renderApiPlaygroundHtml(endpoint: OpenApiEndpoint): string {
           `<div class="api-param-row">
     <label class="api-param-label">${escapeHtml(p.name)}${p.required ? ' <span class="param-required">required</span>' : ""}</label>
     ${p.description ? `<span class="param-description">${escapeHtml(p.description)}</span>` : ""}
-    <input type="text" class="api-param-input" data-param-name="${escapeAttribute(p.name)}" data-param-in="query" placeholder="${escapeAttribute(`${p.schema?.type || "string"}${p.schema?.default !== undefined ? ` (default: ${p.schema.default})` : ""}`)}" />
+    <input type="text" class="api-param-input" data-param-name="${escapeAttribute(p.name)}" data-param-in="query" aria-label="${escapeAttribute(apiPlaygroundInputLabel(p.name, "query"))}" placeholder="${escapeAttribute(`${p.schema?.type || "string"}${p.schema?.default !== undefined ? ` (default: ${p.schema.default})` : ""}`)}" />
   </div>`,
       )
       .join("\n");
@@ -338,7 +354,7 @@ export function renderApiPlaygroundHtml(endpoint: OpenApiEndpoint): string {
     bodyHtml = `<div class="api-section">
   <h4 class="api-section-title">Body</h4>
   <div class="request-body-editor">
-    <textarea class="api-body-textarea" data-content-type="${escapeAttribute(endpoint.requestBody.contentType)}" rows="8" spellcheck="false">${escapeTextarea(exampleJson)}</textarea>
+    <textarea class="api-body-textarea" data-content-type="${escapeAttribute(endpoint.requestBody.contentType)}" aria-label="Enter request body" rows="8" spellcheck="false">${escapeTextarea(exampleJson)}</textarea>
   </div>
 </div>`;
   }

--- a/tests/api-playground.test.ts
+++ b/tests/api-playground.test.ts
@@ -263,6 +263,7 @@ describe("API Playground HTML Renderer", () => {
     const html = renderApiPlaygroundHtml(getUser);
     expect(html).toContain('data-param-name="id"');
     expect(html).toContain('data-param-in="path"');
+    expect(html).toContain('aria-label="Enter id path parameter"');
   });
 
   it("renders parameter inputs for query params", () => {
@@ -273,6 +274,7 @@ describe("API Playground HTML Renderer", () => {
     const html = renderApiPlaygroundHtml(listUsers);
     expect(html).toContain('data-param-name="limit"');
     expect(html).toContain('data-param-in="query"');
+    expect(html).toContain('aria-label="Enter limit query parameter"');
   });
 
   it("renders request body editor for POST endpoints", () => {
@@ -282,6 +284,7 @@ describe("API Playground HTML Renderer", () => {
     ) as OpenApiEndpoint;
     const html = renderApiPlaygroundHtml(createUser);
     expect(html).toContain('class="request-body-editor"');
+    expect(html).toContain('aria-label="Enter request body"');
     expect(html).toContain("Body");
   });
 
@@ -290,6 +293,7 @@ describe("API Playground HTML Renderer", () => {
     const html = renderApiPlaygroundHtml(endpoints[0]);
     expect(html).toContain("auth-header-input");
     expect(html).toContain("Authorization");
+    expect(html).toContain('aria-label="Enter Authorization header"');
     expect(html).toContain("Bearer");
   });
 


### PR DESCRIPTION
## Summary
- Adds stable accessible names to generated API playground auth/path/query inputs.
- Adds an accessible name to the request body textarea.
- Covers the renderer output with unit assertions.

## Ever evidence
Reference Mintlify:
- `private/parity-scan/20260506-232217-api-playground-submit/mintlify-after-tryit.txt` shows API playground inputs with `aria-label` values after clicking Try it.

OpenDocs before:
- `private/parity-scan/20260506-232217-api-playground-submit/opendocs-before.txt` shows `INPUT type=text placeholder=integer (default: 10)` without an accessible name.

OpenDocs after local fix:
- `private/issue-109-ever/20260506-232611/local-after-fix.txt` shows `INPUT type=text placeholder=integer (default: 10) aria-label=Enter limit query parameter`.

## Tests
- `npm test -- tests/api-playground.test.ts`
- `make check`
- `make test`

## Constraints
- Browser QA used Ever snapshot -> act -> snapshot only.
- No Playwright or `make test-e2e` used.

Closes #109
