### PR TITLE
Open assistant from API code Ask AI actions

### DIFF
--- a/src/components/docs/api-reference-layout.tsx
+++ b/src/components/docs/api-reference-layout.tsx
@@ -79,7 +79,7 @@ export function ApiReferenceLayout({ html }: ApiReferenceLayoutProps) {
         );
         const code = activeBlock?.querySelector("code")?.textContent || "";
         const lang = activeBlock?.dataset.lang || "curl";
-        window.dispatchEvent(
+        document.dispatchEvent(
           new CustomEvent("ask-ai-code", { detail: { code, language: lang } }),
         );
       });

--- a/tests/chat-widget.test.tsx
+++ b/tests/chat-widget.test.tsx
@@ -1,3 +1,4 @@
+import { ApiReferenceLayout } from "@/components/docs/api-reference-layout";
 import { ChatWidget } from "@/components/docs/chat-widget";
 import { AskAiButton } from "@/components/docs/docs-topbar";
 import { MdxContent } from "@/components/docs/mdx-content";
@@ -247,5 +248,42 @@ describe("Docs chat widget code context", () => {
     expect(input?.value).toContain("Explain this ts code:");
     expect(input?.value).toContain("```ts");
     expect(input?.value).toContain("const answer = 42;");
+  });
+
+  it("opens the chat panel with API reference code context when Ask AI is clicked", async () => {
+    const html = `
+      <section class="api-ref-layout">
+        <div class="api-ref-code-block active" data-lang="curl">
+          <pre><code>curl --request GET \\
+  --url https://api.example.com/plants</code></pre>
+        </div>
+        <button type="button" class="api-ref-askai-btn">Ask AI</button>
+      </section>
+    `;
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <>
+          <ApiReferenceLayout html={html} />
+          <ChatWidget subdomain="feature004-qa" currentPath="api/plants" />
+        </>,
+      );
+    });
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>(".api-ref-askai-btn")?.click();
+    });
+
+    const input = container.querySelector<HTMLTextAreaElement>(
+      '[data-testid="chat-input"]',
+    );
+    expect(input).not.toBeNull();
+    expect(input?.value).toContain("Explain this curl code:");
+    expect(input?.value).toContain("```curl");
+    expect(input?.value).toContain("curl --request GET");
+    expect(input?.value).toContain("https://api.example.com/plants");
   });
 });


### PR DESCRIPTION
## Summary
- route API reference code-block Ask AI events through the document-level channel that ChatWidget already listens to
- add regression coverage proving API reference Ask AI opens the assistant with the active code sample

## Evidence
- Ever snapshot -> click -> snapshot: `private/browser-parity/shadowfax-sweep-20260508T070438Z/local-issue133-before-api-ask-ai-snapshot.txt` -> `ever click 1669` -> `private/browser-parity/shadowfax-sweep-20260508T070438Z/local-issue133-after-api-ask-ai-snapshot.txt`
- Ever eval: `private/browser-parity/shadowfax-sweep-20260508T070438Z/local-issue133-after-api-ask-ai-eval.json` shows `chatOpen:true` and cURL prompt in `chatInput`
- `npm test -- --run tests/chat-widget.test.tsx`
- `make check`
- `make test` (1782 passed)

Closes #133
