### PR TITLE
Expose API code language selector as accessible tabs

### DIFF
--- a/src/components/docs/api-reference-layout.tsx
+++ b/src/components/docs/api-reference-layout.tsx
@@ -26,24 +26,79 @@ export function ApiReferenceLayout({ html }: ApiReferenceLayoutProps) {
       ".api-ref-code-block",
     );
 
-    for (const tab of langTabs) {
-      tab.addEventListener("click", () => {
-        const lang = tab.dataset.lang;
-        // Deactivate all tabs and blocks
-        for (const t of langTabs) t.classList.remove("active");
-        for (const b of codeBlocks) b.classList.remove("active");
-        // Activate selected
-        tab.classList.add("active");
-        const target = container.querySelector<HTMLDivElement>(
-          `.api-ref-code-block[data-lang="${lang}"]`,
-        );
-        if (target) target.classList.add("active");
+    const activateLanguageTab = (tab: HTMLButtonElement) => {
+      const lang = tab.dataset.lang;
+      // Deactivate all tabs and blocks
+      for (const t of langTabs) {
+        t.classList.remove("active");
+        t.setAttribute("aria-selected", "false");
+        t.tabIndex = -1;
+      }
+      for (const b of codeBlocks) {
+        b.classList.remove("active");
+        b.hidden = true;
+      }
+      // Activate selected
+      tab.classList.add("active");
+      tab.setAttribute("aria-selected", "true");
+      tab.tabIndex = 0;
+      const target = container.querySelector<HTMLDivElement>(
+        `.api-ref-code-block[data-lang="${lang}"]`,
+      );
+      if (target) {
+        target.classList.add("active");
+        target.hidden = false;
+      }
 
-        // Update copy button label
-        const copyBtn = container.querySelector<HTMLButtonElement>(
-          ".api-ref-copy-btn span",
-        );
-        if (copyBtn) copyBtn.textContent = tab.textContent || "cURL";
+      // Update copy button label
+      const copyBtn = container.querySelector<HTMLButtonElement>(
+        ".api-ref-copy-btn span",
+      );
+      if (copyBtn) copyBtn.textContent = tab.textContent || "cURL";
+    };
+
+    const moveLanguageTabFocus = (
+      tab: HTMLButtonElement,
+      direction: "first" | "last" | "next" | "previous",
+    ) => {
+      const tabs = Array.from(langTabs);
+      const currentIndex = tabs.indexOf(tab);
+      if (currentIndex === -1) return;
+
+      const targetIndex =
+        direction === "first"
+          ? 0
+          : direction === "last"
+            ? tabs.length - 1
+            : direction === "next"
+              ? (currentIndex + 1) % tabs.length
+              : (currentIndex - 1 + tabs.length) % tabs.length;
+
+      const target = tabs[targetIndex];
+      target.focus();
+      activateLanguageTab(target);
+    };
+
+    for (const tab of langTabs) {
+      tab.addEventListener("click", () => activateLanguageTab(tab));
+      tab.addEventListener("keydown", (event) => {
+        if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+          event.preventDefault();
+          moveLanguageTabFocus(tab, "next");
+        } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+          event.preventDefault();
+          moveLanguageTabFocus(tab, "previous");
+        } else if (event.key === "Home") {
+          event.preventDefault();
+          moveLanguageTabFocus(tab, "first");
+        } else if (event.key === "End") {
+          event.preventDefault();
+          moveLanguageTabFocus(tab, "last");
+        } else if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          tab.classList.add("active");
+          activateLanguageTab(tab);
+        }
       });
     }
 

