### PR TITLE
Close docs selectors on Escape

### DIFF
--- a/src/components/docs/language-switcher.tsx
+++ b/src/components/docs/language-switcher.tsx
@@ -2,7 +2,7 @@
 
 import { getLanguageInfo } from "@/lib/i18n";
 import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 
 interface LanguageSwitcherProps {
   currentLocale: string;
@@ -21,20 +21,49 @@ export function LanguageSwitcher({
 }: LanguageSwitcherProps) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const dropdownId = useId();
   const router = useRouter();
 
-  // Close on click outside
+  const closeDropdown = useCallback(
+    ({ restoreFocus }: { restoreFocus: boolean }) => {
+      setOpen(false);
+      if (restoreFocus) {
+        triggerRef.current?.focus();
+      }
+    },
+    [],
+  );
+
+  const toggleDropdown = useCallback(() => {
+    triggerRef.current?.focus();
+    setOpen((value) => !value);
+  }, []);
+
+  // Close on click outside or Escape
   useEffect(() => {
+    if (!open) return;
+
     function handleClick(e: MouseEvent) {
       if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
+        closeDropdown({ restoreFocus: false });
       }
     }
-    if (open) {
-      document.addEventListener("mousedown", handleClick);
-      return () => document.removeEventListener("mousedown", handleClick);
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        closeDropdown({ restoreFocus: true });
+      }
     }
-  }, [open]);
+
+    document.addEventListener("mousedown", handleClick);
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      window.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, [closeDropdown, open]);
 
   if (availableLocales.length <= 1) return null;
 
