### PR TITLE
Align ToC active state with Mintlify

### DIFF
--- a/src/components/docs/docs-toc.tsx
+++ b/src/components/docs/docs-toc.tsx
@@ -10,14 +10,22 @@ interface DocsTocProps {
 export function DocsToc({ entries }: DocsTocProps) {
   // Filter to H2 and H3 only for display
   const displayEntries = entries.filter((e) => e.level >= 2 && e.level <= 3);
-  const [activeId, setActiveId] = useState<string>(displayEntries[0]?.id ?? "");
+  const [activeId, setActiveId] = useState<string>("");
   const manuallySelectedIdRef = useRef<string | null>(null);
+  const suppressObserverRef = useRef(false);
+  const entryIdsRef = useRef<Set<string>>(new Set());
   const manualSelectionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+  const observerSuppressionTimerRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
 
   useEffect(() => {
-    setActiveId((current) => current || displayEntries[0]?.id || "");
+    entryIdsRef.current = new Set(displayEntries.map((entry) => entry.id));
+    setActiveId((current) =>
+      current && entryIdsRef.current.has(current) ? current : "",
+    );
   }, [displayEntries]);
 
   useEffect(() => {
@@ -25,7 +33,8 @@ export function DocsToc({ entries }: DocsTocProps) {
 
     const observer = new IntersectionObserver(
       (observerEntries) => {
-        if (manuallySelectedIdRef.current) return;
+        if (manuallySelectedIdRef.current || suppressObserverRef.current)
+          return;
 
         for (const entry of observerEntries) {
           if (entry.isIntersecting) {
@@ -45,9 +54,51 @@ export function DocsToc({ entries }: DocsTocProps) {
   }, [displayEntries]);
 
   useEffect(() => {
+    const suppressExternalHashNavigation = () => {
+      if (manuallySelectedIdRef.current) return;
+      if (observerSuppressionTimerRef.current) {
+        clearTimeout(observerSuppressionTimerRef.current);
+      }
+      suppressObserverRef.current = true;
+      setActiveId("");
+      observerSuppressionTimerRef.current = setTimeout(() => {
+        suppressObserverRef.current = false;
+        observerSuppressionTimerRef.current = null;
+      }, 1500);
+    };
+
+    const handleDocumentClick = (event: MouseEvent) => {
+      const anchor = (event.target as Element | null)?.closest?.(
+        "a[href]",
+      ) as HTMLAnchorElement | null;
+      if (!anchor || anchor.closest(".docs-toc")) return;
+      const href = anchor.getAttribute("href") || "";
+      const hash = href.startsWith("#")
+        ? href.slice(1)
+        : new URL(anchor.href).hash.slice(1);
+      if (hash && entryIdsRef.current.has(hash)) {
+        suppressExternalHashNavigation();
+      }
+    };
+
+    const handleHashChange = () => {
+      const hash = window.location.hash.slice(1);
+      if (hash && entryIdsRef.current.has(hash)) {
+        suppressExternalHashNavigation();
+      }
+    };
+
+    document.addEventListener("click", handleDocumentClick, true);
+    window.addEventListener("hashchange", handleHashChange);
+
     return () => {
+      document.removeEventListener("click", handleDocumentClick, true);
+      window.removeEventListener("hashchange", handleHashChange);
       if (manualSelectionTimerRef.current) {
         clearTimeout(manualSelectionTimerRef.current);
+      }
+      if (observerSuppressionTimerRef.current) {
+        clearTimeout(observerSuppressionTimerRef.current);
       }
     };
   }, []);

--- a/tests/docs-toc-interaction.test.tsx
+++ b/tests/docs-toc-interaction.test.tsx
@@ -39,7 +39,7 @@ describe("DocsToc interactions", () => {
     vi.useFakeTimers();
     latestObserverCallback = null;
     document.body.innerHTML = `
-      <h2 id="create-a-project">Create a project</h2>
+      <h2 id="create-a-project"><a id="create-heading-anchor" href="#create-a-project">Create a project</a></h2>
       <h2 id="install-the-sdk">Install the SDK</h2>
       <h2 id="make-your-first-request">Make your first request</h2>
       <div id="toc-root"></div>
@@ -47,6 +47,67 @@ describe("DocsToc interactions", () => {
     vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
     Element.prototype.scrollIntoView = vi.fn();
     window.history.replaceState(null, "", "/docs/test-project/quickstart");
+  });
+
+  it("does not mark a ToC entry active before user or scroll selection", async () => {
+    const container = document.getElementById("toc-root");
+    if (!container) throw new Error("missing test container");
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<DocsToc entries={tocEntries} />);
+    });
+
+    const links = Array.from(
+      container.querySelectorAll<HTMLAnchorElement>(".docs-toc-link"),
+    );
+
+    expect(links).toHaveLength(3);
+    for (const link of links) {
+      expect(link.className).not.toContain("active");
+    }
+  });
+
+  it("keeps heading-anchor hash navigation from selecting a ToC entry", async () => {
+    const container = document.getElementById("toc-root");
+    if (!container) throw new Error("missing test container");
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<DocsToc entries={tocEntries} />);
+    });
+
+    const createLink = container.querySelector<HTMLAnchorElement>(
+      'a[href="#create-a-project"]',
+    );
+    if (!createLink) throw new Error("missing create ToC link");
+
+    const headingAnchor = document.getElementById("create-heading-anchor");
+    if (!headingAnchor) throw new Error("missing heading anchor");
+
+    await act(async () => {
+      headingAnchor.click();
+      window.history.pushState(null, "", "#create-a-project");
+      window.dispatchEvent(new HashChangeEvent("hashchange"));
+    });
+
+    const createHeading = document.getElementById("create-a-project");
+    if (!createHeading) throw new Error("missing create heading");
+
+    await act(async () => {
+      latestObserverCallback?.([
+        {
+          isIntersecting: true,
+          target: createHeading,
+        } as unknown as IntersectionObserverEntry,
+      ]);
+    });
+
+    expect(createLink.className).not.toContain("active");
+
+    await act(async () => {
+      vi.advanceTimersByTime(1500);
+    });
   });
 
   it("keeps the clicked ToC entry active while smooth scrolling settles", async () => {

--- a/tests/e2e/docs-site-layout.spec.ts
+++ b/tests/e2e/docs-site-layout.spec.ts
@@ -83,14 +83,14 @@ test.describe("Docs site layout — feature-014", () => {
     await expect(mobileSidebar).toBeVisible();
   });
 
-  test("TOC highlights current section on scroll", async ({ page }) => {
+  test("TOC waits for user or scroll selection before highlighting", async ({
+    page,
+  }) => {
     await page.goto("/docs/test-project/quickstart");
     const tocLinks = page.locator(".docs-toc-link");
-    // At least one TOC link should exist if page has headings
     const count = await tocLinks.count();
     if (count > 0) {
-      // First TOC link should be active by default (top of page)
-      await expect(tocLinks.first()).toHaveClass(/active/);
+      await expect(tocLinks.first()).not.toHaveClass(/active/);
     }
   });
 });


### PR DESCRIPTION
## Summary
- start docs ToC with no default active item to match Mintlify top-of-page behavior
- suppress observer activation for non-ToC heading/hash-anchor navigation
- preserve clicked-ToC active retention from #160

## Verification
- Ever snapshot -> act -> snapshot: private/browser-parity/shadowfax-issue-162-verify-20260508T110405Z/local-fixed-toc-inactive-top-final.txt
- make check
- make test (1799 passed)

Closes #162