### PR TITLE
Make docs assistant dismissible for keyboard users

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2638,9 +2638,15 @@ pre.mermaid svg {
   z-index: 50;
   display: flex;
   flex-direction: column;
+  width: auto;
   max-height: 480px;
+  max-width: none;
+  margin: 0;
+  padding: 0;
   background: #111315;
+  border: 0;
   border-top: 1px solid rgba(255, 255, 255, 0.08);
+  color: inherit;
   box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.4);
 }
 

--- a/src/components/docs/chat-widget.tsx
+++ b/src/components/docs/chat-widget.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -165,6 +172,7 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const titleId = useId();
 
   // Listen for toggle-ask-ai custom event from topbar button
   useEffect(() => {
@@ -210,6 +218,20 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
     if (state.isOpen) {
       setTimeout(() => inputRef.current?.focus(), 100);
     }
+  }, [state.isOpen]);
+
+  // Match docs assistant drawer behavior: Escape dismisses the open panel.
+  useEffect(() => {
+    if (!state.isOpen) return;
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        dispatch({ type: "CLOSE" });
+      }
+    };
+
+    window.addEventListener("keydown", handleEscape, true);
+    return () => window.removeEventListener("keydown", handleEscape, true);
   }, [state.isOpen]);
 
   const sendMessage = useCallback(async () => {
@@ -336,6 +358,12 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
   ]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      dispatch({ type: "CLOSE" });
+      return;
+    }
+
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       sendMessage();
@@ -365,7 +393,13 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
   if (!state.isOpen) return null;
 
   return (
-    <div className="chat-widget" data-testid="chat-panel">
+    <dialog
+      open
+      className="chat-widget"
+      data-testid="chat-panel"
+      aria-modal="false"
+      aria-labelledby={titleId}
+    >
       {/* Header */}
       <div className="chat-widget-header">
         <div className="chat-widget-header-left">
@@ -383,13 +417,14 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
             <path d="M12 3l1.5 4.5L18 9l-4.5 1.5L12 15l-1.5-4.5L6 9l4.5-1.5L12 3z" />
             <path d="M18 14l1 3 3 1-3 1-1 3-1-3-3-1 3-1 1-3z" />
           </svg>
-          <span>AI Assistant</span>
+          <span id={titleId}>AI Assistant</span>
         </div>
         <div className="chat-widget-header-actions">
           <button
             type="button"
             data-testid="chat-clear-btn"
             className="chat-widget-icon-btn"
+            aria-label="Clear assistant conversation"
             title="Clear conversation"
             onClick={() => dispatch({ type: "CLEAR" })}
           >
@@ -411,6 +446,7 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
             type="button"
             data-testid="chat-close-btn"
             className="chat-widget-icon-btn"
+            aria-label="Close assistant panel"
             title="Close"
             onClick={() => dispatch({ type: "CLOSE" })}
           >
@@ -604,6 +640,7 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
           type="button"
           data-testid="chat-send-btn"
           className="chat-widget-send-btn"
+          aria-label="Send message"
           disabled={
             (!input.trim() && attachments.length === 0) || state.isStreaming
           }
@@ -625,6 +662,6 @@ export function ChatWidget({ subdomain, currentPath }: ChatWidgetProps) {
           </svg>
         </button>
       </div>
-    </div>
+    </dialog>
   );
 }

--- a/tests/chat-widget.test.tsx
+++ b/tests/chat-widget.test.tsx
@@ -51,6 +51,87 @@ describe("Docs chat widget code context", () => {
     ).not.toBeNull();
   });
 
+  it("labels assistant panel controls and closes with Escape", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <>
+          <AskAiButton />
+          <ChatWidget subdomain="feature004-qa" currentPath="introduction" />
+        </>,
+      );
+    });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="ask-ai-btn"]')
+        ?.click();
+    });
+
+    const panel = container.querySelector('[data-testid="chat-panel"]');
+    expect(panel?.tagName).toBe("DIALOG");
+    expect(panel?.hasAttribute("open")).toBe(true);
+    expect(panel?.getAttribute("aria-modal")).toBe("false");
+    expect(panel?.getAttribute("aria-labelledby")).toBeTruthy();
+    expect(
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="chat-clear-btn"]')
+        ?.getAttribute("aria-label"),
+    ).toBe("Clear assistant conversation");
+    expect(
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="chat-close-btn"]')
+        ?.getAttribute("aria-label"),
+    ).toBe("Close assistant panel");
+    expect(
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="chat-send-btn"]')
+        ?.getAttribute("aria-label"),
+    ).toBe("Send message");
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+
+    expect(container.querySelector('[data-testid="chat-panel"]')).toBeNull();
+  });
+
+  it("closes the assistant when Escape is pressed in the input", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <>
+          <AskAiButton />
+          <ChatWidget subdomain="feature004-qa" currentPath="introduction" />
+        </>,
+      );
+    });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="ask-ai-btn"]')
+        ?.click();
+    });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLTextAreaElement>('[data-testid="chat-input"]')
+        ?.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+        );
+    });
+
+    expect(container.querySelector('[data-testid="chat-panel"]')).toBeNull();
+  });
+
   it("shows starter suggestions and applies one to the input", async () => {
     const container = document.createElement("div");
     document.body.appendChild(container);


### PR DESCRIPTION
## Summary
- Render the docs AI assistant panel as a named non-modal `<dialog>`.
- Add explicit accessible names for clear, close, and send icon controls.
- Close the assistant with Escape from the window capture path and from the focused input.
- Reset dialog default CSS so the existing bottom drawer layout stays unchanged.

Closes #125

## Verification
- Ever gap evidence: `private/browser-parity/shadowfax-20260508T061753Z/local-assistant-after-escape-snapshot.txt`
- Ever fixed-branch open/a11y proof: `private/browser-parity/shadowfax-issue125-20260508T062638Z/local-fixed-v3-assistant-open-snapshot.txt`
- Ever fixed-branch a11y eval: `private/browser-parity/shadowfax-issue125-20260508T062638Z/local-fixed-v3-assistant-a11y-eval.json`
- Ever fixed-branch Escape close proof: `private/browser-parity/shadowfax-issue125-20260508T062638Z/local-fixed-v3-assistant-after-eval-escape-snapshot.txt`
- `npm run build`
- `npm test -- --run tests/chat-widget.test.tsx`
- `make check`
- `make test` (1779 passed)

## Notes
- PR targets `staging`; staging->main PR #68 is intentionally untouched.
