### PR TITLE
Support keyboard navigation for API response status tabs

### DIFF
--- a/src/components/docs/api-reference-layout.tsx
+++ b/src/components/docs/api-reference-layout.tsx
@@ -148,27 +148,69 @@ export function ApiReferenceLayout({ html }: ApiReferenceLayoutProps) {
       ".api-ref-status-panel",
     );
 
+    const activateStatusTab = (tab: HTMLButtonElement) => {
+      const status = tab.dataset.status;
+      for (const t of statusTabs) {
+        t.classList.remove("active");
+        t.setAttribute("aria-selected", "false");
+        t.tabIndex = -1;
+      }
+      for (const p of statusPanels) {
+        p.classList.remove("active");
+        p.hidden = true;
+      }
+      tab.classList.add("active");
+      tab.setAttribute("aria-selected", "true");
+      tab.tabIndex = 0;
+      const target = container.querySelector<HTMLDivElement>(
+        `.api-ref-status-panel[data-status="${status}"]`,
+      );
+      if (target) {
+        target.classList.add("active");
+        target.hidden = false;
+      }
+    };
+
+    const moveStatusTabFocus = (
+      tab: HTMLButtonElement,
+      direction: "first" | "last" | "next" | "previous",
+    ) => {
+      const tabs = Array.from(statusTabs);
+      const currentIndex = tabs.indexOf(tab);
+      if (currentIndex === -1) return;
+
+      const targetIndex =
+        direction === "first"
+          ? 0
+          : direction === "last"
+            ? tabs.length - 1
+            : direction === "next"
+              ? (currentIndex + 1) % tabs.length
+              : (currentIndex - 1 + tabs.length) % tabs.length;
+
+      const target = tabs[targetIndex];
+      target.focus();
+      activateStatusTab(target);
+    };
+
     for (const tab of statusTabs) {
-      tab.addEventListener("click", () => {
-        const status = tab.dataset.status;
-        for (const t of statusTabs) {
-          t.classList.remove("active");
-          t.setAttribute("aria-selected", "false");
-          t.tabIndex = -1;
-        }
-        for (const p of statusPanels) {
-          p.classList.remove("active");
-          p.hidden = true;
-        }
-        tab.classList.add("active");
-        tab.setAttribute("aria-selected", "true");
-        tab.tabIndex = 0;
-        const target = container.querySelector<HTMLDivElement>(
-          `.api-ref-status-panel[data-status="${status}"]`,
-        );
-        if (target) {
-          target.classList.add("active");
-          target.hidden = false;
+      tab.addEventListener("click", () => activateStatusTab(tab));
+      tab.addEventListener("keydown", (event) => {
+        if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+          event.preventDefault();
+          moveStatusTabFocus(tab, "next");
+        } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+          event.preventDefault();
+          moveStatusTabFocus(tab, "previous");
+        } else if (event.key === "Home") {
+          event.preventDefault();
+          moveStatusTabFocus(tab, "first");
+        } else if (event.key === "End") {
+          event.preventDefault();
+          moveStatusTabFocus(tab, "last");
+        } else if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          activateStatusTab(tab);
         }
       });
     }

--- a/tests/api-reference-layout.test.tsx
+++ b/tests/api-reference-layout.test.tsx
@@ -86,6 +86,82 @@ describe("ApiReferenceLayout", () => {
     expect(curlTab?.getAttribute("aria-selected")).toBe("true");
     expect(document.activeElement).toBe(curlTab);
   });
