### PR TITLE
Add CI workflow for Shadowfax agent branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,95 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - staging
+      - main
+  push:
+    branches:
+      - staging
+      - main
+      - "shadowfax/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CI: "true"
+  NEXT_TELEMETRY_DISABLED: "1"
+  NEXT_PUBLIC_APP_URL: http://localhost:3015
+  BETTER_AUTH_URL: http://localhost:3015
+  BETTER_AUTH_SECRET: ci-only-secret-for-github-actions-builds-only-0000
+  AUTH_GOOGLE_ID: ci-google-client-id
+  AUTH_GOOGLE_SECRET: ci-google-client-secret
+  DATABASE_URL: postgresql://opendocs:opendocs@localhost:5432/opendocs
+  AWS_REGION: us-east-1
+  AWS_BEDROCK_REGION: us-east-1
+
+jobs:
+  check:
+    name: TypeCheck & Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run checks
+        run: make check
+
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: make test
+
+  build:
+    name: Production Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      DOCS_PROXY_ALLOWED_HOSTS: opendocs.namuh.co
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary
- Adds a first-party GitHub Actions CI workflow for OpenDocs.
- Runs typecheck/lint, unit tests, and production build on PRs to staging/main, pushes to staging/main, pushes to shadowfax/* branches, and manual dispatch.
- Supplies non-secret CI env defaults so the Next production build can run without repository secrets.

## Verification
- npm ci
- make check
- make test (1802 passed)
- npm run build with CI env defaults

## Notes
- clawhip already routes github.ci-* events for opendocs, so these workflow runs become agent-visible CI signals for Shadowfax.
- Browser parity remains Ever-only; this workflow does not run Playwright.