### PR TITLE
Trap focus inside docs search dialog

### DIFF
--- a/src/components/docs/search-modal.tsx
+++ b/src/components/docs/search-modal.tsx
@@ -47,6 +47,14 @@ export function filterPages(
 
 const RECENT_KEY = "docs-recent-searches";
 const MAX_RECENT = 5;
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
 
 type DocsSearchWindow = Window & { __docsSearchRequested?: boolean };
 
@@ -84,6 +92,12 @@ function saveRecentSearch(query: string): void {
   }
 }
 
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    .filter((element) => element.tabIndex >= 0)
+    .filter((element) => element.getAttribute("aria-hidden") !== "true");
+}
+
 // ── Group results by first breadcrumb segment ─────────────────────────────────
 
 function groupResults(results: SearchResultItem[]): SearchResultGroup[] {
@@ -119,6 +133,7 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
   const [selectedIdx, setSelectedIdx] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
+  const dialogRef = useRef<HTMLDialogElement>(null);
   const abortRef = useRef<AbortController | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const restoreFocusRef = useRef<HTMLElement | null>(null);
@@ -151,6 +166,42 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
       setTimeout(() => {
         restoreFocusTarget.focus();
       }, 0);
+    }
+  }, []);
+
+  const trapTabFocus = useCallback((event: KeyboardEvent) => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const focusableElements = getFocusableElements(dialog);
+    const firstFocusable = focusableElements[0];
+    const lastFocusable = focusableElements[focusableElements.length - 1];
+
+    if (!firstFocusable || !lastFocusable) {
+      event.preventDefault();
+      dialog.focus();
+      return;
+    }
+
+    const activeElement = document.activeElement;
+    if (
+      !(activeElement instanceof HTMLElement) ||
+      !dialog.contains(activeElement)
+    ) {
+      event.preventDefault();
+      firstFocusable.focus();
+      return;
+    }
+
+    if (event.shiftKey && activeElement === firstFocusable) {
+      event.preventDefault();
+      lastFocusable.focus();
+      return;
+    }
+
+    if (!event.shiftKey && activeElement === lastFocusable) {
+      event.preventDefault();
+      firstFocusable.focus();
     }
   }, []);
 
@@ -240,10 +291,13 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
       if (e.key === "Escape" && isOpen) {
         close();
       }
+      if (e.key === "Tab" && isOpen) {
+        trapTabFocus(e);
+      }
     }
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [isOpen, close, open]);
+  }, [isOpen, close, open, trapTabFocus]);
 
   // Auto-focus input
   useEffect(() => {
@@ -336,6 +390,7 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
       }}
     >
       <dialog
+        ref={dialogRef}
         className="search-modal"
         open
         aria-label="Search docs"

--- a/tests/docs-site-layout.test.ts
+++ b/tests/docs-site-layout.test.ts
@@ -304,6 +304,60 @@ describe("Docs site layout — feature-014", () => {
         root.unmount();
       });
     });
+
+    it("traps Tab focus inside the open search dialog", async () => {
+      const { SearchModal } = await import("@/components/docs/search-modal");
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          createElement(SearchModal, {
+            subdomain: "test-project",
+            pages: [
+              { path: "introduction", title: "Introduction" },
+              { path: "quickstart", title: "Quickstart" },
+            ],
+          }),
+        );
+      });
+
+      await act(async () => {
+        document.dispatchEvent(new CustomEvent("open-search"));
+      });
+
+      const input = container.querySelector<HTMLInputElement>(
+        '[data-testid="search-input"]',
+      );
+      const options =
+        container.querySelectorAll<HTMLElement>('[role="option"]');
+      const lastOption = options[options.length - 1];
+
+      lastOption.focus();
+
+      await act(async () => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Tab", bubbles: true }),
+        );
+      });
+
+      expect(document.activeElement).toBe(input);
+
+      await act(async () => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "Tab",
+            shiftKey: true,
+            bubbles: true,
+          }),
+        );
+      });
+
+      expect(document.activeElement).toBe(lastOption);
+
+      await act(async () => {
+        root.unmount();
+      });
+    });
   });
 
   describe("MobileNav", () => {


### PR DESCRIPTION
## Summary
- Trap Tab and Shift+Tab focus within the open docs search dialog.
- Keep existing opener focus restoration on dismissal.
- Add a regression test for cycling focus at the dialog boundaries.

## Evidence
Ever Shadowfax verification under `/Users/ashleyha/dev/opendocs/private/browser-parity/shadowfax-issue-149-verify-20260508T084319Z`:
- `local-fixed-tabtrap-before-snapshot.txt`
- `local-fixed-tabtrap-open-snapshot.txt`
- `local-fixed-tabtrap-after-tabs-snapshot.txt`
- `local-fixed-tabtrap-after-tabs-semantics.json` => `{"open":true,"activeTag":"BUTTON","activeLabel":"plants","activeInsideModal":true,"activeHref":null}`

## Tests
- `npm test -- tests/docs-site-layout.test.ts`
- `make check`
- `make test` (1793 passed)

Closes #149.
