### PR TITLE
Support email/password dashboard sign-in parity

### DIFF
--- a/src/components/auth/google-auth-card.tsx
+++ b/src/components/auth/google-auth-card.tsx
@@ -8,17 +8,72 @@ interface GoogleAuthCardProps {
   mode: "login" | "signup";
 }
 
+type LoadingState = "email" | "google" | null;
+
+function fallbackNameFromEmail(email: string) {
+  const localPart = email.split("@")[0]?.trim();
+  return localPart || "OpenDocs user";
+}
+
 export function GoogleAuthCard({ callbackURL, mode }: GoogleAuthCardProps) {
-  const [loading, setLoading] = useState(false);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [name, setName] = useState("");
+  const [loading, setLoading] = useState<LoadingState>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const isSignup = mode === "signup";
 
   const handleGoogleAuth = async () => {
-    setLoading(true);
-    await authClient.signIn.social({
-      provider: "google",
-      callbackURL,
-    });
+    setLoading("google");
+    setError(null);
+
+    try {
+      const result = await authClient.signIn.social({
+        provider: "google",
+        callbackURL,
+      });
+
+      if (result.error) {
+        setError(result.error.message || "Google sign-in failed.");
+        setLoading(null);
+      }
+    } catch {
+      setError("Google sign-in failed. Please try again.");
+      setLoading(null);
+    }
+  };
+
+  const handleEmailAuth = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setLoading("email");
+    setError(null);
+
+    try {
+      const result = isSignup
+        ? await authClient.signUp.email({
+            email,
+            password,
+            name: name.trim() || fallbackNameFromEmail(email),
+            callbackURL,
+          })
+        : await authClient.signIn.email({
+            email,
+            password,
+            callbackURL,
+          });
+
+      if (result.error) {
+        setError(result.error.message || "Email authentication failed.");
+        setLoading(null);
+        return;
+      }
+
+      window.location.assign(callbackURL);
+    } catch {
+      setError("Email authentication failed. Please try again.");
+      setLoading(null);
+    }
   };
 
   return (
@@ -53,10 +108,77 @@ export function GoogleAuthCard({ callbackURL, mode }: GoogleAuthCardProps) {
         </p>
       </div>
 
+      <form className="space-y-3" onSubmit={handleEmailAuth}>
+        {isSignup && (
+          <label className="block space-y-1 text-sm font-medium text-gray-200">
+            <span>Name</span>
+            <input
+              type="text"
+              autoComplete="name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="Enter your name"
+              className="w-full rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-white placeholder:text-gray-500 focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500"
+            />
+          </label>
+        )}
+
+        <label className="block space-y-1 text-sm font-medium text-gray-200">
+          <span>Email</span>
+          <input
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            placeholder="Enter your email"
+            required
+            className="w-full rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-white placeholder:text-gray-500 focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500"
+          />
+        </label>
+
+        <label className="block space-y-1 text-sm font-medium text-gray-200">
+          <span>Password</span>
+          <input
+            type="password"
+            autoComplete={isSignup ? "new-password" : "current-password"}
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            placeholder="Enter your password"
+            minLength={8}
+            required
+            className="w-full rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-white placeholder:text-gray-500 focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500"
+          />
+        </label>
+
+        {error && (
+          <p className="rounded-md border border-red-900/60 bg-red-950/50 px-3 py-2 text-sm text-red-200">
+            {error}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={loading !== null}
+          className="flex w-full items-center justify-center rounded-lg bg-green-500 px-4 py-3 text-sm font-medium text-gray-950 transition-colors hover:bg-green-400 disabled:opacity-50"
+        >
+          {loading === "email"
+            ? "Continuing..."
+            : isSignup
+              ? "Continue with email"
+              : "Continue with password"}
+        </button>
+      </form>
+
+      <div className="flex items-center gap-3 text-xs text-gray-500">
+        <div className="h-px flex-1 bg-gray-800" />
+        <span>or</span>
+        <div className="h-px flex-1 bg-gray-800" />
+      </div>
+
       <button
         type="button"
         onClick={handleGoogleAuth}
-        disabled={loading}
+        disabled={loading !== null}
         className="flex w-full items-center justify-center gap-3 rounded-lg border border-gray-700 bg-gray-900 px-4 py-3 text-sm font-medium text-white transition-colors hover:bg-gray-800 disabled:opacity-50"
       >
         <svg width="18" height="18" viewBox="0 0 18 18">
@@ -78,7 +200,7 @@ export function GoogleAuthCard({ callbackURL, mode }: GoogleAuthCardProps) {
             fill="#EA4335"
           />
         </svg>
-        {loading ? "Redirecting..." : "Continue with Google"}
+        {loading === "google" ? "Redirecting..." : "Continue with Google"}
       </button>
 
       <p className="text-center text-xs text-gray-500">

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,6 +15,10 @@ export const auth = betterAuth({
   database: drizzleAdapter(db, {
     provider: "pg",
   }),
+  emailAndPassword: {
+    enabled: true,
+    minPasswordLength: 8,
+  },
   socialProviders: {
     google: {
       clientId: process.env.AUTH_GOOGLE_ID ?? "",

--- a/tests/auth-card.test.tsx
+++ b/tests/auth-card.test.tsx
@@ -1,0 +1,28 @@
+import { GoogleAuthCard } from "@/components/auth/google-auth-card";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+describe("GoogleAuthCard", () => {
+  it("renders Mintlify-style email/password and Google options on login", () => {
+    const html = renderToStaticMarkup(
+      <GoogleAuthCard callbackURL="/dashboard" mode="login" />,
+    );
+
+    expect(html).toContain("Enter your email");
+    expect(html).toContain("Enter your password");
+    expect(html).toContain("Continue with password");
+    expect(html).toContain("Continue with Google");
+  });
+
+  it("renders signup email/password flow with Continue with email", () => {
+    const html = renderToStaticMarkup(
+      <GoogleAuthCard callbackURL="/onboarding" mode="signup" />,
+    );
+
+    expect(html).toContain("Enter your name");
+    expect(html).toContain("Enter your email");
+    expect(html).toContain("Enter your password");
+    expect(html).toContain("Continue with email");
+    expect(html).toContain("Continue with Google");
+  });
+});


### PR DESCRIPTION
## Summary
- enable Better Auth email/password credentials alongside existing Google OAuth
- add email/password login/signup controls to the auth card with error handling and callback redirect support
- cover the login/signup auth surface with a focused component test

## Verification
- `npm test -- tests/auth-card.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `make check`
- `make test` (1805 passed)

Closes #173
