### PR TITLE
Fix dashboard light theme dark surface leaks

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -212,17 +212,21 @@ body {
 }
 
 .od-app-shell .text-white,
-.od-app-shell .text-white\/80 {
+.od-app-shell .text-white\/80,
+.od-app-shell .text-zinc-200,
+.od-app-shell .text-zinc-300 {
   color: var(--od-text);
 }
 
 .od-app-shell .text-gray-300,
-.od-app-shell .text-gray-400 {
+.od-app-shell .text-gray-400,
+.od-app-shell .text-zinc-400 {
   color: var(--od-text-muted);
 }
 
 .od-app-shell .text-gray-500,
-.od-app-shell .text-gray-600 {
+.od-app-shell .text-gray-600,
+.od-app-shell .text-zinc-500 {
   color: var(--od-text-subtle);
 }
 
@@ -231,17 +235,30 @@ body {
 .od-app-shell .border-white\/\[0\.04\],
 .od-app-shell .border-white\/10,
 .od-app-shell .border-gray-700,
-.od-app-shell .border-gray-800 {
+.od-app-shell .border-gray-800,
+.od-app-shell .border-zinc-700 {
   border-color: var(--od-border);
 }
 
 .od-app-shell .divide-white\/\[0\.04\] > :not([hidden]) ~ :not([hidden]),
-.od-app-shell .divide-white\/\[0\.06\] > :not([hidden]) ~ :not([hidden]) {
+.od-app-shell .divide-white\/\[0\.06\] > :not([hidden]) ~ :not([hidden]),
+.od-app-shell .divide-zinc-700\/50 > :not([hidden]) ~ :not([hidden]) {
   border-color: var(--od-border-light);
 }
 
 .od-app-shell .bg-\[\#1a1a1a\],
 .od-app-shell .bg-\[\#111111\],
+.od-app-shell .bg-\[\#101010\],
+.od-app-shell .bg-\[\#0c0c0c\],
+.od-app-shell .bg-\[\#161616\],
+.od-app-shell .bg-\[\#1e1e1e\],
+.od-app-shell .bg-\[\#2a2a2a\],
+.od-app-shell .bg-zinc-800,
+.od-app-shell .bg-zinc-800\/10,
+.od-app-shell .bg-zinc-800\/20,
+.od-app-shell .bg-zinc-800\/40,
+.od-app-shell .bg-zinc-800\/60,
+.od-app-shell .bg-gray-900\/50,
 .od-app-shell .bg-white\/\[0\.03\],
 .od-app-shell .bg-white\/\[0\.04\],
 .od-app-shell .bg-white\/5 {
@@ -249,6 +266,9 @@ body {
 }
 
 .od-app-shell .bg-\[\#0f0f0f\],
+.od-app-shell .bg-\[\#0a0a0a\],
+.od-app-shell .bg-\[\#141414\],
+.od-app-shell .bg-gray-800,
 .od-app-shell .bg-white\/\[0\.02\],
 .od-app-shell .bg-white\/\[0\.06\],
 .od-app-shell .bg-white\/\[0\.08\],
@@ -261,10 +281,12 @@ body {
 .od-app-shell .hover\:bg-white\/\[0\.04\]:hover,
 .od-app-shell .hover\:bg-white\/\[0\.06\]:hover,
 .od-app-shell .hover\:bg-white\/\[0\.08\]:hover,
-.od-app-shell .hover\:bg-white\/10:hover {
+.od-app-shell .hover\:bg-white\/10:hover,
+.od-app-shell .hover\:bg-zinc-700\/50:hover {
   background-color: var(--od-panel-muted);
 }
 
+.od-app-shell .text-emerald-200,
 .od-app-shell .text-emerald-300,
 .od-app-shell .text-emerald-400,
 .od-app-shell .text-emerald-500 {

--- a/tests/dashboard-theme-css.test.ts
+++ b/tests/dashboard-theme-css.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const globalsCss = readFileSync("src/app/globals.css", "utf8");
+
+describe("dashboard shell theme CSS", () => {
+  it("maps editor dark canvas classes to dashboard design tokens", () => {
+    expect(globalsCss).toContain(".od-app-shell .bg-\\[\\#0c0c0c\\]");
+    expect(globalsCss).toContain(".od-app-shell .bg-\\[\\#0a0a0a\\]");
+    expect(globalsCss).toContain(".od-app-shell .bg-\\[\\#101010\\]");
+    expect(globalsCss).toContain(".od-app-shell .text-emerald-200");
+  });
+
+  it("maps zinc-based product panels to dashboard design tokens", () => {
+    expect(globalsCss).toContain(".od-app-shell .bg-zinc-800\\/60");
+    expect(globalsCss).toContain(".od-app-shell .border-zinc-700");
+    expect(globalsCss).toContain(".od-app-shell .text-zinc-400");
+    expect(globalsCss).toContain(
+      ".od-app-shell .hover\\:bg-zinc-700\\/50:hover",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Extend the OpenDocs dashboard shell theme compatibility layer for editor canvas classes that still used hard-coded dark backgrounds.
- Add zinc/gray utility mappings so product/settings-adjacent surfaces do not randomly render dark panels inside the light app shell.
- Add a CSS regression test that locks the editor and zinc utility mappings.

## Evidence
- Ever before: `private/browser-parity/ui-theme-parity-20260511T080109Z/local-editor-before-loaded.theme.json` showed `bg-[#0c0c0c]` editor canvas dark backgrounds.
- Ever after: `private/browser-parity/ui-theme-parity-20260511T080109Z/local-editor-seeded-after-restart.theme.json` shows `darkBackgrounds: []` for an active editor page.
- Ever after: `private/browser-parity/ui-theme-parity-20260511T080109Z/local-products-mcp-after-restart.theme.json` shows `darkBackgrounds: []`.
- Ever after: `private/browser-parity/ui-theme-parity-20260511T080109Z/local-settings-security-api-keys-after-restart.theme.json` shows `darkBackgrounds: []`.
- Reference check: live `https://opendocs.namuh.co/login` captured under `private/browser-parity/ui-theme-parity-20260511T080109Z/reference-opendocs-login.*`; authenticated dashboard references are auth-gated.

## Verification
- `npx vitest run tests/dashboard-theme-css.test.ts`
- `make check`
- `make test` (post-rebase on latest `origin/staging`, 1822 passed)
