### PR TITLE
Close docs page actions menu on Escape

### DIFF
--- a/src/components/docs/page-chrome.tsx
+++ b/src/components/docs/page-chrome.tsx
@@ -23,6 +23,7 @@ export function PageHeaderActions({
   const [copied, setCopied] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
   const menuId = useId();
 
   const handleCopy = useCallback(async () => {
@@ -43,16 +44,41 @@ export function PageHeaderActions({
     setMenuOpen(false);
   }, [pageUrl]);
 
-  // Close menu on click outside
+  const handleToggleMenu = useCallback(() => {
+    menuButtonRef.current?.focus();
+    setMenuOpen((open) => !open);
+  }, []);
+
+  // Close menu on click outside or Escape.
   useEffect(() => {
     if (!menuOpen) return;
-    function handleClick(e: MouseEvent) {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMenuOpen(false);
+
+    function closeMenu({ restoreFocus }: { restoreFocus: boolean }) {
+      setMenuOpen(false);
+      if (restoreFocus) {
+        menuButtonRef.current?.focus();
       }
     }
+
+    function handleClick(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        closeMenu({ restoreFocus: false });
+      }
+    }
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        closeMenu({ restoreFocus: true });
+      }
+    }
+
     document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      window.removeEventListener("keydown", handleKeyDown, true);
+    };
   }, [menuOpen]);
 
   return (
@@ -80,10 +106,11 @@ export function PageHeaderActions({
 
       <div className="page-actions-dropdown" ref={menuRef}>
         <button
+          ref={menuButtonRef}
           type="button"
           data-testid="page-actions-btn"
           className="page-action-btn"
-          onClick={() => setMenuOpen(!menuOpen)}
+          onClick={handleToggleMenu}
           aria-label="More page actions"
           aria-haspopup="menu"
           aria-expanded={menuOpen}

--- a/tests/page-header-actions.test.tsx
+++ b/tests/page-header-actions.test.tsx
@@ -88,4 +88,40 @@ describe("PageHeaderActions", () => {
       ).map((item) => item.getAttribute("role")),
     ).toEqual(["menuitem", "menuitem"]);
   });
+
+  it("closes the more actions menu with Escape and restores trigger focus", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <PageHeaderActions
+          title="Introduction"
+          content="Welcome to the docs."
+          pageUrl="/docs/test-project/introduction.md"
+        />,
+      );
+    });
+
+    const moreButton = container.querySelector<HTMLButtonElement>(
+      '[data-testid="page-actions-btn"]',
+    );
+
+    await act(async () => {
+      moreButton?.click();
+    });
+
+    expect(container.querySelector(".page-actions-menu")).not.toBeNull();
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+
+    expect(container.querySelector(".page-actions-menu")).toBeNull();
+    expect(moreButton?.getAttribute("aria-expanded")).toBe("false");
+    expect(document.activeElement).toBe(moreButton);
+  });
 });


### PR DESCRIPTION
## Summary
- Close the docs page More actions menu on Escape.
- Focus the menu trigger when toggling and restore focus to it after keyboard dismissal.
- Preserve click-outside close behavior and existing page action UI.

Closes #129

## Verification
- Ever gap evidence: `private/browser-parity/shadowfax-20260508T064551Z/local-staging-page-actions-after-escape-snapshot.txt`
- Ever gap eval: `private/browser-parity/shadowfax-20260508T064551Z/local-staging-page-actions-after-escape-eval.json`
- Ever fixed open proof: `private/browser-parity/shadowfax-issue129-20260508T065006Z/local-issue129-v2-open-before-eval-escape-snapshot.txt`
- Ever fixed Escape close proof: `private/browser-parity/shadowfax-issue129-20260508T065006Z/local-issue129-v2-after-eval-escape-snapshot.txt`
- Ever fixed close eval: `private/browser-parity/shadowfax-issue129-20260508T065006Z/local-issue129-v2-after-eval-escape-eval.json`
- `npm run build`
- `npm test -- --run tests/page-header-actions.test.tsx`
- `make check`
- `make test` (1781 passed)

## Notes
- Ever `send-keys Escape` did not emit page key events in this session (`local-issue129-keylogger-after-sendkeys.json`), so the fixed Escape proof uses Ever `eval` to dispatch the page `KeyboardEvent` while preserving snapshot → act → snapshot evidence.
- PR targets `staging`; staging->main PR #68 is intentionally untouched.
