### PR TITLE
Fix generated docs block normalization and editor parity

### DIFF
--- a/src/app/api/projects/[id]/pages/[pageId]/route.ts
+++ b/src/app/api/projects/[id]/pages/[pageId]/route.ts
@@ -2,6 +2,7 @@ import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { orgMemberships, pages, projects } from "@/lib/db/schema";
 import { createRequestId, logger } from "@/lib/logger";
+import { normalizeMarkdownContent } from "@/lib/markdown-normalization";
 import { validateUpdatePageRequest } from "@/lib/pages";
 import { and, eq } from "drizzle-orm";
 import { headers } from "next/headers";
@@ -13,7 +14,7 @@ async function resolvePageInProject(
   projectId: string,
   pageId: string,
 ): Promise<
-  | { ok: true; page: { id: string }; role: string }
+  | { ok: true; page: { id: string; title: string }; role: string }
   | { ok: false; response: NextResponse }
 > {
   const membership = await db
@@ -51,7 +52,7 @@ async function resolvePageInProject(
   }
 
   const page = await db
-    .select({ id: pages.id })
+    .select({ id: pages.id, title: pages.title })
     .from(pages)
     .where(and(eq(pages.id, pageId), eq(pages.projectId, projectId)))
     .limit(1);
@@ -105,7 +106,15 @@ export async function GET(
     pageId,
   });
 
-  return NextResponse.json({ page, requestId });
+  return NextResponse.json({
+    page: {
+      ...page,
+      content: normalizeMarkdownContent(page.content ?? "", {
+        title: page.title,
+      }),
+    },
+    requestId,
+  });
 }
 
 /** PUT /api/projects/[id]/pages/[pageId] — update a page */
@@ -162,6 +171,18 @@ export async function PUT(
       error: validation.error,
     });
     return NextResponse.json({ error: validation.error }, { status: 400 });
+  }
+
+  if (typeof validation.fields.content === "string") {
+    validation.fields.content = normalizeMarkdownContent(
+      validation.fields.content,
+      {
+        title:
+          typeof validation.fields.title === "string"
+            ? validation.fields.title
+            : resolved.page.title,
+      },
+    );
   }
 
   // If path is being changed, check uniqueness

--- a/src/app/docs/[subdomain]/[...slug]/page.tsx
+++ b/src/app/docs/[subdomain]/[...slug]/page.tsx
@@ -35,6 +35,7 @@ import {
   parseLocaleFromSlug,
 } from "@/lib/i18n";
 import { KATEX_CSS_URL, renderLatex } from "@/lib/latex";