+
+  it("updates response status tab ARIA state and panels on click", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<ApiReferenceLayout html={apiReferenceTabsHtml()} />);
+    });
+
+    const successTab = container.querySelector<HTMLButtonElement>(
+      '[data-status="200"]',
+    );
+    const errorTab = container.querySelector<HTMLButtonElement>(
+      '[data-status="400"]',
+    );
+    const successPanel = container.querySelector<HTMLDivElement>(
+      '[data-status="200"].api-ref-status-panel',
+    );
+    const errorPanel = container.querySelector<HTMLDivElement>(
+      '[data-status="400"].api-ref-status-panel',
+    );
+
+    expect(successTab?.getAttribute("aria-selected")).toBe("true");
+    expect(successTab?.tabIndex).toBe(0);
+    expect(successPanel?.hidden).toBe(false);
+    expect(errorTab?.getAttribute("aria-selected")).toBe("false");
+    expect(errorTab?.tabIndex).toBe(-1);
+    expect(errorPanel?.hidden).toBe(true);
+
+    await act(async () => {
+      errorTab?.click();
+    });
+
+    expect(successTab?.getAttribute("aria-selected")).toBe("false");
+    expect(successTab?.tabIndex).toBe(-1);
+    expect(successPanel?.hidden).toBe(true);
+    expect(errorTab?.getAttribute("aria-selected")).toBe("true");
+    expect(errorTab?.tabIndex).toBe(0);
+    expect(errorPanel?.hidden).toBe(false);
+  });
+
+  it("supports keyboard navigation for response status tabs", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<ApiReferenceLayout html={apiReferenceTabsHtml()} />);
+    });
+
+    const successTab = container.querySelector<HTMLButtonElement>(
+      '[data-status="200"]',
+    );
+    const errorTab = container.querySelector<HTMLButtonElement>(
+      '[data-status="400"]',
+    );
+
+    await act(async () => {
+      successTab?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+      );
+    });
+
+    expect(errorTab?.getAttribute("aria-selected")).toBe("true");
+    expect(document.activeElement).toBe(errorTab);
+
+    await act(async () => {
+      errorTab?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }),
+      );
+    });
+
+    expect(successTab?.getAttribute("aria-selected")).toBe("true");
+    expect(document.activeElement).toBe(successTab);
+  });
 });
 
 function apiReferenceTabsHtml() {
@@ -101,6 +177,16 @@ function apiReferenceTabsHtml() {
       </div>
       <div id="api-ref-code-panel-python" class="api-ref-code-block" data-lang="python" role="tabpanel" aria-labelledby="api-ref-lang-tab-python" hidden>
         <pre><code>import requests</code></pre>
+      </div>
+      <div class="api-ref-status-tabs" role="tablist" aria-label="Response status codes">
+        <button id="api-response-tab-200" class="api-ref-status-tab active" data-status="200" role="tab" aria-selected="true" aria-controls="api-response-panel-200" tabindex="0">200</button>
+        <button id="api-response-tab-400" class="api-ref-status-tab" data-status="400" role="tab" aria-selected="false" aria-controls="api-response-panel-400" tabindex="-1">400</button>
+      </div>
+      <div id="api-response-panel-200" class="api-ref-status-panel active" data-status="200" role="tabpanel" aria-labelledby="api-response-tab-200">
+        <pre><code>{"ok": true}</code></pre>
+      </div>
+      <div id="api-response-panel-400" class="api-ref-status-panel" data-status="400" role="tabpanel" aria-labelledby="api-response-tab-400" hidden>
+        <pre><code>{"error": true}</code></pre>
       </div>
     </div>
   `;


### PR DESCRIPTION
## Summary
- add Arrow/Home/End keyboard navigation for API response status tabs
- keep focus, aria-selected, roving tabindex, and visible response panel state synchronized
- extend ApiReferenceLayout regression tests for response tab click and keyboard behavior

## Evidence
- Ever gap evidence: `private/browser-parity/shadowfax-sweep-20260508T072926Z/local-api-response-tabs-before-snapshot-2.txt`, `local-api-response-tabs-before-semantics.json`, `local-api-response-tabs-after-arrowright-semantics.json`
- Ever fixed snapshot -> act -> snapshot/eval: `local-issue139-before-response-tabs-keyboard-snapshot.txt` -> `ever click 404 && ever send-keys ArrowRight` -> `local-issue139-after-arrowright-snapshot.txt`, `local-issue139-after-arrowright-semantics.json`
- `npm test -- --run tests/api-reference-layout.test.tsx`
- `make check`
- `make test` (1787 passed)

Closes #139