--- a/src/lib/api-reference.ts
+++ b/src/lib/api-reference.ts
@@ -264,6 +264,15 @@ function escapeHtml(str: string): string {
     .replace(/"/g, "&quot;");
 }
 
+function safeAttributeId(str: string): string {
+  return (
+    str
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "code"
+  );
+}
+
 /**
  * Render a full API reference endpoint page as HTML.
  * Includes: method+URL header, cURL code block with language selector,
@@ -285,24 +294,24 @@ export function renderApiReferencePage(endpoint: OpenApiEndpoint): string {
   // Code examples with language selector
   const examples = generateCodeExamples(endpoint);
   const langTabs = examples
-    .map(
-      (ex, i) =>
-        `<button class="api-ref-lang-tab${i === 0 ? " active" : ""}" data-lang="${escapeHtml(ex.language)}">${escapeHtml(ex.label)}</button>`,
-    )
+    .map((ex, i) => {
+      const langId = safeAttributeId(ex.language);
+      return `<button id="api-ref-lang-tab-${langId}" class="api-ref-lang-tab${i === 0 ? " active" : ""}" data-lang="${escapeHtml(ex.language)}" role="tab" aria-selected="${i === 0 ? "true" : "false"}" aria-controls="api-ref-code-panel-${langId}" tabindex="${i === 0 ? "0" : "-1"}">${escapeHtml(ex.label)}</button>`;
+    })
     .join("\n  ");
 
   const codeBlocks = examples
-    .map(
-      (ex, i) =>
-        `<div class="api-ref-code-block${i === 0 ? " active" : ""}" data-lang="${escapeHtml(ex.language)}">
+    .map((ex, i) => {
+      const langId = safeAttributeId(ex.language);
+      return `<div id="api-ref-code-panel-${langId}" class="api-ref-code-block${i === 0 ? " active" : ""}" data-lang="${escapeHtml(ex.language)}" role="tabpanel" aria-labelledby="api-ref-lang-tab-${langId}"${i === 0 ? "" : " hidden"}>
     <pre><code>${escapeHtml(ex.code)}</code></pre>
-  </div>`,
-    )
+  </div>`;
+    })
     .join("\n");
 
   const codeSection = `<div class="api-ref-code-section" data-testid="code-section">
   <div class="api-ref-code-header">
-    <div class="api-ref-lang-tabs">
+    <div class="api-ref-lang-tabs" role="tablist" aria-label="Code examples">
       ${langTabs}
     </div>
     <div class="api-ref-code-actions">

--- a/tests/api-reference-layout.test.tsx
+++ b/tests/api-reference-layout.test.tsx
@@ -1,0 +1,107 @@
+import { ApiReferenceLayout } from "@/components/docs/api-reference-layout";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it } from "vitest";
+
+// React 19 requires this flag for act() in non-testing-library environments.
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ApiReferenceLayout", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("updates code language tab ARIA state and panels on click", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<ApiReferenceLayout html={apiReferenceTabsHtml()} />);
+    });
+
+    const curlTab =
+      container.querySelector<HTMLButtonElement>('[data-lang="curl"]');
+    const pythonTab = container.querySelector<HTMLButtonElement>(
+      '[data-lang="python"]',
+    );
+    const curlPanel = container.querySelector<HTMLDivElement>(
+      '[data-lang="curl"].api-ref-code-block',
+    );
+    const pythonPanel = container.querySelector<HTMLDivElement>(
+      '[data-lang="python"].api-ref-code-block',
+    );
+
+    expect(curlTab?.getAttribute("aria-selected")).toBe("true");
+    expect(curlTab?.tabIndex).toBe(0);
+    expect(curlPanel?.hidden).toBe(false);
+    expect(pythonTab?.getAttribute("aria-selected")).toBe("false");
+    expect(pythonTab?.tabIndex).toBe(-1);
+    expect(pythonPanel?.hidden).toBe(true);
+
+    await act(async () => {
+      pythonTab?.click();
+    });
+
+    expect(curlTab?.getAttribute("aria-selected")).toBe("false");
+    expect(curlTab?.tabIndex).toBe(-1);
+    expect(curlPanel?.hidden).toBe(true);
+    expect(pythonTab?.getAttribute("aria-selected")).toBe("true");
+    expect(pythonTab?.tabIndex).toBe(0);
+    expect(pythonPanel?.hidden).toBe(false);
+  });
+
+  it("supports keyboard navigation for code language tabs", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<ApiReferenceLayout html={apiReferenceTabsHtml()} />);
+    });
+
+    const curlTab =
+      container.querySelector<HTMLButtonElement>('[data-lang="curl"]');
+    const pythonTab = container.querySelector<HTMLButtonElement>(
+      '[data-lang="python"]',
+    );
+
+    await act(async () => {
+      curlTab?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+      );
+    });
+
+    expect(pythonTab?.getAttribute("aria-selected")).toBe("true");
+    expect(document.activeElement).toBe(pythonTab);
+
+    await act(async () => {
+      pythonTab?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }),
+      );
+    });
+
+    expect(curlTab?.getAttribute("aria-selected")).toBe("true");
+    expect(document.activeElement).toBe(curlTab);
+  });
+});
+
+function apiReferenceTabsHtml() {
+  return `
+    <div class="api-ref-code-section">
+      <div class="api-ref-lang-tabs" role="tablist" aria-label="Code examples">
+        <button id="api-ref-lang-tab-curl" class="api-ref-lang-tab active" data-lang="curl" role="tab" aria-selected="true" aria-controls="api-ref-code-panel-curl" tabindex="0">cURL</button>
+        <button id="api-ref-lang-tab-python" class="api-ref-lang-tab" data-lang="python" role="tab" aria-selected="false" aria-controls="api-ref-code-panel-python" tabindex="-1">Python</button>
+      </div>
+      <button class="api-ref-copy-btn"><span>cURL</span></button>
+      <div id="api-ref-code-panel-curl" class="api-ref-code-block active" data-lang="curl" role="tabpanel" aria-labelledby="api-ref-lang-tab-curl">
+        <pre><code>curl --request GET</code></pre>
+      </div>
+      <div id="api-ref-code-panel-python" class="api-ref-code-block" data-lang="python" role="tabpanel" aria-labelledby="api-ref-lang-tab-python" hidden>
+        <pre><code>import requests</code></pre>
+      </div>
+    </div>
+  `;
+}

--- a/tests/api-reference.test.ts
+++ b/tests/api-reference.test.ts
@@ -309,7 +309,15 @@ describe("renderApiReferencePage", () => {
 
   it("renders code section with language tabs and labeled actions", () => {
     const html = renderApiReferencePage(endpoint);
+    expect(html).toContain('role="tablist"');
+    expect(html).toContain('aria-label="Code examples"');
     expect(html).toContain("api-ref-lang-tab");
+    expect(html).toContain('role="tab"');
+    expect(html).toContain('aria-selected="true"');
+    expect(html).toContain('aria-selected="false"');
+    expect(html).toContain('aria-controls="api-ref-code-panel-curl"');
+    expect(html).toContain('role="tabpanel"');
+    expect(html).toContain('aria-labelledby="api-ref-lang-tab-curl"');
     expect(html).toContain("cURL");
     expect(html).toContain("Python");
     expect(html).toContain("JavaScript");


### PR DESCRIPTION
## Summary
- render API code language controls as an accessible tablist with tab/panel relationships
- keep `aria-selected`, roving `tabindex`, and hidden panel state in sync on click and keyboard navigation
- add renderer and client interaction regression coverage

## Evidence
- Ever snapshot/eval before fix gap: `private/browser-parity/shadowfax-sweep-20260508T071335Z/local-api-tabs-before-snapshot.txt`, `local-api-tabs-semantics-before.json`
- Ever fixed snapshot -> click -> snapshot/eval: `local-issue135-before-api-tabs-snapshot.txt` -> `ever click 231` -> `local-issue135-after-python-tab-snapshot.txt`, `local-issue135-after-python-tab-semantics.json`
- `npm test -- --run tests/api-reference.test.ts tests/api-reference-layout.test.tsx`
- `make check`
- `make test` (1784 passed)

Closes #135
