### PR TITLE
Restore focus after docs search closes

### DIFF
--- a/src/components/docs/search-modal.tsx
+++ b/src/components/docs/search-modal.tsx
@@ -121,6 +121,7 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const abortRef = useRef<AbortController | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const restoreFocusRef = useRef<HTMLElement | null>(null);
   const listboxId = useId();
   const optionIdForIndex = useCallback(
     (index: number) => `${listboxId}-option-${index}`,
@@ -128,6 +129,9 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
   );
 
   const open = useCallback(() => {
+    const activeElement = document.activeElement;
+    restoreFocusRef.current =
+      activeElement instanceof HTMLElement ? activeElement : null;
     setIsOpen(true);
     setQuery("");
     setResults([]);
@@ -136,10 +140,18 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
   }, []);
 
   const close = useCallback(() => {
+    const restoreFocusTarget = restoreFocusRef.current;
     setIsOpen(false);
     setQuery("");
     setResults([]);
     setSelectedIdx(0);
+    restoreFocusRef.current = null;
+
+    if (restoreFocusTarget?.isConnected) {
+      setTimeout(() => {
+        restoreFocusTarget.focus();
+      }, 0);
+    }
   }, []);
 
   // Fetch results from API with debounce

--- a/tests/docs-site-layout.test.ts
+++ b/tests/docs-site-layout.test.ts
@@ -256,6 +256,54 @@ describe("Docs site layout — feature-014", () => {
         root.unmount();
       });
     });
+
+    it("returns focus to the opener when Escape closes search", async () => {
+      const { SearchModal } = await import("@/components/docs/search-modal");
+      const opener = document.createElement("button");
+      const appRoot = document.createElement("div");
+      opener.type = "button";
+      opener.textContent = "Search documentation";
+      container.append(opener, appRoot);
+      opener.focus();
+
+      const root = createRoot(appRoot);
+
+      await act(async () => {
+        root.render(
+          createElement(SearchModal, {
+            subdomain: "test-project",
+            pages: [
+              { path: "introduction", title: "Introduction" },
+              { path: "quickstart", title: "Quickstart" },
+            ],
+          }),
+        );
+      });
+
+      await act(async () => {
+        document.dispatchEvent(new CustomEvent("open-search"));
+      });
+
+      const input = appRoot.querySelector<HTMLInputElement>(
+        '[data-testid="search-input"]',
+      );
+
+      expect(document.activeElement).toBe(input);
+
+      await act(async () => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+        );
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(appRoot.querySelector('[data-testid="search-modal"]')).toBeNull();
+      expect(document.activeElement).toBe(opener);
+
+      await act(async () => {
+        root.unmount();
+      });
+    });
   });
 
   describe("MobileNav", () => {


### PR DESCRIPTION
## Summary
- Capture the focused opener before docs search opens.
- Restore focus to that opener after Escape/dismiss closes the search modal.
- Add a regression test for Escape close focus restoration.

## Evidence
Ever Shadowfax verification under `private/browser-parity/shadowfax-issue-147-verify-20260508T083136Z`:
- `local-fixed-search-before-snapshot.txt`
- `local-fixed-search-open-snapshot.txt`
- `local-fixed-search-open-semantics.json` => search input focused while open.
- `local-fixed-search-after-escape-snapshot.txt`
- `local-fixed-search-after-escape-semantics.json` => `{"open":false,"activeTag":"BUTTON","activeLabel":"Open search","searchFocused":true}`.

## Tests
- `npm test -- tests/docs-site-layout.test.ts`
- `make check`
- `make test` (1792 passed)

Closes #147.
