### PR TITLE
Fix Settings GitHub App install flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,10 @@ AUTH_GOOGLE_ID=your-google-client-id
 AUTH_GOOGLE_SECRET=your-google-client-secret
 GITHUB_APP_ID=your-github-app-id
 GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
+# GitHub App installation URL support. Either set the slug to build
+# https://github.com/apps/<slug>/installations/new or set the full install URL.
+GITHUB_APP_SLUG=your-github-app-slug
+GITHUB_APP_INSTALL_URL=
 
 # App
 NEXT_PUBLIC_APP_URL=http://localhost:3015

--- a/src/app/settings/deployment/github/github-app-client.tsx
+++ b/src/app/settings/deployment/github/github-app-client.tsx
@@ -40,6 +40,7 @@ interface GitHubAppSettingsClientProps {
   isAdmin: boolean;
   selectedRepoFullName?: string | null;
   selectedSource?: SelectedGitHubSource | null;
+  installUrl?: string | null;
 }
 
 function GitHubIcon({
@@ -65,6 +66,7 @@ export function GitHubAppSettingsClient({
   isAdmin,
   selectedRepoFullName,
   selectedSource,
+  installUrl,
 }: GitHubAppSettingsClientProps) {
   const [connections, setConnections] =
     useState<ConnectionData[]>(initialConnections);
@@ -151,45 +153,17 @@ export function GitHubAppSettingsClient({
   }, []);
 
   const handleInstall = useCallback(() => {
-    // In a real implementation, this would redirect to GitHub App install URL
-    // For now, simulate adding a connection
-    setLoading(true);
     setError(null);
-    setTimeout(async () => {
-      try {
-        const res = await fetch("/api/github-connections", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            installationId: `inst_${Date.now()}`,
-            repos: [],
-            autoUpdateEnabled: true,
-          }),
-        });
-        if (!res.ok) {
-          const data = await res.json();
-          throw new Error(data.error ?? "Failed to install");
-        }
-        const data = await res.json();
-        setConnections((prev) => [
-          ...prev,
-          {
-            id: data.connection.id,
-            installationId: data.connection.installationId,
-            repos: data.connection.repos ?? [],
-            autoUpdateEnabled: data.connection.autoUpdateEnabled,
-            createdAt: data.connection.createdAt,
-          },
-        ]);
-        setSuccess("GitHub App installed successfully");
-        setTimeout(() => setSuccess(null), 3000);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to install");
-      } finally {
-        setLoading(false);
-      }
-    }, 500);
-  }, []);
+    if (!installUrl) {
+      setError(
+        "GitHub App installation is not configured. Set GITHUB_APP_SLUG or GITHUB_APP_INSTALL_URL before connecting GitHub.",
+      );
+      return;
+    }
+
+    setLoading(true);
+    window.location.assign(installUrl);
+  }, [installUrl]);
 
   return (
     <div

--- a/src/app/settings/deployment/github/page.tsx
+++ b/src/app/settings/deployment/github/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
 import { githubConnections, orgMemberships, projects } from "@/lib/db/schema";
+import { resolveGitHubAppInstallUrl } from "@/lib/github-app-install";
 import { attachResolvedGitHubSource } from "@/lib/project-response";
 import { eq } from "drizzle-orm";
 import { headers } from "next/headers";
@@ -60,6 +61,7 @@ export default async function GitHubAppSettingsPage() {
       }
       selectedRepoFullName={selectedSource?.repoFullName ?? null}
       selectedSource={selectedSource}
+      installUrl={resolveGitHubAppInstallUrl()}
     />
   );
 }

