### PR TITLE
Add API playground response download control

### DIFF
--- a/src/components/docs/api-playground.tsx
+++ b/src/components/docs/api-playground.tsx
@@ -134,6 +134,9 @@ async function handleSend(btn: HTMLButtonElement): Promise<void> {
   const headersContent = playground.querySelector<HTMLElement>(
     ".api-response-headers-content",
   );
+  const downloadLink = playground.querySelector<HTMLAnchorElement>(
+    ".api-response-download",
+  );
 
   const startTime = performance.now();
 
@@ -161,6 +164,7 @@ async function handleSend(btn: HTMLButtonElement): Promise<void> {
     if (timeEl) timeEl.textContent = `${elapsed}ms`;
 
     // Format response body
+    let responseBodyText = "";
     if (bodyContent) {
       let formatted = result.body || "";
       try {
@@ -168,8 +172,10 @@ async function handleSend(btn: HTMLButtonElement): Promise<void> {
       } catch {
         // not JSON, display raw
       }
+      responseBodyText = formatted;
       bodyContent.textContent = formatted;
     }
+    updateDownloadLink(downloadLink, responseBodyText);
 
     // Format response headers
     if (headersContent) {
@@ -188,8 +194,24 @@ async function handleSend(btn: HTMLButtonElement): Promise<void> {
       bodyContent.textContent =
         err instanceof Error ? err.message : "Request failed";
     }
+    updateDownloadLink(
+      downloadLink,
+      err instanceof Error ? err.message : "Request failed",
+    );
   } finally {
     btn.disabled = false;
     btn.textContent = "Send";
   }
+}
+
+function updateDownloadLink(
+  link: HTMLAnchorElement | null,
+  content: string,
+): void {
+  if (!link) return;
+
+  const text = content || "";
+  link.href = `data:text/plain;charset=utf-8,${encodeURIComponent(text)}`;
+  link.download = "response.txt";
+  link.style.display = "inline-flex";
 }

--- a/src/lib/openapi-parser.ts
+++ b/src/lib/openapi-parser.ts
@@ -354,6 +354,7 @@ export function renderApiPlaygroundHtml(endpoint: OpenApiEndpoint): string {
     <h4 class="api-section-title">Response</h4>
     <span class="api-status-code"></span>
     <span class="api-response-time"></span>
+    <a class="api-response-download" aria-label="Download response file" download="response.txt" href="#" style="display:none">Download</a>
   </div>
   <div class="api-response-tabs">
     <button class="api-resp-tab active" data-resp-tab="body">Body</button>

--- a/tests/api-playground.test.ts
+++ b/tests/api-playground.test.ts
@@ -304,6 +304,9 @@ describe("API Playground HTML Renderer", () => {
     const endpoints = parseOpenApiSpec(SAMPLE_OPENAPI_SPEC);
     const html = renderApiPlaygroundHtml(endpoints[0]);
     expect(html).toContain('class="api-response"');
+    expect(html).toContain('class="api-response-download"');
+    expect(html).toContain('aria-label="Download response file"');
+    expect(html).toContain('download="response.txt"');
   });
 
   it("renders different method badges with correct classes", () => {


### PR DESCRIPTION
## Summary
- Adds a hidden API playground response download link that appears after a response is available.
- Populates the download href from the rendered response body or client-side error text.
- Covers the generated response markup with unit assertions.

## Ever evidence
Reference Mintlify:
- `private/parity-scan/20260506-233841-playground-download-response/mintlify-after-send.txt` shows `A aria-label=Download response file` after Try it -> Send.

OpenDocs before:
- `private/parity-scan/20260506-233841-playground-download-response/opendocs-after-send.txt` shows the response area without a download response control after Send.

OpenDocs after local fix:
- `private/issue-115-ever/20260506-234114/local-after-send.txt` shows `A aria-label=Download response file` after Send.

## Tests
- `npm test -- tests/api-playground.test.ts`
- `make check`
- `make test`

## Constraints
- Browser QA used Ever snapshot -> act -> snapshot only.
- No Playwright or `make test-e2e` used.

Closes #115
