### PR TITLE
Show readable API playground proxy errors

### DIFF
--- a/src/components/docs/api-playground.tsx
+++ b/src/components/docs/api-playground.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import {
+  apiPlaygroundStatusClass,
+  normalizeApiPlaygroundProxyResult,
+} from "@/lib/api-playground-response";
 import { useEffect, useRef } from "react";
 
 interface ApiPlaygroundProps {
@@ -151,12 +155,15 @@ async function handleSend(btn: HTMLButtonElement): Promise<void> {
     });
 
     const elapsed = Math.round(performance.now() - startTime);
-    const result = await proxyRes.json();
+    const result = normalizeApiPlaygroundProxyResult(
+      await proxyRes.json(),
+      proxyRes.status,
+    );
 
     if (responseArea) responseArea.style.display = "block";
     if (statusEl) {
       statusEl.textContent = `${result.status}`;
-      statusEl.className = `api-status-code status-${Math.floor(result.status / 100)}xx`;
+      statusEl.className = apiPlaygroundStatusClass(result.status);
     }
     if (timeEl) timeEl.textContent = `${elapsed}ms`;
 

--- a/src/lib/api-playground-response.ts
+++ b/src/lib/api-playground-response.ts
@@ -1,0 +1,60 @@
+export interface ApiPlaygroundProxyResult {
+  status: number;
+  body: string;
+  headers: Record<string, string>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringifyBody(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+}
+
+function normalizeHeaders(value: unknown): Record<string, string> {
+  if (!isRecord(value)) return {};
+
+  const headers: Record<string, string> = {};
+  for (const [key, headerValue] of Object.entries(value)) {
+    headers[key] = String(headerValue);
+  }
+  return headers;
+}
+
+export function normalizeApiPlaygroundProxyResult(
+  value: unknown,
+  fallbackStatus: number,
+): ApiPlaygroundProxyResult {
+  if (!isRecord(value)) {
+    return {
+      status: fallbackStatus,
+      body: stringifyBody(value),
+      headers: {},
+    };
+  }
+
+  const payloadStatus =
+    typeof value.status === "number" && value.status > 0
+      ? value.status
+      : undefined;
+  const body =
+    value.body !== undefined
+      ? stringifyBody(value.body)
+      : stringifyBody(value.error);
+
+  return {
+    status: payloadStatus ?? fallbackStatus,
+    body,
+    headers: normalizeHeaders(value.headers),
+  };
+}
+
+export function apiPlaygroundStatusClass(status: number): string {
+  if (!Number.isFinite(status) || status <= 0) {
+    return "api-status-code status-5xx";
+  }
+  return `api-status-code status-${Math.floor(status / 100)}xx`;
+}

--- a/tests/api-playground-response.test.ts
+++ b/tests/api-playground-response.test.ts
@@ -1,0 +1,61 @@
+import {
+  apiPlaygroundStatusClass,
+  normalizeApiPlaygroundProxyResult,
+} from "@/lib/api-playground-response";
+import { describe, expect, it } from "vitest";
+
+describe("normalizeApiPlaygroundProxyResult", () => {
+  it("keeps upstream response status, body, and headers", () => {
+    expect(
+      normalizeApiPlaygroundProxyResult(
+        {
+          status: 404,
+          body: '{"error":"missing"}',
+          headers: { "content-type": "application/json" },
+        },
+        200,
+      ),
+    ).toEqual({
+      status: 404,
+      body: '{"error":"missing"}',
+      headers: { "content-type": "application/json" },
+    });
+  });
+
+  it("uses the proxy HTTP status and error message for proxy errors", () => {
+    expect(
+      normalizeApiPlaygroundProxyResult(
+        { error: "Too many proxy requests" },
+        429,
+      ),
+    ).toEqual({
+      status: 429,
+      body: "Too many proxy requests",
+      headers: {},
+    });
+  });
+
+  it("uses proxy HTTP status when the proxy payload has status zero", () => {
+    expect(
+      normalizeApiPlaygroundProxyResult(
+        { status: 0, body: "fetch failed", headers: {} },
+        502,
+      ),
+    ).toEqual({
+      status: 502,
+      body: "fetch failed",
+      headers: {},
+    });
+  });
+});
+
+describe("apiPlaygroundStatusClass", () => {
+  it("maps HTTP status classes", () => {
+    expect(apiPlaygroundStatusClass(202)).toBe("api-status-code status-2xx");
+    expect(apiPlaygroundStatusClass(429)).toBe("api-status-code status-4xx");
+  });
+
+  it("falls back to an error style for invalid statuses", () => {
+    expect(apiPlaygroundStatusClass(0)).toBe("api-status-code status-5xx");
+  });
+});


### PR DESCRIPTION
## Summary
- Normalizes API playground proxy responses before rendering them.
- Falls back to the proxy HTTP status when an error envelope has no upstream status.
- Shows proxy error text in the response body instead of rendering an undefined status.

## Ever evidence
Reference Mintlify:
- `private/parity-scan/20260506-232800-api-playground-send-validation/mintlify-after-send.txt` shows a readable response/error panel after clicking Send.

OpenDocs before:
- `private/parity-scan/20260506-232800-api-playground-send-validation/opendocs-after-send2.txt` shows `Response` followed by `undefined` after clicking Send.

OpenDocs after local fix:
- `private/issue-111-ever/20260506-233111/local-after-send.txt` shows `Response`, status `403`, and `getaddrinfo ENOTFOUND api.example.com` after clicking Send.

## Tests
- `npm test -- tests/api-playground-response.test.ts`
- `make check`
- `make test`

## Constraints
- Browser QA used Ever snapshot -> act -> snapshot only.
- No Playwright or `make test-e2e` used.

Closes #111
