### PR TITLE
Name docs page actions menu for assistive tech

### DIFF
--- a/src/components/docs/page-chrome.tsx
+++ b/src/components/docs/page-chrome.tsx
@@ -3,7 +3,7 @@
 import type { ContextualAiMenuConfig } from "@/lib/contextual-ai-menu";
 import { pageToMarkdown } from "@/lib/page-chrome";
 import { Check, Copy, Link2, MoreVertical } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { ContextualAiMenu } from "./contextual-ai-menu";
 
 interface PageHeaderActionsProps {
@@ -23,6 +23,7 @@ export function PageHeaderActions({
   const [copied, setCopied] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const menuId = useId();
 
   const handleCopy = useCallback(async () => {
     const md = pageToMarkdown(title, content);
@@ -83,16 +84,21 @@ export function PageHeaderActions({
           data-testid="page-actions-btn"
           className="page-action-btn"
           onClick={() => setMenuOpen(!menuOpen)}
+          aria-label="More page actions"
+          aria-haspopup="menu"
+          aria-expanded={menuOpen}
+          aria-controls={menuOpen ? menuId : undefined}
           title="More actions"
         >
           <MoreVertical size={16} />
         </button>
 
         {menuOpen && (
-          <div className="page-actions-menu">
+          <div className="page-actions-menu" id={menuId} role="menu">
             <button
               type="button"
               className="page-actions-menu-item"
+              role="menuitem"
               onClick={handleCopyLink}
             >
               <Link2 size={14} />
@@ -101,6 +107,7 @@ export function PageHeaderActions({
             <button
               type="button"
               className="page-actions-menu-item"
+              role="menuitem"
               onClick={handleViewSource}
             >
               <Copy size={14} />

--- a/tests/page-header-actions.test.tsx
+++ b/tests/page-header-actions.test.tsx
@@ -49,4 +49,43 @@ describe("PageHeaderActions", () => {
     expect(copyButton?.textContent).toContain("Copied");
     expect(copyButton?.getAttribute("aria-label")).toBe("Copied page markdown");
   });
+
+  it("labels the more actions menu trigger and menu items", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <PageHeaderActions
+          title="Introduction"
+          content="Welcome to the docs."
+          pageUrl="/docs/test-project/introduction.md"
+        />,
+      );
+    });
+
+    const moreButton = container.querySelector<HTMLButtonElement>(
+      '[data-testid="page-actions-btn"]',
+    );
+
+    expect(moreButton?.getAttribute("aria-label")).toBe("More page actions");
+    expect(moreButton?.getAttribute("aria-haspopup")).toBe("menu");
+    expect(moreButton?.getAttribute("aria-expanded")).toBe("false");
+    expect(moreButton?.hasAttribute("aria-controls")).toBe(false);
+
+    await act(async () => {
+      moreButton?.click();
+    });
+
+    const menu = container.querySelector<HTMLElement>(".page-actions-menu");
+    expect(moreButton?.getAttribute("aria-expanded")).toBe("true");
+    expect(moreButton?.getAttribute("aria-controls")).toBe(menu?.id);
+    expect(menu?.getAttribute("role")).toBe("menu");
+    expect(
+      Array.from(
+        container.querySelectorAll<HTMLElement>(".page-actions-menu-item"),
+      ).map((item) => item.getAttribute("role")),
+    ).toEqual(["menuitem", "menuitem"]);
+  });
 });


### PR DESCRIPTION
## Summary
- Add an explicit `aria-label` to the docs page More actions button.
- Advertise menu relationship/state with `aria-haspopup`, `aria-expanded`, and `aria-controls`.
- Mark the dropdown and items with `menu`/`menuitem` roles.

Closes #127

## Verification
- Ever before-state evidence: `private/browser-parity/shadowfax-issue125-20260508T062638Z/local-fixed-v3-clean-docs-before-assistant-snapshot.txt`
- Ever fixed closed-state eval: `private/browser-parity/shadowfax-issue127-20260508T063841Z/local-issue127-menu-before-eval.json`
- Ever fixed open-state snapshot: `private/browser-parity/shadowfax-issue127-20260508T063841Z/local-issue127-menu-open-eval-click-snapshot.txt`
- Ever fixed open-state eval: `private/browser-parity/shadowfax-issue127-20260508T063841Z/local-issue127-menu-open-eval.json`
- `npm run build`
- `npm test -- --run tests/page-header-actions.test.tsx`
- `make check`
- `make test` (1780 passed)

## Notes
- PR targets `staging`; staging->main PR #68 is intentionally untouched.
