### PR TITLE
Make docs recent search options keyboard selectable

### DIFF
--- a/src/components/docs/search-modal.tsx
+++ b/src/components/docs/search-modal.tsx
@@ -258,7 +258,11 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
   const hasQuery = query.trim().length > 0;
   const showRecent = !hasQuery && recentSearches.length > 0;
   const defaultPages = !hasQuery && !showRecent ? pages.slice(0, 10) : [];
-  const navigableCount = hasQuery ? results.length : defaultPages.length;
+  const navigableCount = hasQuery
+    ? results.length
+    : showRecent
+      ? recentSearches.length
+      : defaultPages.length;
   const handleModalKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "ArrowDown") {
       e.preventDefault();
@@ -270,8 +274,18 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
       setSelectedIdx((prev) => Math.max(prev - 1, 0));
     } else if (e.key === "Enter") {
       const resultTarget = hasQuery ? results[selectedIdx] : undefined;
-      const defaultTarget = !hasQuery ? defaultPages[selectedIdx] : undefined;
+      const recentTarget = showRecent ? recentSearches[selectedIdx] : undefined;
+      const defaultTarget =
+        !hasQuery && !showRecent ? defaultPages[selectedIdx] : undefined;
       const target = resultTarget || defaultTarget;
+
+      if (recentTarget) {
+        e.preventDefault();
+        setQuery(recentTarget);
+        fetchResults(recentTarget);
+        return;
+      }
+
       if (!target) return;
 
       e.preventDefault();
@@ -362,13 +376,14 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
             <div data-testid="recent-searches" className="search-modal-section">
               <div className="search-modal-section-title">Recent searches</div>
               {recentSearches.map((q, index) => {
+                const selected = index === selectedIdx;
                 return (
                   <button
                     key={q}
                     id={optionIdForIndex(index)}
                     type="button"
-                    {...optionProps(false)}
-                    className="search-modal-result search-modal-recent"
+                    {...optionProps(selected)}
+                    className={`search-modal-result search-modal-recent ${selected ? "search-modal-result-active" : ""}`}
                     onClick={() => {
                       setQuery(q);
                       fetchResults(q);

--- a/tests/docs-site-layout.test.ts
+++ b/tests/docs-site-layout.test.ts
@@ -205,6 +205,57 @@ describe("Docs site layout — feature-014", () => {
         root.unmount();
       });
     });
+
+    it("moves active selection through recent searches with arrow keys", async () => {
+      const { SearchModal } = await import("@/components/docs/search-modal");
+      localStorage.setItem(
+        "docs-recent-searches",
+        JSON.stringify(["plants", "quickstart"]),
+      );
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          createElement(SearchModal, {
+            subdomain: "test-project",
+            pages: [
+              { path: "introduction", title: "Introduction" },
+              { path: "quickstart", title: "Quickstart" },
+            ],
+          }),
+        );
+      });
+
+      await act(async () => {
+        document.dispatchEvent(new CustomEvent("open-search"));
+      });
+
+      const input = container.querySelector<HTMLInputElement>(
+        '[data-testid="search-input"]',
+      );
+      const options =
+        container.querySelectorAll<HTMLElement>('[role="option"]');
+
+      expect(
+        container.querySelector('[data-testid="recent-searches"]'),
+      ).not.toBeNull();
+      expect(input?.getAttribute("aria-activedescendant")).toBe(options[0].id);
+      expect(options[0].getAttribute("aria-selected")).toBe("true");
+
+      await act(async () => {
+        input?.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+        );
+      });
+
+      expect(input?.getAttribute("aria-activedescendant")).toBe(options[1].id);
+      expect(options[0].getAttribute("aria-selected")).toBe("false");
+      expect(options[1].getAttribute("aria-selected")).toBe("true");
+
+      await act(async () => {
+        root.unmount();
+      });
+    });
   });
 
   describe("MobileNav", () => {


### PR DESCRIPTION
## Summary
- include recent-search options in search combobox active-descendant state
- move active recent option with ArrowUp/ArrowDown and apply it with Enter
- update search modal regression coverage for recent result selection

## Evidence
- Ever gap evidence: `private/browser-parity/shadowfax-sweep-20260508T080235Z/local-search-recent-open-snapshot.txt`, `local-search-recent-open-semantics.json`, `local-search-recent-after-arrowdown-semantics.json`
- Ever fixed flow: `local-issue145-before-search-snapshot.txt` -> `ever click 74` -> `local-issue145-search-open-snapshot.txt`, `local-issue145-search-open-semantics.json` -> `ever send-keys ArrowDown` -> `local-issue145-search-after-arrowdown-snapshot.txt`, `local-issue145-search-after-arrowdown-semantics.json`
- `npm test -- --run tests/docs-site-layout.test.ts`
- `make check`
- `make test` (1791 passed)

Closes #145
