### PR TITLE
Make default docs search results keyboard selectable

### DIFF
--- a/src/components/docs/search-modal.tsx
+++ b/src/components/docs/search-modal.tsx
@@ -255,18 +255,29 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
   }, [open]);
 
   // Keyboard navigation within results
-  const allResults = results;
+  const hasQuery = query.trim().length > 0;
+  const showRecent = !hasQuery && recentSearches.length > 0;
+  const defaultPages = !hasQuery && !showRecent ? pages.slice(0, 10) : [];
+  const navigableCount = hasQuery ? results.length : defaultPages.length;
   const handleModalKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "ArrowDown") {
       e.preventDefault();
-      setSelectedIdx((prev) => Math.min(prev + 1, allResults.length - 1));
+      if (navigableCount > 0) {
+        setSelectedIdx((prev) => Math.min(prev + 1, navigableCount - 1));
+      }
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       setSelectedIdx((prev) => Math.max(prev - 1, 0));
-    } else if (e.key === "Enter" && allResults[selectedIdx]) {
+    } else if (e.key === "Enter") {
+      const resultTarget = hasQuery ? results[selectedIdx] : undefined;
+      const defaultTarget = !hasQuery ? defaultPages[selectedIdx] : undefined;
+      const target = resultTarget || defaultTarget;
+      if (!target) return;
+
       e.preventDefault();
-      saveRecentSearch(query);
-      const target = allResults[selectedIdx];
+      if (hasQuery) {
+        saveRecentSearch(query);
+      }
       window.location.href = `/docs/${subdomain}/${target.path}`;
     }
   };
@@ -274,11 +285,8 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
   if (!isOpen) return null;
 
   const grouped = groupResults(results);
-  const hasQuery = query.trim().length > 0;
-  const showRecent = !hasQuery && recentSearches.length > 0;
-  const activeDescendant = allResults[selectedIdx]
-    ? optionIdForIndex(selectedIdx)
-    : undefined;
+  const activeDescendant =
+    navigableCount > 0 ? optionIdForIndex(selectedIdx) : undefined;
   const listboxProps = {
     role: "listbox",
     tabIndex: -1,
@@ -400,7 +408,7 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
                   {group.section}
                 </div>
                 {group.results.map((result) => {
-                  const flatIdx = allResults.indexOf(result);
+                  const flatIdx = results.indexOf(result);
                   return (
                     <Link
                       key={result.path}
@@ -449,14 +457,15 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
           {/* Default: show all pages when no query */}
           {!hasQuery &&
             !showRecent &&
-            pages.slice(0, 10).map((page, index) => {
+            defaultPages.map((page, index) => {
+              const selected = index === selectedIdx;
               return (
                 <Link
                   key={page.path}
                   id={optionIdForIndex(index)}
                   href={`/docs/${subdomain}/${page.path}`}
-                  {...optionProps(false)}
-                  className="search-modal-result"
+                  {...optionProps(selected)}
+                  className={`search-modal-result ${selected ? "search-modal-result-active" : ""}`}
                   onClick={close}
                 >
                   <svg

--- a/tests/docs-site-layout.test.ts
+++ b/tests/docs-site-layout.test.ts
@@ -47,6 +47,7 @@ describe("Docs site layout — feature-014", () => {
     beforeEach(() => {
       container = document.createElement("div");
       document.body.appendChild(container);
+      localStorage.removeItem("docs-recent-searches");
     });
 
     afterEach(() => {
@@ -150,8 +151,55 @@ describe("Docs site layout — feature-014", () => {
       expect(input?.getAttribute("aria-autocomplete")).toBe("list");
       expect(input?.getAttribute("aria-expanded")).toBe("true");
       expect(input?.getAttribute("aria-controls")).toBe(results?.id);
+      expect(input?.getAttribute("aria-activedescendant")).toBe(
+        firstOption?.id,
+      );
       expect(results?.getAttribute("role")).toBe("listbox");
-      expect(firstOption?.getAttribute("aria-selected")).toBe("false");
+      expect(firstOption?.getAttribute("aria-selected")).toBe("true");
+
+      await act(async () => {
+        root.unmount();
+      });
+    });
+
+    it("moves active selection through default results with arrow keys", async () => {
+      const { SearchModal } = await import("@/components/docs/search-modal");
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          createElement(SearchModal, {
+            subdomain: "test-project",
+            pages: [
+              { path: "introduction", title: "Introduction" },
+              { path: "quickstart", title: "Quickstart" },
+            ],
+          }),
+        );
+      });
+
+      await act(async () => {
+        document.dispatchEvent(new CustomEvent("open-search"));
+      });
+
+      const input = container.querySelector<HTMLInputElement>(
+        '[data-testid="search-input"]',
+      );
+      const options =
+        container.querySelectorAll<HTMLElement>('[role="option"]');
+
+      expect(input?.getAttribute("aria-activedescendant")).toBe(options[0].id);
+      expect(options[0].getAttribute("aria-selected")).toBe("true");
+
+      await act(async () => {
+        input?.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+        );
+      });
+
+      expect(input?.getAttribute("aria-activedescendant")).toBe(options[1].id);
+      expect(options[0].getAttribute("aria-selected")).toBe("false");
+      expect(options[1].getAttribute("aria-selected")).toBe("true");
 
       await act(async () => {
         root.unmount();


### PR DESCRIPTION
## Summary
- include empty-query default results in search combobox active-descendant state
- move active default option with ArrowUp/ArrowDown and support Enter navigation
- update search modal regression coverage for default result selection

## Evidence
- Ever gap evidence: `private/browser-parity/shadowfax-sweep-20260508T075302Z/local-search-default-open-snapshot.txt`, `local-search-default-open-semantics.json`, `local-search-default-after-arrowdown-semantics.json`
- Ever fixed flow: `local-issue143-before-search-snapshot.txt` -> `ever click 74` -> `local-issue143-search-open-snapshot.txt`, `local-issue143-search-open-semantics.json` -> `ever send-keys ArrowDown` -> `local-issue143-search-after-arrowdown-snapshot.txt`, `local-issue143-search-after-arrowdown-semantics.json`
- `npm test -- --run tests/docs-site-layout.test.ts`
- `make check`
- `make test` (1790 passed)

Closes #143
