### PR TITLE
Focus feedback thank-you after submission

### DIFF
--- a/src/components/docs/feedback-widget.tsx
+++ b/src/components/docs/feedback-widget.tsx
@@ -17,10 +17,13 @@ export function FeedbackWidget({ subdomain, pagePath }: FeedbackWidgetProps) {
   const [toast, setToast] = useState(false);
   const commentLabelId = useId();
   const commentRef = useRef<HTMLTextAreaElement>(null);
+  const thanksRef = useRef<HTMLParagraphElement>(null);
 
   useEffect(() => {
     if (state === "rated") {
       commentRef.current?.focus();
+    } else if (state === "submitted") {
+      thanksRef.current?.focus();
     }
   }, [state]);
 
@@ -73,7 +76,12 @@ export function FeedbackWidget({ subdomain, pagePath }: FeedbackWidgetProps) {
   if (state === "submitted") {
     return (
       <div className="docs-feedback-widget" data-testid="feedback-widget">
-        <p className="docs-feedback-thanks" data-testid="feedback-thanks">
+        <p
+          ref={thanksRef}
+          className="docs-feedback-thanks"
+          data-testid="feedback-thanks"
+          tabIndex={-1}
+        >
           Thanks for your feedback!
         </p>
         {toast && (

--- a/tests/feedback-widget.test.ts
+++ b/tests/feedback-widget.test.ts
@@ -1,7 +1,7 @@
 import { FeedbackWidget } from "@/components/docs/feedback-widget";
 import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { validateFeedbackPayload } from "../src/lib/feedback";
 
 // React 19 requires this flag for act() in non-testing-library environments.
@@ -286,6 +286,52 @@ describe("Feedback widget visible choices", () => {
 
     expect(document.activeElement).toBe(textarea);
 
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("moves focus to the thank-you message after feedback submission", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+    } as Response);
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        createElement(FeedbackWidget, {
+          subdomain: "test-project",
+          pagePath: "introduction",
+        }),
+      );
+    });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="feedback-thumbs-down"]',
+        )
+        ?.click();
+    });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="feedback-skip"]')
+        ?.click();
+      await Promise.resolve();
+    });
+
+    const thanks = container.querySelector<HTMLElement>(
+      '[data-testid="feedback-thanks"]',
+    );
+
+    expect(thanks?.getAttribute("tabindex")).toBe("-1");
+    expect(document.activeElement).toBe(thanks);
+
+    fetchMock.mockRestore();
     await act(async () => {
       root.unmount();
     });


### PR DESCRIPTION
## Summary
- Focus the feedback thank-you message after Submit/Skip completes.
- Keep the completion message programmatically focusable with `tabIndex=-1`.
- Add regression coverage for focus after feedback submission.

## Evidence
Ever Shadowfax verification under `/Users/ashleyha/dev/opendocs/private/browser-parity/shadowfax-issue-156-verify-20260508T091837Z`:
- `local-fixed-feedback-thanks-before-snapshot.txt`
- `local-fixed-feedback-thanks-comment-snapshot.txt`
- `local-fixed-feedback-thanks-after-skip-snapshot.txt`
- `local-fixed-feedback-thanks-after-skip-semantics.json` => `{"activeTag":"P","activeText":"Thanks for your feedback!","activeTestId":"feedback-thanks","thanksFocused":true,"thanksExists":true,"thanksTabIndex":"-1","widgetText":"Thanks for your feedback!Feedback recorded"}`

## Tests
- `npm test -- tests/feedback-widget.test.ts`
- `make check`
- `make test` (1796 passed)

Closes #156.
