### PR TITLE
Match Mintlify API page browser title

### DIFF
--- a/src/app/docs/[subdomain]/[...slug]/page.tsx
+++ b/src/app/docs/[subdomain]/[...slug]/page.tsx
@@ -197,7 +197,7 @@ export async function generateMetadata({
 
       if (generatedPage) {
         return {
-          title: generatedPage.title,
+          title: "Documentation",
           description: generatedPage.description,
         };
       }

--- a/tests/docs-page-metadata.test.ts
+++ b/tests/docs-page-metadata.test.ts
@@ -67,4 +67,45 @@ describe("docs page metadata", () => {
       title: "404: This page could not be found.",
     });
   });
+  it("uses the Mintlify browser title for generated API pages", async () => {
+    dbMocks.limit
+      .mockResolvedValueOnce([
+        {
+          id: "project-1",
+          name: "Test Project",
+          settings: {
+            openApiSpec: {
+              openapi: "3.0.0",
+              info: { title: "Fixture API", version: "1.0.0" },
+              paths: {
+                "/plants": {
+                  get: {
+                    summary: "Get Plants",
+                    description: "Returns a list of plants.",
+                    responses: { "200": { description: "OK" } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const { generateMetadata } = await import(
+      "@/app/docs/[subdomain]/[...slug]/page"
+    );
+
+    await expect(
+      generateMetadata({
+        params: Promise.resolve({
+          subdomain: "test-project",
+          slug: ["api-reference", "get-plants"],
+        }),
+      }),
+    ).resolves.toMatchObject({
+      title: "Documentation",
+      description: "Returns a list of plants.",
+    });
+  });
 });


### PR DESCRIPTION
## Summary\n- Align generated API reference metadata title with Mintlify's project-level `Documentation` browser title\n- Preserve endpoint descriptions and visible endpoint heading\n- Add metadata regression coverage for generated API pages\n\n## Verification\n- `npm test -- --run tests/docs-page-metadata.test.ts`\n- `make check`\n- `make test`\n- Shadowfax Ever snapshot -> click -> snapshot verification saved under `private/browser-parity/shadowfax-sweep-20260508T100227Z/issue-166-api-title-branch-verification.txt`\n\nCloses #166