### PR TITLE
Expose API playground response sections semantically

### DIFF
--- a/src/components/docs/api-playground.tsx
+++ b/src/components/docs/api-playground.tsx
@@ -37,7 +37,10 @@ export function ApiPlayground({ html }: ApiPlaygroundProps) {
         // Deactivate all tabs
         const allTabs =
           playground.querySelectorAll<HTMLButtonElement>(".api-resp-tab");
-        for (const t of allTabs) t.classList.remove("active");
+        for (const t of allTabs) {
+          t.classList.remove("active");
+          t.setAttribute("aria-selected", String(t === btn));
+        }
         btn.classList.add("active");
 
         // Show/hide panels

--- a/src/lib/openapi-parser.ts
+++ b/src/lib/openapi-parser.ts
@@ -355,14 +355,14 @@ export function renderApiPlaygroundHtml(endpoint: OpenApiEndpoint): string {
     <span class="api-status-code"></span>
     <span class="api-response-time"></span>
   </div>
-  <div class="api-response-tabs">
-    <button class="api-resp-tab active" data-resp-tab="body">Body</button>
-    <button class="api-resp-tab" data-resp-tab="headers">Headers</button>
+  <div class="api-response-tabs" role="tablist" aria-label="Response sections">
+    <button type="button" class="api-resp-tab active" data-resp-tab="body" role="tab" aria-selected="true" aria-label="Show response body">Body</button>
+    <button type="button" class="api-resp-tab" data-resp-tab="headers" role="tab" aria-selected="false" aria-label="Show response headers">Headers</button>
   </div>
-  <div class="api-response-body">
+  <div class="api-response-body" role="tabpanel" aria-label="Response body">
     <pre><code class="api-response-content"></code></pre>
   </div>
-  <div class="api-response-headers" style="display:none">
+  <div class="api-response-headers" role="tabpanel" aria-label="Response headers" style="display:none">
     <pre><code class="api-response-headers-content"></code></pre>
   </div>
 </div>`;

--- a/tests/api-playground.test.ts
+++ b/tests/api-playground.test.ts
@@ -304,6 +304,19 @@ describe("API Playground HTML Renderer", () => {
     const endpoints = parseOpenApiSpec(SAMPLE_OPENAPI_SPEC);
     const html = renderApiPlaygroundHtml(endpoints[0]);
     expect(html).toContain('class="api-response"');
+    expect(html).toContain('role="tablist" aria-label="Response sections"');
+    expect(html).toContain(
+      'role="tab" aria-selected="true" aria-label="Show response body"',
+    );
+    expect(html).toContain(
+      'role="tab" aria-selected="false" aria-label="Show response headers"',
+    );
+    expect(html).toContain(
+      'class="api-response-body" role="tabpanel" aria-label="Response body"',
+    );
+    expect(html).toContain(
+      'class="api-response-headers" role="tabpanel" aria-label="Response headers"',
+    );
   });
 
   it("renders different method badges with correct classes", () => {


### PR DESCRIPTION
## Summary
- Adds tablist/tab semantics and selected state to the API playground Body/Headers response switcher.
- Adds named response body/header tab panels.
- Keeps the existing visual button layout while exposing response sections similarly to Mintlify's named response-section control.

## Ever evidence
Reference Mintlify:
- `private/parity-scan/20260506-233410-playground-response-sections/mintlify-after-send.txt` shows `SELECT aria-label=Select response section` and `DIV role=region aria-label=Response content` after Try it -> Send.

OpenDocs before:
- `private/parity-scan/20260506-233410-playground-response-sections/opendocs-after-send.txt` shows plain `BUTTON` controls for Body and Headers after Send.

OpenDocs after local fix:
- `private/issue-113-ever/20260506-233611/local-after-send.txt` shows `BUTTON role=tab aria-label=Show response body selected=true` and `BUTTON role=tab aria-label=Show response headers selected=false`.

## Tests
- `npm test -- tests/api-playground.test.ts`
- `make check`
- `make test`

## Constraints
- Browser QA used Ever snapshot -> act -> snapshot only.
- No Playwright or `make test-e2e` used.

Closes #113
