### PR TITLE
Fix mobile nav overlay link hit testing

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1896,7 +1896,15 @@ pre.mermaid svg {
   position: fixed;
   inset: 0;
   z-index: 50;
+  width: 100vw;
+  height: 100vh;
+  max-width: none;
+  max-height: none;
+  margin: 0;
+  padding: 0;
+  border: 0;
   background: rgba(0, 0, 0, 0.5);
+  color: inherit;
   backdrop-filter: blur(4px);
 }
 
@@ -1910,6 +1918,15 @@ pre.mermaid svg {
   background: #0f0f11;
   border-right: 1px solid rgba(255, 255, 255, 0.08);
   overflow-y: auto;
+}
+
+.mobile-sidebar-panel .docs-sidebar {
+  position: static;
+  display: block;
+  width: 100%;
+  height: auto;
+  padding-top: 16px;
+  overflow: visible;
 }
 
 .mobile-sidebar-header {


### PR DESCRIPTION
## Summary
- Reset the mobile navigation dialog overlay to full viewport dimensions.
- Override the reused docs sidebar inside the mobile panel so mobile overlay links use correct static, hit-testable geometry.

## Verification
- Shadowfax Ever: `private/browser-parity/shadowfax-sweep-20260508T100227Z/issue-168-mobile-nav-fix-verify.txt` (local private evidence, not committed)
  - Fixed worktree on port 3016: mobile overlay Introduction link hit-tests to its own anchor, real click navigates to `/docs/test-project/introduction`, overlay closes.
- `make check`
- `make test` (1802 passed)

Closes #168
