### PR TITLE
Keep clicked ToC section active

### DIFF
--- a/src/components/docs/docs-toc.tsx
+++ b/src/components/docs/docs-toc.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { TocEntry } from "@/lib/editor";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 interface DocsTocProps {
   entries: TocEntry[];
@@ -11,6 +11,10 @@ export function DocsToc({ entries }: DocsTocProps) {
   // Filter to H2 and H3 only for display
   const displayEntries = entries.filter((e) => e.level >= 2 && e.level <= 3);
   const [activeId, setActiveId] = useState<string>(displayEntries[0]?.id ?? "");
+  const manuallySelectedIdRef = useRef<string | null>(null);
+  const manualSelectionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
   useEffect(() => {
     setActiveId((current) => current || displayEntries[0]?.id || "");
@@ -21,6 +25,8 @@ export function DocsToc({ entries }: DocsTocProps) {
 
     const observer = new IntersectionObserver(
       (observerEntries) => {
+        if (manuallySelectedIdRef.current) return;
+
         for (const entry of observerEntries) {
           if (entry.isIntersecting) {
             setActiveId(entry.target.id);
@@ -38,15 +44,31 @@ export function DocsToc({ entries }: DocsTocProps) {
     return () => observer.disconnect();
   }, [displayEntries]);
 
+  useEffect(() => {
+    return () => {
+      if (manualSelectionTimerRef.current) {
+        clearTimeout(manualSelectionTimerRef.current);
+      }
+    };
+  }, []);
+
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>, id: string) => {
       e.preventDefault();
       const target = document.getElementById(id);
       if (target) {
+        if (manualSelectionTimerRef.current) {
+          clearTimeout(manualSelectionTimerRef.current);
+        }
+        manuallySelectedIdRef.current = id;
         target.scrollIntoView({ behavior: "smooth", block: "start" });
         // Update URL hash without jumping
         window.history.pushState(null, "", `#${id}`);
         setActiveId(id);
+        manualSelectionTimerRef.current = setTimeout(() => {
+          manuallySelectedIdRef.current = null;
+          manualSelectionTimerRef.current = null;
+        }, 1500);
       }
     },
     [],

--- a/tests/docs-toc-interaction.test.tsx
+++ b/tests/docs-toc-interaction.test.tsx
@@ -1,0 +1,95 @@
+import { DocsToc } from "@/components/docs/docs-toc";
+import type { TocEntry } from "@/lib/editor";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// React 19 requires this flag for act() in non-testing-library environments.
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+type ObserverCallback = (entries: IntersectionObserverEntry[]) => void;
+
+let latestObserverCallback: ObserverCallback | null = null;
+
+class MockIntersectionObserver {
+  readonly root = null;
+  readonly rootMargin = "";
+  readonly thresholds = [];
+
+  constructor(callback: ObserverCallback) {
+    latestObserverCallback = callback;
+  }
+
+  disconnect = vi.fn();
+  observe = vi.fn();
+  takeRecords = vi.fn(() => []);
+  unobserve = vi.fn();
+}
+
+const tocEntries: TocEntry[] = [
+  { level: 2, text: "Create a project", id: "create-a-project" },
+  { level: 2, text: "Install the SDK", id: "install-the-sdk" },
+  { level: 2, text: "Make your first request", id: "make-your-first-request" },
+];
+
+describe("DocsToc interactions", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    latestObserverCallback = null;
+    document.body.innerHTML = `
+      <h2 id="create-a-project">Create a project</h2>
+      <h2 id="install-the-sdk">Install the SDK</h2>
+      <h2 id="make-your-first-request">Make your first request</h2>
+      <div id="toc-root"></div>
+    `;
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+    Element.prototype.scrollIntoView = vi.fn();
+    window.history.replaceState(null, "", "/docs/test-project/quickstart");
+  });
+
+  it("keeps the clicked ToC entry active while smooth scrolling settles", async () => {
+    const container = document.getElementById("toc-root");
+    if (!container) throw new Error("missing test container");
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<DocsToc entries={tocEntries} />);
+    });
+
+    const createLink = container.querySelector<HTMLAnchorElement>(
+      'a[href="#create-a-project"]',
+    );
+    const installLink = container.querySelector<HTMLAnchorElement>(
+      'a[href="#install-the-sdk"]',
+    );
+    if (!createLink || !installLink) throw new Error("missing ToC links");
+
+    await act(async () => {
+      installLink.click();
+    });
+
+    expect(window.location.hash).toBe("#install-the-sdk");
+    expect(installLink.className).toContain("active");
+
+    const createHeading = document.getElementById("create-a-project");
+    if (!createHeading) throw new Error("missing create heading");
+
+    await act(async () => {
+      latestObserverCallback?.([
+        {
+          isIntersecting: true,
+          target: createHeading,
+        } as unknown as IntersectionObserverEntry,
+      ]);
+    });
+
+    expect(installLink.className).toContain("active");
+    expect(createLink.className).not.toContain("active");
+
+    await act(async () => {
+      vi.advanceTimersByTime(1500);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Keep a directly clicked docs ToC section highlighted while smooth scrolling settles
- Preserve observer-driven active-heading updates for passive scrolling
- Add a regression test for the click/observer race

## Verification
- Ever snapshot -> ToC click -> snapshot/eval on /docs/test-project/quickstart, evidence in private/browser-parity/shadowfax-issue-160-verify-20260508T093906Z/local-fixed-toc-click-rerun.txt
- make check
- make test (1797 passed)

Closes #160