### PR TITLE
fix: trigger deployments from editor publish

### DIFF
--- a/src/app/editor/main/page.tsx
+++ b/src/app/editor/main/page.tsx
@@ -63,6 +63,12 @@ interface PageListItem {
   updatedAt: string;
 }
 
+interface ActiveEditorProject {
+  id: string;
+  subdomain?: string | null;
+  customDomain?: string | null;
+}
+
 type ActiveTab = "navigation" | "files" | "configurations";
 
 async function getErrorMessage(
@@ -353,11 +359,12 @@ export default function EditorPage() {
     title: string;
     path: string;
   } | null>(null);
-  const { project, loading } = useActiveProject<{ id: string }>();
+  const { project, loading } = useActiveProject<ActiveEditorProject>();
   const projectId = project?.id ?? null;
   const [pagesLoading, setPagesLoading] = useState(true);
   const [content, setContent] = useState("");
   const [saving, setSaving] = useState(false);
+  const [publishing, setPublishing] = useState(false);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [actionError, setActionError] = useState("");
   const [editorMode, setEditorMode] = useState<EditorMode>("visual");
@@ -370,9 +377,17 @@ export default function EditorPage() {
   const visualEditorRef = useRef<VisualEditorHandle | null>(null);
   const autoSaveRef = useRef<ReturnType<typeof createAutoSave> | null>(null);
 
+  const siteUrl = useMemo(() => {
+    if (!project) return undefined;
+    if (project.customDomain) return `https://${project.customDomain}`;
+    if (project.subdomain)
+      return `https://${project.subdomain}.opendocs.namuh.co`;
+    return undefined;
+  }, [project]);
+
   const doSave = useCallback(
     async (contentToSave: string) => {
-      if (!projectId || !selectedPageId) return;
+      if (!projectId || !selectedPageId) return false;
       setSaving(true);
       try {
         const res = await fetch(
@@ -388,10 +403,12 @@ export default function EditorPage() {
         }
         setHasUnsavedChanges(false);
         setActionError("");
+        return true;
       } catch (error) {
         setActionError(
           error instanceof Error ? error.message : "Failed to save page",
         );
+        return false;
       } finally {
         setSaving(false);
       }
@@ -400,7 +417,9 @@ export default function EditorPage() {
   );
 
   useEffect(() => {
-    autoSaveRef.current = createAutoSave(doSave, 2000);
+    autoSaveRef.current = createAutoSave(async (value) => {
+      await doSave(value);
+    }, 2000);
     return () => {
       autoSaveRef.current?.cancel();
     };
@@ -478,6 +497,44 @@ export default function EditorPage() {
   async function handleSaveContent() {
     autoSaveRef.current?.cancel();
     await doSave(content);
+  }
+
+  async function handlePublish() {
+    if (!projectId || publishing) return;
+    autoSaveRef.current?.cancel();
+    setPublishing(true);
+    setActionError("");
+
+    try {
+      if (hasUnsavedChanges) {
+        const saved = await doSave(content);
+        if (!saved) return;
+      }
+
+      const response = await fetch("/api/deployments", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          commitMessage: selectedPage
+            ? `Update ${selectedPage.path}`
+            : "Manual Update",
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          await getErrorMessage(response, "Failed to trigger deployment"),
+        );
+      }
+
+      setHasUnsavedChanges(false);
+    } catch (error) {
+      setActionError(
+        error instanceof Error ? error.message : "Failed to publish changes",
+      );
+    } finally {
+      setPublishing(false);
+    }
   }
 
   async function handleSaveSettings(updates: Record<string, unknown>) {
@@ -760,8 +817,13 @@ export default function EditorPage() {
               onLink={handleLink}
               onImage={handleImage}
               onSave={handleSaveContent}
-              isSaving={saving}
+              isSaving={saving || publishing}
               hasUnsavedChanges={hasUnsavedChanges}
+              siteUrl={siteUrl}
+              projectId={projectId}
+              currentBranch={currentBranch}
+              onBranchChange={setCurrentBranch}
+              onPublish={handlePublish}
               showSettings={showSettings}
               onToggleSettings={() => setShowSettings(!showSettings)}
               showComments={showComments}

--- a/src/components/editor/editor-toolbar.tsx
+++ b/src/components/editor/editor-toolbar.tsx
@@ -400,12 +400,7 @@ export function EditorToolbar({
             <button
               type="button"
               data-testid="publish-btn"
-              className={clsx(
-                "ml-1 px-3 py-1.5 text-xs font-medium rounded-md transition-colors",
-                hasUnsavedChanges || isSaving
-                  ? "text-white bg-emerald-600 hover:bg-emerald-500"
-                  : "text-gray-300 bg-gray-800 hover:bg-gray-700",
-              )}
+              className="ml-1 px-3 py-1.5 text-xs font-medium rounded-md transition-colors text-white bg-emerald-600 hover:bg-emerald-500"
             >
               Publish
             </button>
@@ -427,15 +422,15 @@ export function EditorToolbar({
                 <button
                   type="button"
                   onClick={onPublish}
-                  disabled={!hasUnsavedChanges}
+                  disabled={isSaving}
                   className={clsx(
                     "w-full px-3 py-2 text-sm font-medium rounded-md transition-colors",
-                    hasUnsavedChanges
-                      ? "text-white bg-emerald-600 hover:bg-emerald-500"
-                      : "text-gray-500 bg-gray-800 cursor-not-allowed",
+                    isSaving
+                      ? "text-gray-400 bg-gray-800 cursor-wait"
+                      : "text-white bg-emerald-600 hover:bg-emerald-500",
                   )}
                 >
-                  Publish
+                  {isSaving ? "Publishing..." : "Publish"}
                 </button>
               </div>
               <Popover.Arrow className="fill-[#1a1a1a]" />


### PR DESCRIPTION
## Summary
- Wire the editor Publish popover to save pending document edits before deployment
- Trigger the existing deployment endpoint from the editor publish flow
- Keep Publish available even after autosave clears the unsaved state, matching the dashboard deployment behavior
- Pass project branch/site URL context into the editor toolbar so the publish popover points at the live docs URL

## Validation
- make check
- make test
- Ever browser: edited a docs page in /editor/main, clicked Publish, verified /api/deployments created a succeeded deployment
- Ever browser: dashboard activity shows "Update introduction" with Successful status

## Screenshots
- Before editor: private/parity-editor/screenshots/opendocs-editor-before.jpg
- Edited before publish: private/parity-editor/screenshots/opendocs-editor-edited-before-publish.jpg
- After dashboard deployment: private/parity-editor/screenshots/opendocs-dashboard-deployment-after-editor-publish.jpg
