### PR TITLE
Support selector arrow-key navigation

### DIFF
--- a/src/components/docs/language-switcher.tsx
+++ b/src/components/docs/language-switcher.tsx
@@ -22,6 +22,7 @@ export function LanguageSwitcher({
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const dropdownId = useId();
   const router = useRouter();
 
@@ -54,6 +55,27 @@ export function LanguageSwitcher({
       if (e.key === "Escape") {
         e.preventDefault();
         closeDropdown({ restoreFocus: true });
+        return;
+      }
+
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        const options = optionRefs.current.filter(Boolean);
+        if (options.length === 0) return;
+
+        e.preventDefault();
+        const activeIndex = options.findIndex(
+          (option) => option === document.activeElement,
+        );
+        const nextIndex =
+          e.key === "ArrowDown"
+            ? activeIndex === -1
+              ? 0
+              : (activeIndex + 1) % options.length
+            : activeIndex === -1
+              ? options.length - 1
+              : (activeIndex - 1 + options.length) % options.length;
+
+        options[nextIndex]?.focus();
       }
     }
 
@@ -135,12 +157,15 @@ export function LanguageSwitcher({
           aria-label="Language selection"
           data-testid="language-switcher-dropdown"
         >
-          {availableLocales.map((locale) => {
+          {availableLocales.map((locale, index) => {
             const info = getLanguageInfo(locale);
             const isActive = locale === currentLocale;
             return (
               <button
                 key={locale}
+                ref={(element) => {
+                  optionRefs.current[index] = element;
+                }}
                 type="button"
                 aria-label={`Switch to ${info?.name ?? locale}`}
                 aria-current={isActive ? "true" : undefined}

--- a/src/components/docs/version-switcher.tsx
+++ b/src/components/docs/version-switcher.tsx
@@ -31,6 +31,7 @@ export function VersionSwitcher({
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const dropdownId = useId();
   const router = useRouter();
 
@@ -63,6 +64,27 @@ export function VersionSwitcher({
       if (e.key === "Escape") {
         e.preventDefault();
         closeDropdown({ restoreFocus: true });
+        return;
+      }
+
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        const options = optionRefs.current.filter(Boolean);
+        if (options.length === 0) return;
+
+        e.preventDefault();
+        const activeIndex = options.findIndex(
+          (option) => option === document.activeElement,
+        );
+        const nextIndex =
+          e.key === "ArrowDown"
+            ? activeIndex === -1
+              ? 0
+              : (activeIndex + 1) % options.length
+            : activeIndex === -1
+              ? options.length - 1
+              : (activeIndex - 1 + options.length) % options.length;
+
+        options[nextIndex]?.focus();
       }
     }
 
@@ -143,13 +165,16 @@ export function VersionSwitcher({
           aria-label="Version selection"
           data-testid="version-switcher-dropdown"
         >
-          {availableVersions.map((tag) => {
+          {availableVersions.map((tag, index) => {
             const info = getVersionByTag(versionsConfig, tag);
             const isActive = tag === currentVersion;
             const isDefault = tag === defaultTag;
             return (
               <button
                 key={tag}
+                ref={(element) => {
+                  optionRefs.current[index] = element;
+                }}
                 type="button"
                 aria-label={`Switch to docs version ${info?.name ?? tag}${isDefault ? " (default)" : ""}`}
                 aria-current={isActive ? "true" : undefined}

--- a/tests/docs-selector-a11y.test.tsx
+++ b/tests/docs-selector-a11y.test.tsx
@@ -78,6 +78,26 @@ describe("docs selector accessibility", () => {
 
     await act(async () => {
       window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+      );
+    });
+
+    expect(document.activeElement).toBe(
+      container.querySelector('[data-testid="version-option-v1"]'),
+    );
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }),
+      );
+    });
+
+    expect(document.activeElement).toBe(
+      container.querySelector('[data-testid="version-option-v2"]'),
+    );
+
+    await act(async () => {
+      window.dispatchEvent(
         new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
       );
     });
@@ -135,6 +155,26 @@ describe("docs selector accessibility", () => {
         .querySelector('[data-testid="lang-option-ko"]')
         ?.getAttribute("aria-label"),
     ).toBe("Switch to Korean");
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+      );
+    });
+
+    expect(document.activeElement).toBe(
+      container.querySelector('[data-testid="lang-option-en"]'),
+    );
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+      );
+    });
+
+    expect(document.activeElement).toBe(
+      container.querySelector('[data-testid="lang-option-ko"]'),
+    );
 
     await act(async () => {
       window.dispatchEvent(


### PR DESCRIPTION
## Summary
- Add ArrowUp/ArrowDown focus traversal to docs version and language selector dropdowns
- Preserve Escape close/focus restoration behavior
- Cover selector traversal in docs selector accessibility tests

## Verification
- Ever snapshot -> open selector -> ArrowDown -> snapshot/eval for version and language, evidence in private/browser-parity/shadowfax-issue-158-verify-20260508T092656Z
- make check
- make test (1796 passed)

Closes #158