### PR TITLE
Trap focus inside mobile docs navigation

### DIFF
--- a/src/components/docs/mobile-nav.tsx
+++ b/src/components/docs/mobile-nav.tsx
@@ -5,6 +5,21 @@ import { X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { DocsSidebar } from "./docs-sidebar";
 
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    .filter((element) => element.tabIndex >= 0)
+    .filter((element) => element.getAttribute("aria-hidden") !== "true");
+}
+
 export function MobileMenuButton() {
   return (
     <button
@@ -91,6 +106,38 @@ export function MobileSidebar({
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") {
         setIsOpen(false);
+      }
+      if (event.key === "Tab" && overlayRef.current) {
+        const focusableElements = getFocusableElements(overlayRef.current);
+        const firstFocusable = focusableElements[0];
+        const lastFocusable = focusableElements[focusableElements.length - 1];
+
+        if (!firstFocusable || !lastFocusable) {
+          event.preventDefault();
+          overlayRef.current.focus();
+          return;
+        }
+
+        const activeElement = document.activeElement;
+        if (
+          !(activeElement instanceof HTMLElement) ||
+          !overlayRef.current.contains(activeElement)
+        ) {
+          event.preventDefault();
+          firstFocusable.focus();
+          return;
+        }
+
+        if (event.shiftKey && activeElement === firstFocusable) {
+          event.preventDefault();
+          lastFocusable.focus();
+          return;
+        }
+
+        if (!event.shiftKey && activeElement === lastFocusable) {
+          event.preventDefault();
+          firstFocusable.focus();
+        }
       }
     }
 

--- a/tests/docs-site-layout.test.ts
+++ b/tests/docs-site-layout.test.ts
@@ -434,6 +434,88 @@ describe("Docs site layout — feature-014", () => {
       });
       container.remove();
     });
+
+    it("traps Tab focus inside the open mobile navigation", async () => {
+      const { MobileMenuButton, MobileSidebar } = await import(
+        "@/components/docs/mobile-nav"
+      );
+      const container = document.createElement("div");
+      document.body.appendChild(container);
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          createElement(
+            "div",
+            null,
+            createElement(MobileMenuButton),
+            createElement(MobileSidebar, {
+              nav: [
+                {
+                  type: "item",
+                  label: "Introduction",
+                  path: "introduction",
+                  pageId: "intro",
+                },
+                {
+                  type: "item",
+                  label: "Quickstart",
+                  path: "quickstart",
+                  pageId: "quickstart",
+                },
+              ],
+              activePath: "introduction",
+              subdomain: "test-project",
+              projectName: "Test Project",
+            }),
+          ),
+        );
+      });
+
+      await act(async () => {
+        container
+          .querySelector<HTMLButtonElement>('[data-testid="mobile-menu-btn"]')
+          ?.click();
+      });
+
+      const dialog = container.querySelector<HTMLElement>(
+        '[data-testid="mobile-sidebar"]',
+      );
+      const focusable = Array.from(
+        dialog?.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+        ) ?? [],
+      );
+      const firstFocusable = focusable[0];
+      const lastFocusable = focusable[focusable.length - 1];
+
+      lastFocusable.focus();
+
+      await act(async () => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Tab", bubbles: true }),
+        );
+      });
+
+      expect(document.activeElement).toBe(firstFocusable);
+
+      await act(async () => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            key: "Tab",
+            shiftKey: true,
+            bubbles: true,
+          }),
+        );
+      });
+
+      expect(document.activeElement).toBe(lastFocusable);
+
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    });
   });
 
   describe("Layout structure", () => {


### PR DESCRIPTION
## Summary
- Trap Tab and Shift+Tab focus within the open mobile docs navigation drawer.
- Preserve Escape, overlay-click, and close-button dismissal.
- Add a regression test for drawer focus cycling.

## Evidence
Ever Shadowfax verification under `/Users/ashleyha/dev/opendocs/private/browser-parity/shadowfax-issue-151-verify-20260508T084921Z`:
- `local-fixed-mobile-nav-before-snapshot.txt`
- `local-fixed-mobile-nav-open-snapshot.txt`
- `local-fixed-mobile-nav-after-tabs-snapshot.txt`
- `local-fixed-mobile-nav-after-tabs-semantics.json` => `{"open":true,"activeTag":"BUTTON","activeLabel":"Close navigation","activeInsideDialog":true,"activeHref":null}`

## Tests
- `npm test -- tests/docs-site-layout.test.ts`
- `make check`
- `make test` (1794 passed)

Closes #151.
