### PR TITLE
Label API playground Send controls

### DIFF
--- a/src/lib/openapi-parser.ts
+++ b/src/lib/openapi-parser.ts
@@ -345,7 +345,7 @@ export function renderApiPlaygroundHtml(endpoint: OpenApiEndpoint): string {
 
   // Send button
   const sendBtn = `<div class="api-send-section">
-  <button class="api-send-btn" data-method="${methodLower}" data-path="${escapeAttribute(endpoint.path)}" data-base-url="${escapeAttribute(endpoint.baseUrl)}">Send</button>
+  <button class="api-send-btn" aria-label="Send" data-method="${methodLower}" data-path="${escapeAttribute(endpoint.path)}" data-base-url="${escapeAttribute(endpoint.baseUrl)}">Send</button>
 </div>`;
 
   // Response area

--- a/tests/api-playground.test.ts
+++ b/tests/api-playground.test.ts
@@ -297,6 +297,7 @@ describe("API Playground HTML Renderer", () => {
     const endpoints = parseOpenApiSpec(SAMPLE_OPENAPI_SPEC);
     const html = renderApiPlaygroundHtml(endpoints[0]);
     expect(html).toContain('class="api-send-btn"');
+    expect(html).toContain('aria-label="Send"');
     expect(html).toContain("Send");
   });
 


### PR DESCRIPTION
## Summary
- Adds a stable accessible label to generated API playground Send buttons.
- Covers the generated Send markup with a unit assertion.

## Ever evidence
Reference Mintlify:
- `private/parity-scan/20260506-234437-playground-send-label/mintlify-after-tryit.txt` shows `BUTTON aria-label=Send` after opening Try it.

OpenDocs before:
- `private/parity-scan/20260506-234437-playground-send-label/opendocs-before.txt` shows the playground submit as plain `BUTTON` / `Send`.

OpenDocs after local fix:
- `private/issue-117-ever/20260506-234600/local-after-fix.txt` shows `BUTTON aria-label=Send`.

## Tests
- `npm test -- tests/api-playground.test.ts`
- `make check`
- `make test`

## Constraints
- Browser QA used Ever snapshot -> act -> snapshot only.
- No Playwright or `make test-e2e` used.

Closes #117
