### PR TITLE
Match Mintlify 404 title for missing docs routes

### DIFF
--- a/src/app/docs/[subdomain]/[...slug]/page.tsx
+++ b/src/app/docs/[subdomain]/[...slug]/page.tsx
@@ -81,6 +81,11 @@ interface DocsPageProps {
 }
 
 const APP_URL = getPublicAppUrl();
+const DOCS_NOT_FOUND_TITLE = "404: This page could not be found.";
+
+function getDocsNotFoundMetadata(): Metadata {
+  return { title: DOCS_NOT_FOUND_TITLE };
+}
 
 function normalizeHeadingText(value: string): string {
   return value
@@ -125,7 +130,7 @@ export async function generateMetadata({
     .where(eq(projects.subdomain, subdomain))
     .limit(1);
 
-  if (projectResult.length === 0) return {};
+  if (projectResult.length === 0) return getDocsNotFoundMetadata();
 
   const project = projectResult[0];
   const docsSettings = (project.settings || {}) as Record<string, unknown>;
@@ -179,7 +184,27 @@ export async function generateMetadata({
     )
     .limit(1);
 
-  if (pageResult.length === 0) return {};
+  if (pageResult.length === 0) {
+    if (findRedirect(docsConfig.advanced.redirects, pagePath)) return {};
+
+    const spec = docsSettings.openApiSpec as
+      | Record<string, unknown>
+      | undefined;
+    if (spec && typeof spec === "object") {
+      const generatedPage = isAsyncApiSpec(spec)
+        ? findVirtualAsyncApiPage(generateAsyncApiPages(spec), pagePath)
+        : findVirtualPage(generateVirtualPages(spec), pagePath);
+
+      if (generatedPage) {
+        return {
+          title: generatedPage.title,
+          description: generatedPage.description,
+        };
+      }
+    }
+
+    return getDocsNotFoundMetadata();
+  }
 
   const page = pageResult[0];
   const meta = buildPageMetadata(

--- a/tests/docs-page-metadata.test.ts
+++ b/tests/docs-page-metadata.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dbMocks = vi.hoisted(() => ({
+  select: vi.fn(),
+  limit: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: dbMocks.select,
+  },
+}));
+
+function setupDbChain() {
+  const chain = {
+    from: vi.fn(() => chain),
+    where: vi.fn(() => chain),
+    limit: dbMocks.limit,
+  };
+  dbMocks.select.mockReturnValue(chain);
+}
+
+describe("docs page metadata", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDbChain();
+  });
+
+  it("uses the standard 404 title when the docs project is missing", async () => {
+    dbMocks.limit.mockResolvedValueOnce([]);
+
+    const { generateMetadata } = await import(
+      "@/app/docs/[subdomain]/[...slug]/page"
+    );
+
+    await expect(
+      generateMetadata({
+        params: Promise.resolve({
+          subdomain: "missing-docs",
+          slug: ["does-not-exist"],
+        }),
+      }),
+    ).resolves.toMatchObject({
+      title: "404: This page could not be found.",
+    });
+  });
+
+  it("uses the standard 404 title when a docs page slug is missing", async () => {
+    dbMocks.limit
+      .mockResolvedValueOnce([
+        { id: "project-1", name: "Test Project", settings: {} },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const { generateMetadata } = await import(
+      "@/app/docs/[subdomain]/[...slug]/page"
+    );
+
+    await expect(
+      generateMetadata({
+        params: Promise.resolve({
+          subdomain: "test-project",
+          slug: ["does-not-exist"],
+        }),
+      }),
+    ).resolves.toMatchObject({
+      title: "404: This page could not be found.",
+    });
+  });
+});


### PR DESCRIPTION
## Summary\n- Set missing public docs route metadata to `404: This page could not be found.`\n- Preserve generated OpenAPI/AsyncAPI virtual page metadata when no DB page exists\n- Add regression coverage for missing docs project/page metadata\n\n## Verification\n- `make check`\n- `make test` (1801 passed)\n- Shadowfax Ever: `private/browser-parity/shadowfax-issue-164-verify-fixed-20260508T122844Z.txt`\n\nCloses #164