### PR TITLE
Support keyboard navigation for API playground response tabs

### DIFF
--- a/src/components/docs/api-playground.tsx
+++ b/src/components/docs/api-playground.tsx
@@ -32,31 +32,78 @@ export function ApiPlayground({ html }: ApiPlaygroundProps) {
     // Wire up response tab switching
     const respTabButtons =
       container.querySelectorAll<HTMLButtonElement>(".api-resp-tab");
+    const activateResponseTab = (btn: HTMLButtonElement) => {
+      const playground = btn.closest(".api-playground");
+      if (!playground) return;
+      const tab = btn.dataset.respTab;
+
+      // Deactivate all tabs
+      const allTabs =
+        playground.querySelectorAll<HTMLButtonElement>(".api-resp-tab");
+      for (const t of allTabs) {
+        t.classList.remove("active");
+        t.setAttribute("aria-selected", String(t === btn));
+        t.tabIndex = t === btn ? 0 : -1;
+      }
+      btn.classList.add("active");
+
+      // Show/hide panels
+      const bodyPanel =
+        playground.querySelector<HTMLDivElement>(".api-response-body");
+      const headersPanel = playground.querySelector<HTMLDivElement>(
+        ".api-response-headers",
+      );
+      if (bodyPanel)
+        bodyPanel.style.display = tab === "body" ? "block" : "none";
+      if (headersPanel)
+        headersPanel.style.display = tab === "headers" ? "block" : "none";
+    };
+
+    const moveResponseTabFocus = (
+      btn: HTMLButtonElement,
+      direction: "first" | "last" | "next" | "previous",
+    ) => {
+      const playground = btn.closest(".api-playground");
+      if (!playground) return;
+      const tabs = Array.from(
+        playground.querySelectorAll<HTMLButtonElement>(".api-resp-tab"),
+      );
+      const currentIndex = tabs.indexOf(btn);
+      if (currentIndex === -1) return;
+
+      const targetIndex =
+        direction === "first"
+          ? 0
+          : direction === "last"
+            ? tabs.length - 1
+            : direction === "next"
+              ? (currentIndex + 1) % tabs.length
+              : (currentIndex - 1 + tabs.length) % tabs.length;
+
+      const target = tabs[targetIndex];
+      target.focus();
+      activateResponseTab(target);
+    };
+
     for (const btn of respTabButtons) {
-      btn.addEventListener("click", () => {
-        const playground = btn.closest(".api-playground");
-        if (!playground) return;
-        const tab = btn.dataset.respTab;
-
-        // Deactivate all tabs
-        const allTabs =
-          playground.querySelectorAll<HTMLButtonElement>(".api-resp-tab");
-        for (const t of allTabs) {
-          t.classList.remove("active");
-          t.setAttribute("aria-selected", String(t === btn));
+      btn.addEventListener("click", () => activateResponseTab(btn));
+      btn.addEventListener("keydown", (event) => {
+        if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+          event.preventDefault();
+          moveResponseTabFocus(btn, "next");
+        } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+          event.preventDefault();
+          moveResponseTabFocus(btn, "previous");
+        } else if (event.key === "Home") {
+          event.preventDefault();
+          moveResponseTabFocus(btn, "first");
+        } else if (event.key === "End") {
+          event.preventDefault();
+          moveResponseTabFocus(btn, "last");
+        } else if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          activateResponseTab(btn);
         }
-        btn.classList.add("active");
-
-        // Show/hide panels
-        const bodyPanel =
-          playground.querySelector<HTMLDivElement>(".api-response-body");
-        const headersPanel = playground.querySelector<HTMLDivElement>(
-          ".api-response-headers",
-        );
-        if (bodyPanel)
-          bodyPanel.style.display = tab === "body" ? "block" : "none";
-        if (headersPanel)
-          headersPanel.style.display = tab === "headers" ? "block" : "none";
       });
     }
   }, [html]);

