### PR TITLE
Focus feedback textarea after rating

### DIFF
--- a/src/components/docs/feedback-widget.tsx
+++ b/src/components/docs/feedback-widget.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ThumbsDown, ThumbsUp } from "lucide-react";
-import { useCallback, useId, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 
 type WidgetState = "idle" | "rated" | "submitting" | "submitted";
 
@@ -16,6 +16,13 @@ export function FeedbackWidget({ subdomain, pagePath }: FeedbackWidgetProps) {
   const [comment, setComment] = useState("");
   const [toast, setToast] = useState(false);
   const commentLabelId = useId();
+  const commentRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (state === "rated") {
+      commentRef.current?.focus();
+    }
+  }, [state]);
 
   const submitFeedback = useCallback(
     async (
@@ -116,6 +123,7 @@ export function FeedbackWidget({ subdomain, pagePath }: FeedbackWidgetProps) {
               : "Sorry to hear that. How can we improve?"}
           </p>
           <textarea
+            ref={commentRef}
             className="docs-feedback-textarea"
             data-testid="feedback-textarea"
             aria-labelledby={commentLabelId}

--- a/tests/feedback-widget.test.ts
+++ b/tests/feedback-widget.test.ts
@@ -257,4 +257,38 @@ describe("Feedback widget visible choices", () => {
     });
     container.remove();
   });
+
+  it("moves focus to the optional feedback comment textarea after rating", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(FeedbackWidget, {
+          subdomain: "test-project",
+          pagePath: "introduction",
+        }),
+      );
+    });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="feedback-thumbs-down"]',
+        )
+        ?.click();
+    });
+
+    const textarea = container.querySelector<HTMLTextAreaElement>(
+      '[data-testid="feedback-textarea"]',
+    );
+
+    expect(document.activeElement).toBe(textarea);
+
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
 });


### PR DESCRIPTION
## Summary
- Focus the optional feedback comment textarea after a Yes/No rating reveals it.
- Preserve the existing prompt-based accessible label from #137.
- Add a regression test for focus movement after rating.

## Evidence
Ever Shadowfax verification under `/Users/ashleyha/dev/opendocs/private/browser-parity/shadowfax-issue-154-verify-20260508T091154Z`:
- `local-fixed-feedback-before-snapshot.txt`
- `local-fixed-feedback-no-after-snapshot.txt`
- `local-fixed-feedback-no-semantics.json` => `{"activeTag":"TEXTAREA","activeTestId":"feedback-textarea","activePlaceholder":"Tell us more (optional)","textareaFocused":true,"textareaExists":true,"ariaLabelledby":"_R_t9clritqbn5rlb_","labelText":"Sorry to hear that. How can we improve?"}`

## Tests
- `npm test -- tests/feedback-widget.test.ts`
- `make check`
- `make test` (1795 passed)

Closes #154.
