### PR TITLE
Label docs feedback comment textarea

### DIFF
--- a/src/components/docs/feedback-widget.tsx
+++ b/src/components/docs/feedback-widget.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ThumbsDown, ThumbsUp } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback, useId, useState } from "react";
 
 type WidgetState = "idle" | "rated" | "submitting" | "submitted";
 
@@ -15,6 +15,7 @@ export function FeedbackWidget({ subdomain, pagePath }: FeedbackWidgetProps) {
   const [rating, setRating] = useState<"helpful" | "not_helpful" | null>(null);
   const [comment, setComment] = useState("");
   const [toast, setToast] = useState(false);
+  const commentLabelId = useId();
 
   const submitFeedback = useCallback(
     async (
@@ -109,7 +110,7 @@ export function FeedbackWidget({ subdomain, pagePath }: FeedbackWidgetProps) {
 
       {(state === "rated" || state === "submitting") && (
         <div className="docs-feedback-comment-section">
-          <p className="docs-feedback-comment-label">
+          <p id={commentLabelId} className="docs-feedback-comment-label">
             {rating === "helpful"
               ? "Great! Any additional feedback?"
               : "Sorry to hear that. How can we improve?"}
@@ -117,6 +118,7 @@ export function FeedbackWidget({ subdomain, pagePath }: FeedbackWidgetProps) {
           <textarea
             className="docs-feedback-textarea"
             data-testid="feedback-textarea"
+            aria-labelledby={commentLabelId}
             placeholder="Tell us more (optional)"
             value={comment}
             onChange={(e) => setComment(e.target.value)}

--- a/tests/feedback-widget.test.ts
+++ b/tests/feedback-widget.test.ts
@@ -218,4 +218,43 @@ describe("Feedback widget visible choices", () => {
     });
     container.remove();
   });
+
+  it("labels the optional feedback comment textarea with the visible prompt", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(FeedbackWidget, {
+          subdomain: "test-project",
+          pagePath: "introduction",
+        }),
+      );
+    });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="feedback-thumbs-down"]',
+        )
+        ?.click();
+    });
+
+    const textarea = container.querySelector<HTMLTextAreaElement>(
+      '[data-testid="feedback-textarea"]',
+    );
+    const label = container.querySelector<HTMLElement>(
+      ".docs-feedback-comment-label",
+    );
+
+    expect(label?.textContent).toBe("Sorry to hear that. How can we improve?");
+    expect(label?.id).toBeTruthy();
+    expect(textarea?.getAttribute("aria-labelledby")).toBe(label?.id);
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
 });


### PR DESCRIPTION
## Summary
- label the feedback comment textarea from the visible follow-up prompt
- add regression coverage for the not-helpful feedback comment flow

## Evidence
- Ever gap evidence: `private/browser-parity/shadowfax-sweep-20260508T072102Z/local-feedback-before-snapshot.txt`, `local-feedback-after-no-click-eval.json`
- Ever fixed snapshot -> click -> snapshot/eval: `local-issue137-before-feedback-snapshot.txt` -> `ever click 222` -> `local-issue137-after-no-click-snapshot.txt`, `local-issue137-after-no-click-eval.json`
- `npm test -- --run tests/feedback-widget.test.ts`
- `make check`
- `make test` (1785 passed)

Closes #137
