### PR TITLE
Make mobile docs navigation keyboard-dismissable

### DIFF
--- a/src/components/docs/mobile-nav.tsx
+++ b/src/components/docs/mobile-nav.tsx
@@ -2,7 +2,7 @@
 
 import type { DocsNavEntry } from "@/lib/mdx-renderer";
 import { X } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { DocsSidebar } from "./docs-sidebar";
 
 export function MobileMenuButton() {
@@ -49,6 +49,7 @@ export function MobileSidebar({
   projectName,
 }: MobileSidebarProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const overlayRef = useRef<HTMLDialogElement>(null);
 
   useEffect(() => {
     function handleToggle() {
@@ -77,17 +78,49 @@ export function MobileSidebar({
     };
   }, [isOpen]);
 
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const previouslyFocused =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+
+    overlayRef.current?.focus();
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      previouslyFocused?.focus();
+    };
+  }, [isOpen]);
+
   if (!isOpen) return null;
 
   return (
-    <div
+    <dialog
+      ref={overlayRef}
       data-testid="mobile-sidebar"
+      open
+      aria-modal="true"
+      aria-label={`${projectName} navigation`}
       className="mobile-sidebar-overlay"
       onClick={(e) => {
         if (e.target === e.currentTarget) setIsOpen(false);
       }}
       onKeyDown={(e) => {
         if (e.key === "Escape") setIsOpen(false);
+      }}
+      onCancel={(e) => {
+        e.preventDefault();
+        setIsOpen(false);
       }}
     >
       <div className="mobile-sidebar-panel">
@@ -99,7 +132,7 @@ export function MobileSidebar({
             onClick={() => setIsOpen(false)}
             aria-label="Close navigation"
           >
-            <X size={20} />
+            <X size={20} aria-hidden="true" />
           </button>
         </div>
         <DocsSidebar
@@ -109,6 +142,6 @@ export function MobileSidebar({
           projectName={projectName}
         />
       </div>
-    </div>
+    </dialog>
   );
 }

--- a/tests/docs-site-layout.test.ts
+++ b/tests/docs-site-layout.test.ts
@@ -169,6 +169,70 @@ describe("Docs site layout — feature-014", () => {
       const mod = await import("@/components/docs/mobile-nav");
       expect(mod.MobileSidebar).toBeDefined();
     });
+
+    it("opens mobile navigation as a labelled dialog and closes on Escape", async () => {
+      const { MobileMenuButton, MobileSidebar } = await import(
+        "@/components/docs/mobile-nav"
+      );
+      const container = document.createElement("div");
+      document.body.appendChild(container);
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          createElement(
+            "div",
+            null,
+            createElement(MobileMenuButton),
+            createElement(MobileSidebar, {
+              nav: [
+                {
+                  type: "item",
+                  label: "Introduction",
+                  path: "introduction",
+                  pageId: "intro",
+                },
+              ],
+              activePath: "introduction",
+              subdomain: "test-project",
+              projectName: "Test Project",
+            }),
+          ),
+        );
+      });
+
+      await act(async () => {
+        container
+          .querySelector<HTMLButtonElement>('[data-testid="mobile-menu-btn"]')
+          ?.click();
+      });
+
+      const dialog = container.querySelector<HTMLElement>(
+        '[data-testid="mobile-sidebar"]',
+      );
+      expect(dialog?.tagName).toBe("DIALOG");
+      expect(dialog?.getAttribute("aria-modal")).toBe("true");
+      expect(dialog?.getAttribute("aria-label")).toBe(
+        "Test Project navigation",
+      );
+      expect(document.body.style.overflow).toBe("hidden");
+
+      await act(async () => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+        );
+      });
+
+      expect(
+        container.querySelector('[data-testid="mobile-sidebar"]'),
+      ).toBeNull();
+      expect(document.body.style.overflow).toBe("");
+
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    });
   });
 
   describe("Layout structure", () => {


### PR DESCRIPTION
## Summary
- render the mobile docs sidebar overlay as a labelled dialog
- focus the dialog on open and close it from Escape/document key handling
- preserve scroll locking and add unit coverage for modal semantics + Escape dismissal

## Verification
- Ever browser QA: `private/browser-parity/shadowfax-20260508T053047Z/local-mobile-nav-open-act-snapshot.txt` (pre-fix gap evidence)
- Ever browser QA: `private/browser-parity/shadowfax-20260508T053047Z/local-issue-121-webpack-before.txt`
- Ever browser QA: `private/browser-parity/shadowfax-20260508T053047Z/local-issue-121-webpack-act-snapshots.txt`
- `make check`
- `make test`

Closes #121