### PR TITLE
Route workspace home through dashboard login

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -9,6 +9,15 @@ const PROTECTED_PREFIXES = [
   "/analytics",
 ];
 
+const WORKSPACE_HOME_PATTERN = /^\/[^/]+\/[^/]+\/home$/;
+
+function isProtectedDashboardPath(pathname: string) {
+  return (
+    PROTECTED_PREFIXES.some((prefix) => pathname.startsWith(prefix)) ||
+    WORKSPACE_HOME_PATTERN.test(pathname)
+  );
+}
+
 export async function proxy(request: NextRequest) {
   const start = Date.now();
   const sessionCookie = getSessionCookie(request);
@@ -28,8 +37,7 @@ export async function proxy(request: NextRequest) {
   // Unauthenticated users visiting protected routes or onboarding → redirect to login
   if (
     !sessionCookie &&
-    (PROTECTED_PREFIXES.some((prefix) => pathname.startsWith(prefix)) ||
-      pathname === "/onboarding")
+    (isProtectedDashboardPath(pathname) || pathname === "/onboarding")
   ) {
     const loginUrl = new URL("/login", request.url);
     loginUrl.searchParams.set("returnTo", `${pathname}${search}`);
@@ -48,6 +56,7 @@ export async function proxy(request: NextRequest) {
 export const config = {
   matcher: [
     "/dashboard/:path*",
+    "/:orgSlug/:projectSlug/home",
     "/settings/:path*",
     "/products/:path*",
     "/analytics/:path*",

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -26,6 +26,20 @@ describe("Proxy", () => {
     expect(response?.headers.get("location")).toContain("/login");
   });
 
+  it("redirects unauthenticated Mintlify-style workspace home routes with returnTo", async () => {
+    getSessionCookieMock.mockReturnValue(null);
+    const { config, proxy } = await import("@/proxy");
+    const response = await proxy(
+      makeNextRequest("http://localhost/namuhinc/namuhinc/home?tab=activity"),
+    );
+
+    expect(config.matcher).toContain("/:orgSlug/:projectSlug/home");
+    expect(response?.status).toBe(307);
+    expect(response?.headers.get("location")).toBe(
+      "http://localhost/login?returnTo=%2Fnamuhinc%2Fnamuhinc%2Fhome%3Ftab%3Dactivity",
+    );
+  });
+
   it("adds Server-Timing header for performance monitoring", async () => {
     getSessionCookieMock.mockReturnValue({ session: { id: "session-1" } });
     const { proxy } = await import("@/proxy");


### PR DESCRIPTION
## Summary
- Protect Mintlify-style `/:orgSlug/:projectSlug/home` workspace dashboard routes in the proxy
- Preserve the full workspace URL in `returnTo` for unauthenticated login redirects
- Add middleware coverage for the workspace route matcher and redirect target

Closes #171.

## Evidence
- Shadowfax-scoped Ever: Mintlify workspace route reaches sign-in, deployed OpenDocs route returned the framework 404.
- Local post-patch HTTP: `/namuhinc/namuhinc/home?tab=activity` redirects to `/login?returnTo=%2Fnamuhinc%2Fnamuhinc%2Fhome%3Ftab%3Dactivity`.

## Tests
- `npx vitest run tests/middleware.test.ts`
- `make check`
- `make test` (1803 passed)