--- a/src/lib/openapi-parser.ts
+++ b/src/lib/openapi-parser.ts
@@ -373,13 +373,13 @@ export function renderApiPlaygroundHtml(endpoint: OpenApiEndpoint): string {
     <a class="api-response-download" aria-label="Download response file" download="response.txt" href="#" style="display:none">Download</a>
   </div>
   <div class="api-response-tabs" role="tablist" aria-label="Response sections">
-    <button type="button" class="api-resp-tab active" data-resp-tab="body" role="tab" aria-selected="true" aria-label="Show response body">Body</button>
-    <button type="button" class="api-resp-tab" data-resp-tab="headers" role="tab" aria-selected="false" aria-label="Show response headers">Headers</button>
+    <button type="button" id="api-response-body-tab" class="api-resp-tab active" data-resp-tab="body" role="tab" aria-selected="true" aria-controls="api-response-body-panel" tabindex="0" aria-label="Show response body">Body</button>
+    <button type="button" id="api-response-headers-tab" class="api-resp-tab" data-resp-tab="headers" role="tab" aria-selected="false" aria-controls="api-response-headers-panel" tabindex="-1" aria-label="Show response headers">Headers</button>
   </div>
-  <div class="api-response-body" role="tabpanel" aria-label="Response body">
+  <div id="api-response-body-panel" class="api-response-body" role="tabpanel" aria-labelledby="api-response-body-tab" aria-label="Response body">
     <pre><code class="api-response-content"></code></pre>
   </div>
-  <div class="api-response-headers" role="tabpanel" aria-label="Response headers" style="display:none">
+  <div id="api-response-headers-panel" class="api-response-headers" role="tabpanel" aria-labelledby="api-response-headers-tab" aria-label="Response headers" style="display:none">
     <pre><code class="api-response-headers-content"></code></pre>
   </div>
 </div>`;

--- a/tests/api-playground-layout.test.tsx
+++ b/tests/api-playground-layout.test.tsx
@@ -1,0 +1,109 @@
+import { ApiPlayground } from "@/components/docs/api-playground";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it } from "vitest";
+
+// React 19 requires this flag for act() in non-testing-library environments.
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ApiPlayground response tabs", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("updates response tab ARIA state and panels on click", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<ApiPlayground html={apiPlaygroundTabsHtml()} />);
+    });
+
+    const bodyTab = container.querySelector<HTMLButtonElement>(
+      '[data-resp-tab="body"]',
+    );
+    const headersTab = container.querySelector<HTMLButtonElement>(
+      '[data-resp-tab="headers"]',
+    );
+    const bodyPanel =
+      container.querySelector<HTMLElement>(".api-response-body");
+    const headersPanel = container.querySelector<HTMLElement>(
+      ".api-response-headers",
+    );
+
+    expect(bodyTab?.getAttribute("aria-selected")).toBe("true");
+    expect(bodyTab?.tabIndex).toBe(0);
+    expect(bodyPanel?.style.display).not.toBe("none");
+    expect(headersTab?.getAttribute("aria-selected")).toBe("false");
+    expect(headersTab?.tabIndex).toBe(-1);
+    expect(headersPanel?.style.display).toBe("none");
+
+    await act(async () => {
+      headersTab?.click();
+    });
+
+    expect(bodyTab?.getAttribute("aria-selected")).toBe("false");
+    expect(bodyTab?.tabIndex).toBe(-1);
+    expect(bodyPanel?.style.display).toBe("none");
+    expect(headersTab?.getAttribute("aria-selected")).toBe("true");
+    expect(headersTab?.tabIndex).toBe(0);
+    expect(headersPanel?.style.display).toBe("block");
+  });
+
+  it("supports keyboard navigation for response tabs", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<ApiPlayground html={apiPlaygroundTabsHtml()} />);
+    });
+
+    const bodyTab = container.querySelector<HTMLButtonElement>(
+      '[data-resp-tab="body"]',
+    );
+    const headersTab = container.querySelector<HTMLButtonElement>(
+      '[data-resp-tab="headers"]',
+    );
+
+    await act(async () => {
+      bodyTab?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+      );
+    });
+
+    expect(headersTab?.getAttribute("aria-selected")).toBe("true");
+    expect(document.activeElement).toBe(headersTab);
+
+    await act(async () => {
+      headersTab?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }),
+      );
+    });
+
+    expect(bodyTab?.getAttribute("aria-selected")).toBe("true");
+    expect(document.activeElement).toBe(bodyTab);
+  });
+});
+
+function apiPlaygroundTabsHtml() {
+  return `
+    <div class="api-playground">
+      <div class="api-response" style="display:block">
+        <div class="api-response-tabs" role="tablist" aria-label="Response sections">
+          <button type="button" id="api-response-body-tab" class="api-resp-tab active" data-resp-tab="body" role="tab" aria-selected="true" aria-controls="api-response-body-panel" tabindex="0" aria-label="Show response body">Body</button>
+          <button type="button" id="api-response-headers-tab" class="api-resp-tab" data-resp-tab="headers" role="tab" aria-selected="false" aria-controls="api-response-headers-panel" tabindex="-1" aria-label="Show response headers">Headers</button>
+        </div>
+        <div id="api-response-body-panel" class="api-response-body" role="tabpanel" aria-labelledby="api-response-body-tab" aria-label="Response body">
+          <pre><code class="api-response-content">{}</code></pre>
+        </div>
+        <div id="api-response-headers-panel" class="api-response-headers" role="tabpanel" aria-labelledby="api-response-headers-tab" aria-label="Response headers" style="display:none">
+          <pre><code class="api-response-headers-content"></code></pre>
+        </div>
+      </div>
+    </div>
+  `;
+}

--- a/tests/api-playground.test.ts
+++ b/tests/api-playground.test.ts
@@ -311,16 +311,16 @@ describe("API Playground HTML Renderer", () => {
     expect(html).toContain('class="api-response"');
     expect(html).toContain('role="tablist" aria-label="Response sections"');
     expect(html).toContain(
-      'role="tab" aria-selected="true" aria-label="Show response body"',
+      'role="tab" aria-selected="true" aria-controls="api-response-body-panel" tabindex="0" aria-label="Show response body"',
     );
     expect(html).toContain(
-      'role="tab" aria-selected="false" aria-label="Show response headers"',
+      'role="tab" aria-selected="false" aria-controls="api-response-headers-panel" tabindex="-1" aria-label="Show response headers"',
     );
     expect(html).toContain(
-      'class="api-response-body" role="tabpanel" aria-label="Response body"',
+      'class="api-response-body" role="tabpanel" aria-labelledby="api-response-body-tab" aria-label="Response body"',
     );
     expect(html).toContain(
-      'class="api-response-headers" role="tabpanel" aria-label="Response headers"',
+      'class="api-response-headers" role="tabpanel" aria-labelledby="api-response-headers-tab" aria-label="Response headers"',
     );
     expect(html).toContain('class="api-response-download"');
     expect(html).toContain('aria-label="Download response file"');


### PR DESCRIPTION
## Summary
- add roving tabindex and Arrow/Home/End keyboard navigation for playground response Body/Headers tabs
- wire response tab buttons to labelled response panels
- add renderer and client interaction regression coverage

## Evidence
- Ever gap evidence: `private/browser-parity/shadowfax-sweep-20260508T074007Z/local-api-playground-tabs-before-snapshot.txt`, `local-api-playground-tabs-before-semantics.json`, `local-api-playground-tabs-after-arrowright-semantics.json`
- Ever fixed visible-response flow: `local-issue141-visible-response-before-send-snapshot.txt` -> `ever click 881` -> `local-issue141-visible-response-after-send-snapshot.txt` -> `ever click 892 && ever send-keys ArrowRight` -> `local-issue141-after-visible-arrowright-snapshot.txt`, `local-issue141-after-visible-arrowright-semantics.json`
- `npm test -- --run tests/api-playground.test.ts tests/api-playground-layout.test.tsx`
- `make check`
- `make test` (1789 passed)

Closes #141
