### PR TITLE
Fix editor docs config persistence and branding

### DIFF
--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -201,6 +201,10 @@ export async function PUT(
     )?.installationId ??
     null;
 
+  const settingsUpdate = validation.fields.settings as
+    | Record<string, unknown>
+    | undefined;
+
   const mergedSettings = mergeProjectSettingsWithGitHubSource(
     existing[0].settings,
     buildGitHubSourceSelection({
@@ -209,6 +213,7 @@ export async function PUT(
       repoBranch: resolvedRepoBranch,
       repoPath: resolvedRepoPath,
     }),
+    settingsUpdate,
   );
 
   const updateFields = {

--- a/src/app/docs/[subdomain]/[...slug]/page.tsx
+++ b/src/app/docs/[subdomain]/[...slug]/page.tsx
@@ -20,7 +20,11 @@ import { renderApiReferencePage } from "@/lib/api-reference";
 import { getPublicAppUrl } from "@/lib/app-url";
 import { db } from "@/lib/db";
 import { pages, projects } from "@/lib/db/schema";
-import { findRedirect, mergeDocsConfig } from "@/lib/docs-config";
+import {
+  findRedirect,
+  getDocsThemeCssVars,
+  mergeDocsConfig,
+} from "@/lib/docs-config";
 import { getFooterSettings } from "@/lib/docs-footer";
 import { extractToc } from "@/lib/editor";
 import {
@@ -69,6 +73,7 @@ import { and, eq } from "drizzle-orm";
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import { notFound, permanentRedirect } from "next/navigation";
+import type { CSSProperties } from "react";
 
 interface DocsPageProps {
   params: Promise<{ subdomain: string; slug: string[] }>;
@@ -539,8 +544,10 @@ export default async function DocsPage({
     { includeConfiguredRoutes: hasGeneratedApiRoute },
   );
 
+  const docsThemeStyle = getDocsThemeCssVars(docsConfig) as CSSProperties;
+
   return (
-    <div className="docs-layout">
+    <div className="docs-layout" style={docsThemeStyle}>
       <DocsTopbar
         projectName={project.name}
         subdomain={subdomain}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -65,7 +65,7 @@ body {
   z-index: 100;
   transform: translateY(-150%);
   border-radius: 8px;
-  background: #16a34a;
+  background: var(--docs-primary, #16a34a);
   color: #ffffff;
   padding: 8px 12px;
   font-size: 13px;
@@ -172,7 +172,7 @@ body {
   gap: 4px;
   padding: 6px 14px;
   border-radius: 8px;
-  background: #16a34a;
+  background: var(--docs-primary, #16a34a);
   color: #fff;
   font-size: 13px;
   font-weight: 500;
@@ -328,7 +328,7 @@ body {
 
 .docs-breadcrumb {
   font-size: 13px;
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
   margin-bottom: 8px;
   font-weight: 500;
 }
@@ -338,7 +338,7 @@ body {
 }
 
 .docs-breadcrumb-active {
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
 }
 
 .docs-title-row {
@@ -611,7 +611,7 @@ body {
 }
 
 .docs-content blockquote {
-  border-left: 3px solid #16a34a;
+  border-left: 3px solid var(--docs-primary, #16a34a);
   padding: 8px 16px;
   margin: 16px 0;
   color: #9ca3af;
@@ -707,7 +707,7 @@ body {
 }
 
 .code-ask-ai {
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
 }
 
 .code-ask-ai:hover {
@@ -782,7 +782,7 @@ body {
 }
 
 .callout-tip .callout-icon {
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
 }
 
 .callout-icon {
@@ -907,7 +907,7 @@ body {
   height: 32px;
   border-radius: 50%;
   background: rgba(22, 163, 74, 0.15);
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -996,8 +996,8 @@ body {
 }
 
 .tab-button.active {
-  color: #16a34a;
-  border-bottom-color: #16a34a;
+  color: var(--docs-primary, #16a34a);
+  border-bottom-color: var(--docs-primary, #16a34a);
 }
 
 .tab-panel {
@@ -1217,7 +1217,7 @@ pre.mermaid svg {
 
 .update-date {
   font-size: 13px;
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
   font-weight: 500;
   margin-bottom: 4px;
 }
@@ -1678,6 +1678,16 @@ pre.mermaid svg {
   color: #f9fafb;
 }
 
+.docs-topbar-logo-icon {
+  color: var(--docs-primary, #16a34a);
+}
+
+.docs-topbar-logo-image {
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
+}
+
 /* ── Search Modal ─────────────────────────────────────────────────────────── */
 
 .search-modal-overlay {
@@ -2057,11 +2067,11 @@ pre.mermaid svg {
 }
 
 .lang-switcher-option-active {
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
 }
 
 .lang-switcher-option-active:hover {
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
 }
 
 .lang-switcher-option-code {
@@ -2154,11 +2164,11 @@ pre.mermaid svg {
 }
 
 .version-switcher-option-active {
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
 }
 
 .version-switcher-option-active:hover {
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
 }
 
 .version-switcher-option-name {
@@ -2173,7 +2183,7 @@ pre.mermaid svg {
   padding: 2px 6px;
   border-radius: 4px;
   background: rgba(22, 163, 74, 0.15);
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
 }
 
 /* ── Light Theme ──────────────────────────────────────────────────────────── */
@@ -2276,7 +2286,7 @@ pre.mermaid svg {
 }
 
 [data-theme="light"] .lang-switcher-option-active {
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
 }
 
 [data-theme="light"] .version-switcher-btn {
@@ -2306,7 +2316,7 @@ pre.mermaid svg {
 }
 
 [data-theme="light"] .version-switcher-option-active {
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
 }
 
 [data-theme="light"] .version-switcher-default-badge {
@@ -2335,7 +2345,7 @@ pre.mermaid svg {
 }
 
 [data-theme="light"] .docs-nav-item.active {
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
   background: rgba(22, 163, 74, 0.06);
 }
 
@@ -2352,7 +2362,7 @@ pre.mermaid svg {
 }
 
 [data-theme="light"] .docs-breadcrumb {
-  color: #16a34a;
+  color: var(--docs-primary, #16a34a);
 }
 
 [data-theme="light"] .page-action-btn {
@@ -2759,7 +2769,7 @@ pre.mermaid svg {
 }
 
 .chat-message-user .chat-message-avatar {
-  background: #16a34a;
+  background: var(--docs-primary, #16a34a);
   color: white;
 }
 
@@ -2786,7 +2796,7 @@ pre.mermaid svg {
 }
 
 .chat-message-user .chat-message-content {
-  background: #16a34a;
+  background: var(--docs-primary, #16a34a);
   color: white;
   border-bottom-right-radius: 4px;
 }
@@ -2936,7 +2946,7 @@ pre.mermaid svg {
 }
 
 .chat-widget-textarea:focus {
-  border-color: #16a34a;
+  border-color: var(--docs-primary, #16a34a);
 }
 
 .chat-widget-textarea::placeholder {
@@ -2955,7 +2965,7 @@ pre.mermaid svg {
   width: 36px;
   height: 36px;
   border-radius: 8px;
-  background: #16a34a;
+  background: var(--docs-primary, #16a34a);
   border: none;
   color: white;
   cursor: pointer;
@@ -3112,8 +3122,8 @@ pre.mermaid svg {
 }
 
 .method-get {
-  background: #16a34a22;
-  color: #16a34a;
+  background: var(--docs-primary-soft, #16a34a22);
+  color: var(--docs-primary, #16a34a);
 }
 .method-post {
   background: #2563eb22;
@@ -3202,7 +3212,7 @@ pre.mermaid svg {
 }
 
 .api-param-input:focus {
-  border-color: #16a34a;
+  border-color: var(--docs-primary, #16a34a);
 }
 
 .api-param-input::placeholder {
@@ -3229,7 +3239,7 @@ pre.mermaid svg {
 }
 
 .api-body-textarea:focus {
-  border-color: #16a34a;
+  border-color: var(--docs-primary, #16a34a);
 }
 
 .api-send-section {
@@ -3237,7 +3247,7 @@ pre.mermaid svg {
 }
 
 .api-send-btn {
-  background: #16a34a;
+  background: var(--docs-primary, #16a34a);
   color: #fff;
   border: none;
   border-radius: 6px;
@@ -3285,8 +3295,8 @@ pre.mermaid svg {
 }
 
 .status-2xx {
-  background: #16a34a22;
-  color: #16a34a;
+  background: var(--docs-primary-soft, #16a34a22);
+  color: var(--docs-primary, #16a34a);
 }
 .status-3xx {
   background: #2563eb22;
@@ -3325,8 +3335,8 @@ pre.mermaid svg {
 }
 
 .api-resp-tab.active {
-  color: #16a34a;
-  border-bottom-color: #16a34a;
+  color: var(--docs-primary, #16a34a);
+  border-bottom-color: var(--docs-primary, #16a34a);
 }
 
 .api-resp-tab:hover {
@@ -3475,7 +3485,7 @@ pre.mermaid svg {
 }
 
 .api-ref-tryit-btn {
-  background: #16a34a;
+  background: var(--docs-primary, #16a34a);
   color: #fff;
   border: none;
   border-radius: 6px;
@@ -3525,7 +3535,7 @@ pre.mermaid svg {
 
 .api-ref-lang-tab.active {
   color: #fff;
-  border-bottom-color: #16a34a;
+  border-bottom-color: var(--docs-primary, #16a34a);
 }
 
 .api-ref-lang-tab:hover {
@@ -3612,8 +3622,8 @@ pre.mermaid svg {
 }
 
 .api-ref-status-tab.active {
-  color: #16a34a;
-  border-bottom-color: #16a34a;
+  color: var(--docs-primary, #16a34a);
+  border-bottom-color: var(--docs-primary, #16a34a);
 }
 
 .api-ref-status-tab:hover {

--- a/src/components/docs/docs-topbar.tsx
+++ b/src/components/docs/docs-topbar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { mergeDocsConfig } from "@/lib/docs-config";
 import type { VersionsConfig } from "@/lib/versions";
 import Link from "next/link";
 import { LanguageSwitcher } from "./language-switcher";
@@ -87,6 +88,35 @@ export function AskAiButton() {
   );
 }
 
+export function getConfiguredDocsLogo(
+  settings: DocsTopbarProps["settings"],
+): { path: string; href: string } | null {
+  const raw = (settings || {}) as Record<string, unknown>;
+  const rawDocsConfig = raw.docsConfig;
+
+  if (!rawDocsConfig || typeof rawDocsConfig !== "object") {
+    const legacyLogo =
+      typeof raw.logoUrl === "string"
+        ? raw.logoUrl
+        : typeof raw.logoDarkUrl === "string"
+          ? raw.logoDarkUrl
+          : "";
+    return legacyLogo ? { path: legacyLogo, href: "" } : null;
+  }
+
+  const docsConfig = mergeDocsConfig(
+    rawDocsConfig as Partial<Record<string, unknown>>,
+  );
+  const path =
+    docsConfig.headerTopbar.logoPath ||
+    docsConfig.visualBranding.logoDarkPath ||
+    docsConfig.visualBranding.logoLightPath;
+
+  if (!path) return null;
+
+  return { path, href: docsConfig.visualBranding.logoLink || "/" };
+}
+
 export function DocsTopbar({
   projectName,
   subdomain,
@@ -98,6 +128,8 @@ export function DocsTopbar({
   const githubProps = getGithubLinkProps(s.githubUrl);
   const supportHref = buildSupportHref(s.supportEmail);
   const dashboardUrl = buildDashboardUrl(subdomain);
+  const configuredLogo = getConfiguredDocsLogo(settings);
+  const logoHref = configuredLogo?.href || `/docs/${subdomain}`;
 
   return (
     <>
@@ -107,37 +139,45 @@ export function DocsTopbar({
       <div className="docs-topbar">
         <div className="docs-topbar-left">
           <MobileMenuButton />
-          <Link href={`/docs/${subdomain}`} className="docs-topbar-logo">
-            <svg
-              width="28"
-              height="28"
-              viewBox="0 0 24 24"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              aria-label="Logo"
-              className="docs-topbar-logo-icon"
-            >
-              <title>Logo</title>
-              <path
-                d="M12 2L2 7l10 5 10-5-10-5Z"
-                fill="#16A34A"
-                opacity="0.8"
+          <Link href={logoHref} className="docs-topbar-logo">
+            {configuredLogo ? (
+              <img
+                src={configuredLogo.path}
+                alt="Logo"
+                className="docs-topbar-logo-image"
               />
-              <path
-                d="M2 17l10 5 10-5"
-                stroke="#16A34A"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-              <path
-                d="M2 12l10 5 10-5"
-                stroke="#16A34A"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
+            ) : (
+              <svg
+                width="28"
+                height="28"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-label="Logo"
+                className="docs-topbar-logo-icon"
+              >
+                <title>Logo</title>
+                <path
+                  d="M12 2L2 7l10 5 10-5-10-5Z"
+                  fill="currentColor"
+                  opacity="0.8"
+                />
+                <path
+                  d="M2 17l10 5 10-5"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+                <path
+                  d="M2 12l10 5 10-5"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            )}
             <span className="docs-topbar-title">{projectName}</span>
           </Link>
         </div>

--- a/src/components/editor/configs-panel.tsx
+++ b/src/components/editor/configs-panel.tsx
@@ -298,6 +298,10 @@ function FieldLabel({ children }: { children: React.ReactNode }) {
   return <span className="block text-xs text-gray-400 mb-1">{children}</span>;
 }
 
+function FieldHelp({ children }: { children: React.ReactNode }) {
+  return <p className="mt-1 text-[11px] leading-4 text-gray-500">{children}</p>;
+}
+
 function TextInput({
   value,
   onChange,
@@ -537,6 +541,10 @@ function VisualBrandingForm({ config, updateSection }: SectionProps) {
         onChange={(v) => update({ primaryColor: v })}
         testId="config-branding-primary"
       />
+      <FieldHelp>
+        Applies to published docs accents such as active navigation, links,
+        buttons, API tabs, and the default OpenDocs logo color after Save.
+      </FieldHelp>
       <ColorField
         label="Light color"
         value={d.lightColor}
@@ -557,6 +565,10 @@ function VisualBrandingForm({ config, updateSection }: SectionProps) {
           placeholder="/logo-light.svg"
           testId="config-branding-logo-light"
         />
+        <FieldHelp>
+          Optional public asset path for light theme. Header &amp; Topbar logo
+          path below takes precedence when set.
+        </FieldHelp>
       </div>
       <div>
         <FieldLabel>Logo (dark mode path)</FieldLabel>
@@ -566,6 +578,10 @@ function VisualBrandingForm({ config, updateSection }: SectionProps) {
           placeholder="/logo-dark.svg"
           testId="config-branding-logo-dark"
         />
+        <FieldHelp>
+          Optional public asset path for dark theme. Use paths such as
+          /logo-dark.svg or uploaded public asset URLs.
+        </FieldHelp>
       </div>
       <div>
         <FieldLabel>Logo link</FieldLabel>
@@ -575,6 +591,10 @@ function VisualBrandingForm({ config, updateSection }: SectionProps) {
           placeholder="/"
           testId="config-branding-logo-link"
         />
+        <FieldHelp>
+          Destination for the docs logo link, for example /, /docs, or an
+          absolute marketing-site URL.
+        </FieldHelp>
       </div>
     </>
   );
@@ -639,6 +659,10 @@ function HeaderTopbarForm({ config, updateSection }: SectionProps) {
           placeholder="/logo.svg"
           testId="config-topbar-logo"
         />
+        <FieldHelp>
+          Primary logo shown in the docs topbar. Leave blank to use the visual
+          branding light/dark logo paths or the default OpenDocs mark.
+        </FieldHelp>
       </div>
       <div>
         <div className="flex items-center justify-between mb-1">

--- a/src/lib/docs-config.ts
+++ b/src/lib/docs-config.ts
@@ -346,6 +346,15 @@ export function mergeDocsConfig(
   };
 }
 
+export function getDocsThemeCssVars(
+  config: DocsConfig,
+): Record<string, string> {
+  return {
+    "--docs-primary": config.visualBranding.primaryColor,
+    "--docs-primary-soft": `${config.visualBranding.primaryColor}22`,
+  };
+}
+
 // ── Validation ───────────────────────────────────────────────────────────
 
 export type ValidationResult =

--- a/src/lib/github-source.ts
+++ b/src/lib/github-source.ts
@@ -95,8 +95,9 @@ export function resolveGitHubSource(params: {
 export function mergeProjectSettingsWithGitHubSource(
   existing: Record<string, unknown> | null | undefined,
   selection: GitHubSourceSelection | null,
+  updates?: Record<string, unknown> | null,
 ): Record<string, unknown> {
-  const next = { ...(existing ?? {}) };
+  const next = { ...(existing ?? {}), ...(updates ?? {}) };
 
   if (selection) {
     next.githubSource = selection;

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -156,14 +156,14 @@ export function validateCreateProjectRequest(body: unknown):
 export function validateUpdateProjectRequest(
   body: unknown,
 ):
-  | { valid: true; fields: Record<string, string> }
+  | { valid: true; fields: Record<string, unknown> }
   | { valid: false; error: string } {
   if (!body || typeof body !== "object") {
     return { valid: false, error: "No fields to update" };
   }
 
   const raw = body as Record<string, unknown>;
-  const fields: Record<string, string> = {};
+  const fields: Record<string, unknown> = {};
 
   if (raw.name !== undefined) {
     if (typeof raw.name !== "string") {
@@ -260,5 +260,5 @@ export function validateUpdateProjectRequest(
     result.settings = settingsUpdate;
   }
 
-  return { valid: true, fields: result as Record<string, string> };
+  return { valid: true, fields: result };
 }

--- a/tests/docs-config.test.ts
+++ b/tests/docs-config.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_DOCS_CONFIG,
   type DocsConfig,
   exportDocsConfigJson,
+  getDocsThemeCssVars,
   importDocsConfigJson,
   mergeDocsConfig,
   sectionIdToConfigKey,
@@ -57,6 +58,16 @@ describe("mergeDocsConfig", () => {
     });
     expect(result.visualBranding.primaryColor).toBe("#FF0000");
     expect(result.visualBranding.theme).toBe("dark"); // default
+  });
+
+  it("exports CSS variables for applying the primary color to docs chrome", () => {
+    const config = mergeDocsConfig({
+      visualBranding: { primaryColor: "#FF0000" },
+    });
+    expect(getDocsThemeCssVars(config)).toEqual({
+      "--docs-primary": "#FF0000",
+      "--docs-primary-soft": "#FF000022",
+    });
   });
 
   it("preserves topbarLinks array when provided", () => {

--- a/tests/docs-topbar.test.ts
+++ b/tests/docs-topbar.test.ts
@@ -106,6 +106,63 @@ describe("Docs topbar — feature-014a", () => {
       const href = buildSupportHref(undefined);
       expect(href).toContain("mailto:");
     });
+
+    it("resolves configured docs logo path and link from docs config", async () => {
+      const { getConfiguredDocsLogo } = await import(
+        "@/components/docs/docs-topbar"
+      );
+      expect(
+        getConfiguredDocsLogo({
+          docsConfig: {
+            visualBranding: {
+              logoLink: "https://example.com",
+              logoDarkPath: "/dark.svg",
+            },
+            headerTopbar: {
+              logoPath: "/topbar.svg",
+            },
+          },
+        }),
+      ).toEqual({ path: "/topbar.svg", href: "https://example.com" });
+    });
+
+    it("renders the configured docs logo image and link", async () => {
+      const { DocsTopbar } = await import("@/components/docs/docs-topbar");
+      const html = renderToStaticMarkup(
+        DocsTopbar({
+          projectName: "Test Project",
+          subdomain: "test-project",
+          settings: {
+            docsConfig: {
+              visualBranding: {
+                logoLink: "https://example.com",
+              },
+              headerTopbar: {
+                logoPath: "/topbar.svg",
+              },
+            },
+          },
+        }),
+      );
+
+      expect(html).toContain('href="https://example.com"');
+      expect(html).toContain('src="/topbar.svg"');
+      expect(html).toContain('class="docs-topbar-logo-image"');
+    });
+
+    it("uses currentColor for the default logo mark", async () => {
+      const { DocsTopbar } = await import("@/components/docs/docs-topbar");
+      const html = renderToStaticMarkup(
+        DocsTopbar({
+          projectName: "Test Project",
+          subdomain: "test-project",
+          settings: {},
+        }),
+      );
+
+      expect(html).toContain('fill="currentColor"');
+      expect(html).toContain('stroke="currentColor"');
+    });
   });
 
   describe("Ask AI toggle", () => {

--- a/tests/github-source.test.ts
+++ b/tests/github-source.test.ts
@@ -61,4 +61,34 @@ describe("github-source helpers", () => {
       },
     });
   });
+
+  it("preserves incoming docs config settings while refreshing github source", () => {
+    expect(
+      mergeProjectSettingsWithGitHubSource(
+        {
+          githubSource: { repoFullName: "old/repo" },
+          docsConfig: {
+            visualBranding: { primaryColor: "#16A34A" },
+          },
+        },
+        buildGitHubSourceSelection({
+          repoUrl: "https://github.com/acme/docs",
+          repoBranch: "main",
+        }),
+        {
+          docsConfig: {
+            visualBranding: { primaryColor: "#FF0000" },
+          },
+        },
+      ),
+    ).toMatchObject({
+      docsConfig: {
+        visualBranding: { primaryColor: "#FF0000" },
+      },
+      githubSource: {
+        repoFullName: "acme/docs",
+        branch: "main",
+      },
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- preserve incoming `docsConfig` settings when refreshing GitHub source metadata
- apply configured docs primary color via CSS variables in rendered docs chrome
- surface configured logo paths/logo links in docs topbar and improve editor guidance

## Evidence
- `make check` ✅
- `make test` ✅ (1777 passed)
- Ever/Shadowfax evidence:
  - `private/browser-parity/shadowfax-20260508T053111Z/local-issue-122-editor-visual-expanded-final-snapshot.txt`
  - `private/browser-parity/shadowfax-20260508T053111Z/local-issue-122-editor-persisted-visual-final-eval.json` → primary `#FF0000`
  - `private/browser-parity/shadowfax-20260508T053111Z/local-issue-122-rendered-docs-css-eval.json` → `--docs-primary: #FF0000`, `--docs-primary-soft: #FF000022`

Fixes #122