--- a/src/lib/github-app-install.ts
+++ b/src/lib/github-app-install.ts
@@ -1,0 +1,47 @@
+const GITHUB_APP_SLUG_PATTERN = /^[a-zA-Z0-9-]+$/;
+
+export interface GitHubAppInstallEnv {
+  [key: string]: string | undefined;
+  GITHUB_APP_INSTALL_URL?: string;
+  GITHUB_APP_SLUG?: string;
+  NEXT_PUBLIC_GITHUB_APP_SLUG?: string;
+}
+
+function normalizeExplicitInstallUrl(value: string | undefined): string | null {
+  const url = value?.trim();
+  if (!url) return null;
+
+  try {
+    const parsed = new URL(url);
+    if (
+      parsed.protocol !== "https:" ||
+      parsed.hostname !== "github.com" ||
+      !parsed.pathname.startsWith("/apps/")
+    ) {
+      return null;
+    }
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+function normalizeAppSlug(value: string | undefined): string | null {
+  const slug = value?.trim().replace(/^\/+|\/+$/g, "");
+  if (!slug || !GITHUB_APP_SLUG_PATTERN.test(slug)) return null;
+  return slug;
+}
+
+export function resolveGitHubAppInstallUrl(
+  env: GitHubAppInstallEnv = process.env,
+): string | null {
+  const explicitUrl = normalizeExplicitInstallUrl(env.GITHUB_APP_INSTALL_URL);
+  if (explicitUrl) return explicitUrl;
+
+  const slug =
+    normalizeAppSlug(env.GITHUB_APP_SLUG) ??
+    normalizeAppSlug(env.NEXT_PUBLIC_GITHUB_APP_SLUG);
+  if (!slug) return null;
+
+  return `https://github.com/apps/${slug}/installations/new`;
+}

--- a/tests/github-app-install.test.ts
+++ b/tests/github-app-install.test.ts
@@ -1,0 +1,38 @@
+import { resolveGitHubAppInstallUrl } from "@/lib/github-app-install";
+import { describe, expect, it } from "vitest";
+
+describe("resolveGitHubAppInstallUrl", () => {
+  it("uses an explicit GitHub app install URL", () => {
+    expect(
+      resolveGitHubAppInstallUrl({
+        GITHUB_APP_INSTALL_URL:
+          "https://github.com/apps/opendocs/installations/new?state=settings",
+        GITHUB_APP_SLUG: "ignored",
+      }),
+    ).toBe("https://github.com/apps/opendocs/installations/new?state=settings");
+  });
+
+  it("builds the GitHub installation URL from the app slug", () => {
+    expect(resolveGitHubAppInstallUrl({ GITHUB_APP_SLUG: "open-docs" })).toBe(
+      "https://github.com/apps/open-docs/installations/new",
+    );
+  });
+
+  it("falls back to the public slug when provided", () => {
+    expect(
+      resolveGitHubAppInstallUrl({ NEXT_PUBLIC_GITHUB_APP_SLUG: "open-docs" }),
+    ).toBe("https://github.com/apps/open-docs/installations/new");
+  });
+
+  it("returns null for missing or invalid configuration", () => {
+    expect(resolveGitHubAppInstallUrl({})).toBeNull();
+    expect(
+      resolveGitHubAppInstallUrl({ GITHUB_APP_SLUG: "bad/slug" }),
+    ).toBeNull();
+    expect(
+      resolveGitHubAppInstallUrl({
+        GITHUB_APP_INSTALL_URL: "https://example.com/apps/opendocs",
+      }),
+    ).toBeNull();
+  });
+});

--- a/tests/github-app-settings-client.test.tsx
+++ b/tests/github-app-settings-client.test.tsx
@@ -1,0 +1,69 @@
+import { GitHubAppSettingsClient } from "@/app/settings/deployment/github/github-app-client";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeAll, describe, expect, it } from "vitest";
+
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+function renderClient(installUrl: string | null) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <GitHubAppSettingsClient
+        initialConnections={[]}
+        isAdmin={true}
+        installUrl={installUrl}
+      />,
+    );
+  });
+
+  return { container, root };
+}
+
+describe("GitHubAppSettingsClient", () => {
+  it("does not create a fake connection when the GitHub App install URL is missing", () => {
+    const { container, root } = renderClient(null);
+    const installButton = container.querySelector(
+      '[data-testid="install-github-app-btn"]',
+    );
+    expect(installButton).toBeTruthy();
+
+    act(() => {
+      installButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain(
+      "GitHub App installation is not configured",
+    );
+    expect(container.textContent).not.toContain(
+      "GitHub App installed successfully",
+    );
+    expect(container.textContent).not.toContain("Active connections");
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("keeps the install action available when a GitHub App install URL is configured", () => {
+    const { container, root } = renderClient(
+      "https://github.com/apps/open-docs/installations/new",
+    );
+
+    expect(
+      container.querySelector('[data-testid="install-github-app-btn"]'),
+    ).toBeTruthy();
+    expect(container.textContent).not.toContain(
+      "GitHub App installed successfully",
+    );
+
+    act(() => root.unmount());
+    container.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- Replaced the Settings GitHub App install simulation with a real install-url redirect path.
- Added server-side resolution for `GITHUB_APP_INSTALL_URL` / `GITHUB_APP_SLUG`, plus `.env.example` documentation.
- When provider install URL is missing, the button now shows an actionable setup error instead of writing fake `github_connections` rows.
- Added regression coverage for URL resolution and missing-config click behavior.

## Browser QA (Ever)
Evidence kept under `private/browser-parity/settings-github-integration/`.
- Before fix: Settings → Deployment → GitHub app → Install created a fake `inst_1778486...` connection in-place without opening GitHub.
- After fix with no provider config: click shows `GitHub App installation is not configured...` and no active connection is created.

## Validation
- `make check`
- `make test` (1817 passed)

## Follow-up
- Larger provider/callback setup gap filed as #179.
