### PR TITLE
Fix dashboard same-origin data fetches

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,5 @@
 import { ACTIVE_PROJECT_COOKIE, findActiveProject } from "@/lib/active-project";
-import { getBetterAuthUrl } from "@/lib/auth";
+import { getRequestAppUrl } from "@/lib/app-url";
 import {
   effectiveDeploymentStatus,
   projectDisplayStatus,
@@ -14,7 +14,7 @@ import {
 } from "@/lib/db/schema";
 import { getServerSession } from "@/lib/session";
 import { and, desc, eq } from "drizzle-orm";
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { DashboardHomeClient } from "./dashboard-home-client";
 
@@ -152,7 +152,7 @@ export default async function DashboardPage({
       .limit(20);
 
     const cookieHeader = (await cookies()).toString();
-    const authBaseUrl = getBetterAuthUrl();
+    const authBaseUrl = getRequestAppUrl(await headers());
     const [manualHandoffResponse, resolvedManualHandoffResponse] =
       await Promise.all([
         fetch(`${authBaseUrl}/api/analytics/manual-handoffs?limit=20`, {

--- a/src/lib/app-url.ts
+++ b/src/lib/app-url.ts
@@ -6,3 +6,24 @@ export function getPublicAppUrl() {
   }
   return "http://localhost:3015";
 }
+
+function firstForwardedValue(value: string | null): string | null {
+  return value?.split(",")[0]?.trim() || null;
+}
+
+/** Build the app origin for the current request, preferring proxy headers. */
+export function getRequestAppUrl(headers: Headers) {
+  const forwardedHost = firstForwardedValue(headers.get("x-forwarded-host"));
+  const host = forwardedHost ?? headers.get("host")?.trim();
+
+  if (!host) return getPublicAppUrl();
+
+  const forwardedProto = firstForwardedValue(headers.get("x-forwarded-proto"));
+  const protocol =
+    forwardedProto ??
+    (host.startsWith("localhost") || host.startsWith("127.0.0.1")
+      ? "http"
+      : "https");
+
+  return `${protocol}://${host}`.replace(/\/+$/, "");
+}

--- a/tests/app-url.test.ts
+++ b/tests/app-url.test.ts
@@ -1,4 +1,4 @@
-import { getPublicAppUrl } from "@/lib/app-url";
+import { getPublicAppUrl, getRequestAppUrl } from "@/lib/app-url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 describe("getPublicAppUrl", () => {
@@ -26,5 +26,37 @@ describe("getPublicAppUrl", () => {
     vi.stubEnv("NEXT_PUBLIC_APP_URL", "");
 
     expect(getPublicAppUrl()).toBe("http://localhost:3015");
+  });
+});
+
+describe("getRequestAppUrl", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("uses localhost request host instead of configured public URL", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "http://localhost:3015");
+
+    expect(getRequestAppUrl(new Headers({ host: "localhost:3016" }))).toBe(
+      "http://localhost:3016",
+    );
+  });
+
+  it("prefers forwarded proxy origin", () => {
+    expect(
+      getRequestAppUrl(
+        new Headers({
+          host: "internal:3000",
+          "x-forwarded-host": "opendocs.namuh.co",
+          "x-forwarded-proto": "https",
+        }),
+      ),
+    ).toBe("https://opendocs.namuh.co");
+  });
+
+  it("falls back to public app URL when request host is unavailable", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://opendocs.namuh.co/");
+
+    expect(getRequestAppUrl(new Headers())).toBe("https://opendocs.namuh.co");
   });
 });


### PR DESCRIPTION
## Summary
- fixed dashboard server-side manual-handoff fetches to use the current request origin instead of `BETTER_AUTH_URL`
- added request-origin helper coverage for localhost alternate-port QA and forwarded production hosts
- kept private dev/Ever evidence under `private/dev-log-sweep/`

## Root cause / evidence
- `npm run dev` on 3015 was blocked by another active worktree, so this branch ran on 3016.
- Authenticated Ever browser navigation to `/` redirected to `/dashboard` and surfaced `TypeError: fetch failed` / dashboard 500s because the dashboard fetched `/api/analytics/manual-handoffs` through the configured auth URL rather than the active request origin.
- Post-fix Ever navigation to `http://localhost:3016/` landed on `/dashboard` and server logs showed manual-handoff requests returning 200 and dashboard returning 200.

## Validation
- `npx vitest run tests/app-url.test.ts`
- `make check && make test` (1814 tests passed)
- Local route sweep after fix: key public/protected routes returned expected 200/redirect/404 statuses and `/api/health` returned 200.

## Notes
- No new broad parity issue filed: this slice found a runtime-origin bug, not a larger Mintlify visual parity gap.