@@ -57,12 +86,14 @@ export function LanguageSwitcher({
   return (
     <div className="lang-switcher" ref={ref} data-testid="language-switcher">
       <button
+        ref={triggerRef}
         type="button"
         className="lang-switcher-btn"
-        onClick={() => setOpen((v) => !v)}
+        onClick={toggleDropdown}
         aria-label={`Select docs language, current language ${currentInfo?.name ?? currentLocale}`}
         aria-expanded={open}
         aria-haspopup="listbox"
+        aria-controls={open ? dropdownId : undefined}
         data-testid="language-switcher-btn"
       >
         <svg
@@ -99,6 +130,7 @@ export function LanguageSwitcher({
 
       {open && (
         <nav
+          id={dropdownId}
           className="lang-switcher-dropdown"
           aria-label="Language selection"
           data-testid="language-switcher-dropdown"

--- a/src/components/docs/version-switcher.tsx
+++ b/src/components/docs/version-switcher.tsx
@@ -7,7 +7,7 @@ import {
   getVersionByTag,
 } from "@/lib/versions";
 import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 
 interface VersionSwitcherProps {
   currentVersion: string;
@@ -30,20 +30,49 @@ export function VersionSwitcher({
 }: VersionSwitcherProps) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const dropdownId = useId();
   const router = useRouter();
 
-  // Close on click outside
+  const closeDropdown = useCallback(
+    ({ restoreFocus }: { restoreFocus: boolean }) => {
+      setOpen(false);
+      if (restoreFocus) {
+        triggerRef.current?.focus();
+      }
+    },
+    [],
+  );
+
+  const toggleDropdown = useCallback(() => {
+    triggerRef.current?.focus();
+    setOpen((value) => !value);
+  }, []);
+
+  // Close on click outside or Escape
   useEffect(() => {
+    if (!open) return;
+
     function handleClick(e: MouseEvent) {
       if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
+        closeDropdown({ restoreFocus: false });
       }
     }
-    if (open) {
-      document.addEventListener("mousedown", handleClick);
-      return () => document.removeEventListener("mousedown", handleClick);
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        closeDropdown({ restoreFocus: true });
+      }
     }
-  }, [open]);
+
+    document.addEventListener("mousedown", handleClick);
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      window.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, [closeDropdown, open]);
 
   if (availableVersions.length <= 1) return null;
 
@@ -66,12 +95,14 @@ export function VersionSwitcher({
   return (
     <div className="version-switcher" ref={ref} data-testid="version-switcher">
       <button
+        ref={triggerRef}
         type="button"
         className="version-switcher-btn"
-        onClick={() => setOpen((v) => !v)}
+        onClick={toggleDropdown}
         aria-label={`Select docs version, current version ${currentInfo?.name ?? currentVersion}`}
         aria-expanded={open}
         aria-haspopup="listbox"
+        aria-controls={open ? dropdownId : undefined}
         data-testid="version-switcher-btn"
       >
         <svg
@@ -107,6 +138,7 @@ export function VersionSwitcher({
 
       {open && (
         <nav
+          id={dropdownId}
           className="version-switcher-dropdown"
           aria-label="Version selection"
           data-testid="version-switcher-dropdown"

--- a/tests/docs-selector-a11y.test.tsx
+++ b/tests/docs-selector-a11y.test.tsx
@@ -60,7 +60,11 @@ describe("docs selector accessibility", () => {
       trigger?.click();
     });
 
+    const dropdown = container.querySelector<HTMLElement>(
+      '[data-testid="version-switcher-dropdown"]',
+    );
     expect(trigger?.getAttribute("aria-expanded")).toBe("true");
+    expect(trigger?.getAttribute("aria-controls")).toBe(dropdown?.id);
     expect(
       container
         .querySelector('[data-testid="version-option-v1"]')
@@ -71,6 +75,19 @@ describe("docs selector accessibility", () => {
         .querySelector('[data-testid="version-option-v2"]')
         ?.getAttribute("aria-label"),
     ).toBe("Switch to docs version Version 2.0 (default)");
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+
+    expect(trigger?.getAttribute("aria-expanded")).toBe("false");
+    expect(trigger?.hasAttribute("aria-controls")).toBe(false);
+    expect(
+      container.querySelector('[data-testid="version-switcher-dropdown"]'),
+    ).toBeNull();
+    expect(document.activeElement).toBe(trigger);
   });
 
   it("labels the language selector and language options", async () => {
@@ -103,7 +120,11 @@ describe("docs selector accessibility", () => {
       trigger?.click();
     });
 
+    const dropdown = container.querySelector<HTMLElement>(
+      '[data-testid="language-switcher-dropdown"]',
+    );
     expect(trigger?.getAttribute("aria-expanded")).toBe("true");
+    expect(trigger?.getAttribute("aria-controls")).toBe(dropdown?.id);
     expect(
       container
         .querySelector('[data-testid="lang-option-en"]')
@@ -114,5 +135,18 @@ describe("docs selector accessibility", () => {
         .querySelector('[data-testid="lang-option-ko"]')
         ?.getAttribute("aria-label"),
     ).toBe("Switch to Korean");
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+
+    expect(trigger?.getAttribute("aria-expanded")).toBe("false");
+    expect(trigger?.hasAttribute("aria-controls")).toBe(false);
+    expect(
+      container.querySelector('[data-testid="language-switcher-dropdown"]'),
+    ).toBeNull();
+    expect(document.activeElement).toBe(trigger);
   });
 });


### PR DESCRIPTION
## Summary
- Close docs version and language selector dropdowns on Escape.
- Restore focus to the selector trigger after keyboard dismissal.
- Add `aria-controls` only while the relevant selector dropdown is mounted.

Closes #131

## Verification
- Ever gap evidence: `private/browser-parity/shadowfax-issue129-20260508T065006Z/local-staging-version-after-escape-eval.json`
- Ever fixed version open/close snapshots: `private/browser-parity/shadowfax-issue131-20260508T070156Z/local-issue131-version-open-snapshot.txt`, `private/browser-parity/shadowfax-issue131-20260508T070156Z/local-issue131-version-after-escape-snapshot.txt`
- Ever fixed language open/close snapshots: `private/browser-parity/shadowfax-issue131-20260508T070156Z/local-issue131-language-open-snapshot.txt`, `private/browser-parity/shadowfax-issue131-20260508T070156Z/local-issue131-language-after-escape-snapshot.txt`
- Ever final closed eval: `private/browser-parity/shadowfax-issue131-20260508T070156Z/local-issue131-selectors-final-closed-eval.json`
- `npm run build`
- `npm test -- --run tests/docs-selector-a11y.test.tsx`
- `make check`
- `make test` (1781 passed)

## Notes
- PR targets `staging`; staging->main PR #68 is intentionally untouched.