+import { normalizeMarkdownContent } from "@/lib/markdown-normalization";
 import { buildDocsNav, renderMdxContent } from "@/lib/mdx-renderer";
 import {
   type VirtualApiPage,
@@ -469,7 +470,9 @@ export default async function DocsPage({
     // Render DB page (existing behavior)
     pageTitle = applyProjectBrandCasing(currentPage.title, project.name);
     pageDescription = currentPage.description || "";
-    pageContent = currentPage.content || "";
+    pageContent = normalizeMarkdownContent(currentPage.content || "", {
+      title: pageTitle,
+    });
 
     // Resolve snippets and variables before rendering
     const snippetPages = allPages

--- a/src/app/editor/main/page.tsx
+++ b/src/app/editor/main/page.tsx
@@ -39,6 +39,7 @@ import {
   Trash2,
   X,
 } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 interface PageData {
@@ -349,6 +350,7 @@ function DeletePageModal({
 }
 
 export default function EditorPage() {
+  const router = useRouter();
   const [pages, setPages] = useState<PageListItem[]>([]);
   const [selectedPage, setSelectedPage] = useState<PageData | null>(null);
   const [selectedPageId, setSelectedPageId] = useState<string | null>(null);
@@ -384,6 +386,11 @@ export default function EditorPage() {
       return `https://${project.subdomain}.opendocs.namuh.co`;
     return undefined;
   }, [project]);
+
+  const previewUrl = useMemo(() => {
+    if (!project?.subdomain || !selectedPage?.path) return undefined;
+    return `/docs/${project.subdomain}/${selectedPage.path}`;
+  }, [project, selectedPage]);
 
   const doSave = useCallback(
     async (contentToSave: string) => {
@@ -528,6 +535,7 @@ export default function EditorPage() {
       }
 
       setHasUnsavedChanges(false);
+      router.push("/dashboard");
     } catch (error) {
       setActionError(
         error instanceof Error ? error.message : "Failed to publish changes",
@@ -696,7 +704,7 @@ export default function EditorPage() {
 
   return (
     <div className="h-screen flex bg-[#0f0f0f] text-white overflow-hidden">
-      <aside className="w-72 border-r border-white/[0.08] bg-[#111111] flex flex-col">
+      <aside className="w-64 border-r border-white/[0.08] bg-[#111111] flex flex-col">
         <div className="p-4 border-b border-white/[0.08]">
           <div className="flex items-center justify-between mb-3">
             <div className="flex items-center gap-2">
@@ -820,6 +828,7 @@ export default function EditorPage() {
               isSaving={saving || publishing}
               hasUnsavedChanges={hasUnsavedChanges}
               siteUrl={siteUrl}
+              previewUrl={previewUrl}
               projectId={projectId}
               currentBranch={currentBranch}
               onBranchChange={setCurrentBranch}
@@ -835,7 +844,7 @@ export default function EditorPage() {
             />
 
             <div className="flex-1 flex min-h-0">
-              <div className="flex-1 min-w-0 flex flex-col">
+              <div className="flex-1 min-w-0 flex flex-col bg-[#0c0c0c]">
                 {actionError && (
                   <div className="px-4 py-2 border-b border-red-500/20 bg-red-500/5 text-sm text-red-400">
                     {actionError}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3972,3 +3972,43 @@ pre.mermaid svg {
     padding: 0 16px;
   }
 }
+
+/* ── Editor authoring surface ─────────────────────────────────────────────── */
+.editor-toolbar {
+  scrollbar-width: none;
+}
+
+.editor-toolbar::-webkit-scrollbar {
+  display: none;
+}
+
+.editor-prose h1 {
+  margin: 0 0 0.75rem;
+  color: #f8fafc;
+  font-size: clamp(2rem, 3.4vw, 3.5rem);
+  line-height: 1.05;
+  letter-spacing: -0.045em;
+  font-weight: 700;
+}
+
+.editor-prose h2 {
+  margin: 3rem 0 0.75rem;
+  padding-top: 2rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  color: #f8fafc;
+  font-size: 1.35rem;
+  line-height: 1.25;
+  letter-spacing: -0.02em;
+  font-weight: 650;
+}
+
+.editor-prose p {
+  margin: 0.75rem 0 0;
+  color: #d1d5db;
+  font-size: 0.98rem;
+  line-height: 1.8;
+}
+
+.editor-prose a {
+  color: #34d399;
+}

--- a/src/components/editor/editor-toolbar.tsx
+++ b/src/components/editor/editor-toolbar.tsx
@@ -45,6 +45,7 @@ interface EditorToolbarProps {
   onToggleAnalytics?: () => void;
   onPublish?: () => void;
   siteUrl?: string;
+  previewUrl?: string;
   projectId?: string | null;
   currentBranch?: string;
   onBranchChange?: (branch: string) => void;
@@ -80,6 +81,7 @@ export function EditorToolbar({
   onToggleAnalytics,
   onPublish,
   siteUrl,
+  previewUrl,
   projectId,
   currentBranch = "main",
   onBranchChange,
@@ -91,11 +93,11 @@ export function EditorToolbar({
   const [showAddNew, setShowAddNew] = useState(false);
 
   return (
-    <div className="flex items-center justify-between px-3 py-1.5 border-b border-white/[0.08] bg-[#0f0f0f] shrink-0">
+    <div className="editor-toolbar flex items-center justify-between gap-3 overflow-x-auto px-4 py-2 border-b border-white/[0.08] bg-[#101010]/95 backdrop-blur shrink-0">
       {/* Left: Mode toggle + undo/redo */}
-      <div className="flex items-center gap-1">
+      <div className="flex shrink-0 items-center gap-1">
         {/* Mode toggle tabs */}
-        <div className="flex items-center bg-[#1a1a1a] rounded-md p-0.5 mr-2">
+        <div className="flex items-center bg-[#1a1a1a] rounded-lg p-0.5 mr-2 ring-1 ring-white/[0.06]">
           <button
             type="button"
             data-testid="mode-visual"
@@ -167,7 +169,7 @@ export function EditorToolbar({
       </div>
 
       {/* Center: Formatting toolbar (visible in both modes) */}
-      <div className="flex items-center gap-0.5">
+      <div className="order-3 flex shrink-0 items-center gap-0.5 rounded-lg border border-white/[0.06] bg-white/[0.02] px-1 py-0.5">
         <button
           type="button"
           data-testid="toolbar-bold"
@@ -232,7 +234,7 @@ export function EditorToolbar({
             type="button"
             data-testid="add-new-dropdown-btn"
             onClick={() => setShowAddNew(!showAddNew)}
-            className="flex items-center gap-1 px-2 py-1 text-xs text-gray-400 hover:text-white hover:bg-white/[0.06] rounded transition-colors"
+            className="flex items-center gap-1 whitespace-nowrap px-2 py-1 text-xs text-gray-400 hover:text-white hover:bg-white/[0.06] rounded transition-colors"
           >
             <Plus size={12} />
             <span>Add new</span>
@@ -309,7 +311,7 @@ export function EditorToolbar({
       </div>
 
       {/* Right: Search, Settings, Preview, Publish */}
-      <div className="flex items-center gap-1">
+      <div className="order-2 ml-auto flex shrink-0 items-center gap-1.5">
         {/* Auto-save indicator */}
         {isSaving && (
           <span className="text-[10px] text-gray-500 mr-2">Saving...</span>
@@ -345,7 +347,7 @@ export function EditorToolbar({
           type="button"
           onClick={onToggleSuggestions}
           className={clsx(
-            "p-1.5 rounded transition-colors",
+            "hidden xl:flex p-1.5 rounded transition-colors",
             showSuggestions
               ? "bg-emerald-600/20 text-emerald-400"
               : "text-gray-500 hover:text-white hover:bg-white/[0.06]",
@@ -360,7 +362,7 @@ export function EditorToolbar({
           type="button"
           onClick={onToggleAnalytics}
           className={clsx(
-            "p-1.5 rounded transition-colors",
+            "hidden xl:flex p-1.5 rounded transition-colors",
             showAnalytics
               ? "bg-emerald-600/20 text-emerald-400"
               : "text-gray-500 hover:text-white hover:bg-white/[0.06]",
@@ -388,10 +390,17 @@ export function EditorToolbar({
 
         <button
           type="button"
-          className="p-1.5 rounded text-gray-500 hover:text-white hover:bg-white/[0.06] transition-colors"
+          onClick={() => {
+            if (previewUrl) {
+              window.open(previewUrl, "_blank", "noopener,noreferrer");
+            }
+          }}
+          disabled={!previewUrl}
+          className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.08] px-2.5 py-1.5 text-xs font-medium text-gray-300 transition-colors hover:border-white/[0.16] hover:bg-white/[0.06] hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
           aria-label="Preview"
         >
-          <ExternalLink size={14} />
+          <ExternalLink size={13} />
+          <span className="hidden 2xl:inline">Preview</span>
         </button>
 
         {/* Publish button with popover */}
@@ -400,7 +409,7 @@ export function EditorToolbar({
             <button
               type="button"
               data-testid="publish-btn"
-              className="ml-1 px-3 py-1.5 text-xs font-medium rounded-md transition-colors text-white bg-emerald-600 hover:bg-emerald-500"
+              className="ml-0 inline-flex items-center gap-1.5 whitespace-nowrap rounded-md bg-emerald-500 px-3.5 py-1.5 text-xs font-semibold text-black shadow-sm shadow-emerald-500/20 transition-colors hover:bg-emerald-400"
             >
               Publish
             </button>
@@ -415,19 +424,23 @@ export function EditorToolbar({
               <div className="space-y-3">
                 <div className="flex items-center gap-2 text-sm text-gray-300">
                   <ExternalLink size={14} className="text-gray-500" />
-                  <span className="text-gray-500 truncate">
-                    {siteUrl || "your-project.mintlify.app"}
+                  <span className="text-gray-400 truncate">
+                    {siteUrl || previewUrl || "your-project.mintlify.app"}
                   </span>
                 </div>
+                <p className="text-xs leading-5 text-gray-500">
+                  Save the current page, publish the docs site, and open the
+                  deployment on the dashboard.
+                </p>
                 <button
                   type="button"
                   onClick={onPublish}
                   disabled={isSaving}
                   className={clsx(
-                    "w-full px-3 py-2 text-sm font-medium rounded-md transition-colors",
+                    "w-full px-3 py-2 text-sm font-semibold rounded-md transition-colors",
                     isSaving
                       ? "text-gray-400 bg-gray-800 cursor-wait"
-                      : "text-white bg-emerald-600 hover:bg-emerald-500",
+                      : "text-black bg-emerald-500 hover:bg-emerald-400",
                   )}
                 >
                   {isSaving ? "Publishing..." : "Publish"}

--- a/src/components/editor/markdown-editor.tsx
+++ b/src/components/editor/markdown-editor.tsx
@@ -73,7 +73,7 @@ export function MarkdownEditor({
 
   return (
     <div
-      className="flex h-full overflow-hidden bg-[#0a0a0a]"
+      className="flex h-full overflow-hidden bg-[#0c0c0c]"
       data-testid="markdown-editor"
     >
       {/* Line numbers gutter */}
@@ -99,7 +99,7 @@ export function MarkdownEditor({
         onKeyUp={handleKeyUp}
         onKeyDown={handleKeyDown}
         onClick={handleClick}
-        className="flex-1 bg-transparent text-emerald-300 text-sm font-mono py-4 px-4 resize-none focus:outline-none leading-[1.625rem] overflow-auto"
+        className="mx-auto max-w-4xl flex-1 resize-none overflow-auto bg-transparent px-6 py-8 font-mono text-sm leading-[1.75rem] text-emerald-200 focus:outline-none"
         spellCheck={false}
         placeholder="Write your MDX content here..."
         data-testid="markdown-textarea"

--- a/src/components/editor/toc-panel.tsx
+++ b/src/components/editor/toc-panel.tsx
@@ -11,14 +11,20 @@ interface TocPanelProps {
 export function TocPanel({ entries, activeId }: TocPanelProps) {
   if (entries.length === 0) {
     return (
-      <div className="px-4 py-8 text-center text-sm text-gray-600">
+      <aside
+        className="hidden w-60 shrink-0 border-l border-white/[0.08] bg-[#101010] px-5 py-8 text-center text-sm text-gray-600 lg:block"
+        aria-label="Table of contents"
+      >
         No headings found
-      </div>
+      </aside>
     );
   }
 
   return (
-    <nav className="px-3 py-3" aria-label="Table of contents">
+    <nav
+      className="hidden w-60 shrink-0 overflow-y-auto border-l border-white/[0.08] bg-[#101010] px-4 py-6 lg:block"
+      aria-label="Table of contents"
+    >
       <h4 className="text-[10px] font-medium text-gray-600 uppercase tracking-wider mb-2 px-1">
         On this page
       </h4>
@@ -27,15 +33,16 @@ export function TocPanel({ entries, activeId }: TocPanelProps) {
           <li key={entry.id}>
             <a
               href={`#${entry.id}`}
+              title={entry.text}
               className={clsx(
-                "block text-xs py-1 rounded transition-colors",
+                "block truncate rounded py-1.5 text-xs leading-5 transition-colors",
                 entry.level === 1 && "pl-1",
                 entry.level === 2 && "pl-3",
                 entry.level === 3 && "pl-5",
                 entry.level >= 4 && "pl-7",
                 activeId === entry.id
                   ? "text-emerald-400"
-                  : "text-gray-500 hover:text-gray-300",
+                  : "text-gray-500 hover:text-gray-200",
               )}
             >
               {entry.text}

--- a/src/components/editor/visual-editor.tsx
+++ b/src/components/editor/visual-editor.tsx
@@ -457,11 +457,7 @@ export const VisualEditor = forwardRef<VisualEditorHandle, VisualEditorProps>(
       editorProps: {
         attributes: {
           class:
-            "prose prose-invert max-w-none px-6 py-4 focus:outline-none min-h-full " +
-            "prose-headings:text-white prose-p:text-gray-300 prose-a:text-emerald-400 " +
-            "prose-strong:text-white prose-code:text-emerald-300 prose-code:bg-[#1a1a1a] " +
-            "prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm " +
-            "prose-hr:border-white/[0.08] prose-blockquote:border-emerald-500 prose-blockquote:text-gray-400",
+            "editor-prose mx-auto min-h-full w-full max-w-3xl px-8 py-10 focus:outline-none lg:px-12",
         },
       },
       onUpdate: ({
@@ -560,7 +556,7 @@ export const VisualEditor = forwardRef<VisualEditorHandle, VisualEditorProps>(
 
     return (
       <div
-        className="h-full overflow-auto bg-[#0f0f0f]"
+        className="h-full overflow-auto bg-[#0c0c0c]"
         data-testid="visual-editor"
       >
         <EditorContent editor={editor} className="h-full" />

--- a/src/lib/github-docs-import.ts
+++ b/src/lib/github-docs-import.ts
@@ -1,5 +1,7 @@
 import { extractFrontmatter } from "@/lib/editor";
 import { parseGitHubUrl } from "@/lib/git-settings";
+import { normalizeMarkdownContent } from "@/lib/markdown-normalization";
+import { titleFromPath } from "@/lib/pages";
 
 export interface ImportedGitHubDocPage {
   path: string;
@@ -124,7 +126,10 @@ function stripHtmlTags(value: string): string {
   return value.replace(/<[^>]+>/g, "").trim();
 }
 
-function normalizeGitHubMarkdownContent(content: string): string {
+function normalizeGitHubMarkdownContent(
+  content: string,
+  title?: string | null,
+): string {
   let normalized = content.replace(/\r\n?/g, "\n");
 
   normalized = normalized.replace(/<br\s*\/?\s*>/gi, "\n");
@@ -157,12 +162,15 @@ function normalizeGitHubMarkdownContent(content: string): string {
   normalized = normalized.replace(/<\/?(?:p|div|span|center)\b[^>]*>/gi, "\n");
   normalized = normalized.replace(/<!--([\s\S]*?)-->/g, "");
 
-  return normalized
-    .split("\n")
-    .map((line) => line.replace(/[ \t]+$/g, ""))
-    .join("\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
+  return normalizeMarkdownContent(
+    normalized
+      .split("\n")
+      .map((line) => line.replace(/[ \t]+$/g, ""))
+      .join("\n")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim(),
+    { title },
+  );
 }
 
 const EXCLUDED_PATHS = [
@@ -250,15 +258,19 @@ export async function importGitHubDocs(
           `GitHub content request failed with status ${response.status} for ${filePath}`,
         );
       }
-      const content = normalizeGitHubMarkdownContent(await response.text());
       const pagePath = toPagePath(filePath, basePath);
       if (!pagePath) {
         return null;
       }
+      const content = normalizeGitHubMarkdownContent(
+        await response.text(),
+        titleFromPath(pagePath),
+      );
+      const title = toTitle(content, pagePath);
       return {
         path: pagePath,
-        title: toTitle(content, pagePath),
-        content,
+        title,
+        content: normalizeMarkdownContent(content, { title }),
       } satisfies ImportedGitHubDocPage;
     }),
   );

--- a/src/lib/markdown-normalization.ts
+++ b/src/lib/markdown-normalization.ts
@@ -1,0 +1,171 @@
+/**
+ * Markdown normalization helpers shared by import, page creation, and render
+ * boundaries. Keep this conservative: repair malformed block boundaries without
+ * rewriting valid prose or fenced code.
+ */
+
+interface NormalizeMarkdownContentOptions {
+  /** Known page title. Used to repair a fused first heading, e.g. "# IntroBody". */
+  title?: string | null;
+}
+
+function normalizeComparable(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[`*_~]/g, "")
+    .replace(/<[^>]+>/g, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function findKnownTitleBoundary(text: string, title?: string | null): number {
+  const trimmedTitle = title?.trim();
+  if (!trimmedTitle) return -1;
+
+  if (!text.startsWith(trimmedTitle)) return -1;
+
+  const remainder = text.slice(trimmedTitle.length);
+  if (!remainder) return -1;
+
+  // Only repair a fused title/body boundary. If the next char is already
+  // whitespace or punctuation, the heading is intentionally longer.
+  if (!/^[A-Z0-9]/.test(remainder)) return -1;
+
+  return trimmedTitle.length;
+}
+
+function findCamelParagraphBoundary(text: string): number {
+  const boundaryPattern = /[a-z0-9](?=[A-Z][a-z])/g;
+  let match: RegExpExecArray | null = boundaryPattern.exec(text);
+
+  while (match) {
+    const boundary = match.index + 1;
+    const heading = text.slice(0, boundary).trim();
+    const paragraph = text.slice(boundary).trim();
+
+    // Avoid changing single-token product/API names such as "OAuthFlow".
+    // The generic repair only applies when the likely heading is multi-word
+    // and the right side looks like paragraph prose.
+    if (heading.includes(" ") && paragraph.includes(" ")) {
+      return boundary;
+    }
+
+    match = boundaryPattern.exec(text);
+  }
+
+  return -1;
+}
+
+function splitFusedHeadingLine(
+  line: string,
+  options: NormalizeMarkdownContentOptions,
+): string[] {
+  const match = line.match(/^(#{1,6})\s+(.+)$/);
+  if (!match) return [line];
+
+  const marker = match[1];
+  const text = match[2].trim();
+  const knownTitleBoundary = findKnownTitleBoundary(text, options.title);
+  const boundary =
+    knownTitleBoundary > -1
+      ? knownTitleBoundary
+      : findCamelParagraphBoundary(text);
+
+  if (boundary === -1) return [line];
+
+  const heading = text.slice(0, boundary).trim();
+  const paragraph = text.slice(boundary).trim();
+  if (!heading || !paragraph) return [line];
+
+  return [`${marker} ${heading}`, "", paragraph];
+}
+
+function repairInlineHeadingMarkers(line: string): string[] {
+  return line.replace(/([^#\n])(?=#{1,6}\s+\S)/g, "$1\n\n").split("\n");
+}
+
+function ensureBlankLineBeforeHeading(lines: string[]): string[] {
+  const output: string[] = [];
+
+  for (const line of lines) {
+    if (
+      /^#{1,6}\s+\S/.test(line) &&
+      output.length > 0 &&
+      output[output.length - 1]?.trim()
+    ) {
+      output.push("");
+    }
+
+    output.push(line);
+  }
+
+  return output;
+}
+
+function ensureBlankLineAfterHeading(lines: string[]): string[] {
+  const output: string[] = [];
+
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index];
+    output.push(line);
+
+    if (
+      /^#{1,6}\s+\S/.test(line) &&
+      lines[index + 1]?.trim() &&
+      !/^#{1,6}\s+\S/.test(lines[index + 1] ?? "")
+    ) {
+      output.push("");
+    }
+  }
+
+  return output;
+}
+
+/** Normalize markdown block spacing and repair common fused heading/body text. */
+export function normalizeMarkdownContent(
+  content: string,
+  options: NormalizeMarkdownContentOptions = {},
+): string {
+  if (!content) return "";
+
+  const normalizedTitle = options.title
+    ? normalizeComparable(options.title)
+    : "";
+  const input = content.replace(/\r\n?/g, "\n");
+  const repairedLines: string[] = [];
+  let inCodeFence = false;
+
+  for (const rawLine of input.split("\n")) {
+    const line = rawLine.replace(/[ \t]+$/g, "");
+    const trimmed = line.trim();
+
+    if (trimmed.startsWith("```")) {
+      repairedLines.push(line);
+      inCodeFence = !inCodeFence;
+      continue;
+    }
+
+    if (inCodeFence) {
+      repairedLines.push(line);
+      continue;
+    }
+
+    for (const segment of repairInlineHeadingMarkers(line)) {
+      const titleForSegment =
+        normalizedTitle &&
+        normalizeComparable(segment).startsWith(normalizedTitle)
+          ? options.title
+          : undefined;
+      repairedLines.push(
+        ...splitFusedHeadingLine(segment, { title: titleForSegment }),
+      );
+    }
+  }
+
+  return ensureBlankLineAfterHeading(
+    ensureBlankLineBeforeHeading(repairedLines),
+  )
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}

--- a/src/lib/pages.ts
+++ b/src/lib/pages.ts
@@ -1,3 +1,5 @@
+import { normalizeMarkdownContent } from "@/lib/markdown-normalization";
+
 /**
  * Page utilities — path normalization, validation, tree building.
  */
@@ -87,7 +89,9 @@ export function validateCreatePageRequest(body: unknown):
   };
 
   if (typeof raw.content === "string") {
-    result.content = raw.content;
+    result.content = normalizeMarkdownContent(raw.content, {
+      title: result.title,
+    });
   }
 
   if (typeof raw.description === "string") {
@@ -133,7 +137,9 @@ export function validateUpdatePageRequest(
     if (typeof raw.content !== "string") {
       return { valid: false, error: "Content must be a string" };
     }
-    fields.content = raw.content;
+    fields.content = normalizeMarkdownContent(raw.content, {
+      title: typeof raw.title === "string" ? raw.title : undefined,
+    });
   }
 
   if (raw.description !== undefined) {

--- a/tests/github-docs-import.test.ts
+++ b/tests/github-docs-import.test.ts
@@ -336,6 +336,38 @@ ${"```"}
     }
   });
 
+  it("normalizes malformed generated headings during import", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("/git/trees/")) {
+        return {
+          ok: true,
+          json: async () => ({ tree: [{ path: "README.md", type: "blob" }] }),
+        };
+      }
+      return {
+        ok: true,
+        text: async () =>
+          "# IntroductionGenerated docs content.## Deploy verificationPublishing works.",
+      };
+    });
+
+    const { importGitHubDocs } = await import("@/lib/github-docs-import");
+    const result = await importGitHubDocs({
+      repoUrl: "https://github.com/acme/docs",
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.pages[0]).toMatchObject({
+        path: "introduction",
+        title: "Introduction",
+        content:
+          "# Introduction\n\nGenerated docs content.\n\n## Deploy verification\n\nPublishing works.",
+      });
+    }
+  });
+
   it("excludes internal agent and repo files", async () => {
     const fetchMock = vi.fn(async (url: string) => {
       if (url.includes("/git/trees/")) {

--- a/tests/markdown-normalization.test.ts
+++ b/tests/markdown-normalization.test.ts
@@ -1,0 +1,45 @@
+import { normalizeMarkdownContent } from "@/lib/markdown-normalization";
+import { describe, expect, it } from "vitest";
+
+describe("normalizeMarkdownContent", () => {
+  it("repairs fused headings and paragraphs using the known page title", () => {
+    const malformed =
+      "# IntroductionGenerated docs content updated.## Deploy verificationPublishing from the editor now saves the page.";
+
+    expect(
+      normalizeMarkdownContent(malformed, { title: "Introduction" }),
+    ).toBe(`# Introduction
+
+Generated docs content updated.
+
+## Deploy verification
+
+Publishing from the editor now saves the page.`);
+  });
+
+  it("keeps fenced code content unchanged while normalizing surrounding headings", () => {
+    const markdown = `# GuideInstall the SDK.
+
+\`\`\`ts
+const sample = "# Not a headingBody";
+\`\`\`
+
+## NextStepUse the dashboard.`;
+
+    expect(normalizeMarkdownContent(markdown, { title: "Guide" })).toBe(`# Guide
+
+Install the SDK.
+
+\`\`\`ts
+const sample = "# Not a headingBody";
+\`\`\`
+
+## NextStepUse the dashboard.`);
+  });
+
+  it("does not split single-token CamelCase headings without a known title", () => {
+    expect(normalizeMarkdownContent("# OAuthFlowGuide")).toBe(
+      "# OAuthFlowGuide",
+    );
+  });
+});

--- a/tests/pages.test.ts
+++ b/tests/pages.test.ts
@@ -169,6 +169,24 @@ describe("validateCreatePageRequest", () => {
     });
   });
 
+  it("normalizes malformed generated markdown content", async () => {
+    const validate = await getValidate();
+    expect(
+      validate({
+        path: "intro",
+        title: "Introduction",
+        content:
+          "# IntroductionGenerated docs proof.## Deploy verificationPublishing works.",
+      }),
+    ).toEqual({
+      valid: true,
+      path: "intro",
+      title: "Introduction",
+      content:
+        "# Introduction\n\nGenerated docs proof.\n\n## Deploy verification\n\nPublishing works.",
+    });
+  });
+
   it("rejects missing path", async () => {
     const validate = await getValidate();
     expect(validate({ title: "Hello" })).toEqual({
@@ -215,6 +233,24 @@ describe("validateUpdatePageRequest", () => {
     expect(validate({ content: "# Updated content" })).toEqual({
       valid: true,
       fields: { content: "# Updated content" },
+    });
+  });
+
+  it("normalizes content updates when a title is provided", async () => {
+    const validate = await getValidate();
+    expect(
+      validate({
+        title: "Introduction",
+        content:
+          "# IntroductionGenerated docs proof.## Deploy verificationPublishing works.",
+      }),
+    ).toEqual({
+      valid: true,
+      fields: {
+        title: "Introduction",
+        content:
+          "# Introduction\n\nGenerated docs proof.\n\n## Deploy verification\n\nPublishing works.",
+      },
     });
   });
 


### PR DESCRIPTION
## Summary
- Add conservative markdown normalization for fused generated/imported heading and paragraph blocks.
- Apply normalization across GitHub import, page update/read, and public docs render boundaries.
- Polish the editor authoring surface: centered content width, visible right TOC, stronger toolbar, Preview button, and clearer Publish popover/dashboard handoff.

## Evidence
- `make check` ✅
- `make test` ✅ (1811 passed)
- Ever-only browser QA captured under ignored `private/parity-editor/`:
  - editor after TOC visible
  - publish popover
  - public docs normalized rendering
  - dashboard after publish

## Notes
- Playwright/e2e intentionally not run; OpenDocs browser QA for this task used Ever CLI only.
- Private screenshots/reports remain ignored and are not included in this PR.
