### PR TITLE
Show visible docs feedback choices

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1485,14 +1485,22 @@ pre.mermaid svg {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
+  gap: 0.375rem;
+  min-width: 64px;
   height: 36px;
+  padding: 0 0.75rem;
   border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.1);
   background: rgba(255, 255, 255, 0.04);
   color: #9ca3af;
   cursor: pointer;
   transition: all 0.15s;
+}
+
+.docs-feedback-btn-label {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1;
 }
 
 .docs-feedback-btn:hover {

--- a/src/components/docs/feedback-widget.tsx
+++ b/src/components/docs/feedback-widget.tsx
@@ -90,7 +90,8 @@ export function FeedbackWidget({ subdomain, pagePath }: FeedbackWidgetProps) {
               data-testid="feedback-thumbs-up"
               aria-label="Yes, this page was helpful"
             >
-              <ThumbsUp size={16} />
+              <ThumbsUp size={16} aria-hidden="true" />
+              <span className="docs-feedback-btn-label">Yes</span>
             </button>
             <button
               type="button"
@@ -99,7 +100,8 @@ export function FeedbackWidget({ subdomain, pagePath }: FeedbackWidgetProps) {
               data-testid="feedback-thumbs-down"
               aria-label="No, this page was not helpful"
             >
-              <ThumbsDown size={16} />
+              <ThumbsDown size={16} aria-hidden="true" />
+              <span className="docs-feedback-btn-label">No</span>
             </button>
           </div>
         </div>

--- a/tests/feedback-widget.test.ts
+++ b/tests/feedback-widget.test.ts
@@ -1,5 +1,13 @@
+import { FeedbackWidget } from "@/components/docs/feedback-widget";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
 import { describe, expect, it } from "vitest";
 import { validateFeedbackPayload } from "../src/lib/feedback";
+
+// React 19 requires this flag for act() in non-testing-library environments.
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
 
 // ── Feedback API validation logic ────────────────────────────────────────────
 
@@ -171,5 +179,43 @@ describe("Feedback widget state machine", () => {
     state = handleSubmitStart(state);
     state = handleSubmitSuccess(state);
     expect(state.rating).toBe("helpful");
+  });
+});
+
+describe("Feedback widget visible choices", () => {
+  it("renders explicit Yes and No labels while preserving accessible names", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(FeedbackWidget, {
+          subdomain: "test-project",
+          pagePath: "introduction",
+        }),
+      );
+    });
+
+    const helpful = container.querySelector<HTMLButtonElement>(
+      '[data-testid="feedback-thumbs-up"]',
+    );
+    const notHelpful = container.querySelector<HTMLButtonElement>(
+      '[data-testid="feedback-thumbs-down"]',
+    );
+
+    expect(helpful?.textContent).toContain("Yes");
+    expect(helpful?.getAttribute("aria-label")).toBe(
+      "Yes, this page was helpful",
+    );
+    expect(notHelpful?.textContent).toContain("No");
+    expect(notHelpful?.getAttribute("aria-label")).toBe(
+      "No, this page was not helpful",
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
   });
 });


### PR DESCRIPTION
## Summary
- show visible Yes / No text on docs feedback buttons while preserving the existing aria-labels
- adjust feedback button sizing for icon-plus-label controls
- add unit coverage for visible feedback choices

## Verification
- Ever browser QA: `private/browser-parity/shadowfax-20260508T052112Z/local-issue-119-feedback-labels-snapshot-2.txt`
- Ever browser QA: `private/browser-parity/shadowfax-20260508T052112Z/local-issue-119-feedback-no-act-snapshot.txt`
- `make check`
- `make test`

Closes #119