### PR TITLE
Complete GitHub App setup callback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,8 +31,13 @@ AUTH_GOOGLE_ID=your-google-client-id
 AUTH_GOOGLE_SECRET=your-google-client-secret
 GITHUB_APP_ID=your-github-app-id
 GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
-# GitHub App installation URL support. Either set the slug to build
-# https://github.com/apps/<slug>/installations/new or set the full install URL.
+# GitHub App install/setup
+# Configure the GitHub App "Setup URL" to:
+#   http://localhost:3015/api/github-connections/callback
+# Production/staging should use the deployed origin, e.g.:
+#   https://opendocs.namuh.co/api/github-connections/callback
+# The settings page uses GITHUB_APP_INSTALL_URL when set; otherwise it builds
+# https://github.com/apps/<GITHUB_APP_SLUG>/installations/new.
 GITHUB_APP_SLUG=your-github-app-slug
 GITHUB_APP_INSTALL_URL=
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ BETTER_AUTH_URL=https://opendocs.namuh.co
 AUTH_GOOGLE_ID=your-google-oauth-client-id
 AUTH_GOOGLE_SECRET=your-google-oauth-client-secret
 GITHUB_WEBHOOK_SECRET=your-github-webhook-secret
+GITHUB_APP_ID=your-github-app-id
+GITHUB_APP_PRIVATE_KEY=your-github-app-private-key
+GITHUB_APP_SLUG=your-github-app-slug
+# Optional override if the default slug URL is not correct:
+GITHUB_APP_INSTALL_URL=https://github.com/apps/your-github-app-slug/installations/new
 ```
 
 Google OAuth must include this production redirect URI:
@@ -160,6 +165,14 @@ Google OAuth must include this production redirect URI:
 ```text
 https://opendocs.namuh.co/api/auth/callback/google
 ```
+
+The GitHub App must set its **Setup URL** to the deployed callback route so GitHub returns `installation_id` and `setup_action` after install/update:
+
+```text
+https://opendocs.namuh.co/api/github-connections/callback
+```
+
+For staging, use the staging origin with the same path.
 
 ### AWS and storage
 

--- a/src/app/api/github-connections/callback/route.ts
+++ b/src/app/api/github-connections/callback/route.ts
@@ -1,0 +1,216 @@
+import { auth } from "@/lib/auth";
+import { db } from "@/lib/db";
+import {
+  githubConnections,
+  orgMemberships,
+  organizations,
+} from "@/lib/db/schema";
+import { hydrateGitHubInstallationRepos } from "@/lib/github-app-setup";
+import type { GitHubRepo } from "@/lib/github-webhook";
+import { createRequestId, logger } from "@/lib/logger";
+import { eq } from "drizzle-orm";
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+
+const SETTINGS_PATH = "/settings/deployment/github";
+
+async function resolveUserOrg(userId: string) {
+  const rows = await db
+    .select({
+      orgId: orgMemberships.orgId,
+      role: orgMemberships.role,
+      orgName: organizations.name,
+    })
+    .from(orgMemberships)
+    .innerJoin(organizations, eq(orgMemberships.orgId, organizations.id))
+    .where(eq(orgMemberships.userId, userId))
+    .limit(1);
+
+  return rows[0] ?? null;
+}
+
+function redirectWithStatus(request: Request, params: Record<string, string>) {
+  const url = new URL(SETTINGS_PATH, request.url);
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return NextResponse.redirect(url, { status: 303 });
+}
+
+function parseInstallationId(value: string | null): string | null {
+  if (!value || !/^\d+$/.test(value)) return null;
+  const numeric = Number(value);
+  if (!Number.isSafeInteger(numeric) || numeric <= 0) return null;
+  return value;
+}
+
+/**
+ * GET /api/github-connections/callback
+ *
+ * GitHub redirects the app setup URL here with installation_id and setup_action.
+ * We only persist after minting a real installation token and hydrating the
+ * repositories GitHub reports for that installation.
+ */
+export async function GET(request: Request) {
+  const requestId = createRequestId();
+  const session = await auth.api.getSession({ headers: await headers() });
+
+  if (!session) {
+    logger.warn("github_app_setup_callback_unauthorized", {
+      requestId,
+      route: "/api/github-connections/callback",
+      method: "GET",
+    });
+    return redirectWithStatus(request, {
+      github_app: "error",
+      error: "unauthorized",
+      requestId,
+    });
+  }
+
+  const url = new URL(request.url);
+  const installationId = parseInstallationId(
+    url.searchParams.get("installation_id"),
+  );
+  const setupAction = url.searchParams.get("setup_action") ?? "";
+
+  if (
+    !installationId ||
+    !["install", "update", "request"].includes(setupAction)
+  ) {
+    logger.warn("github_app_setup_callback_invalid_request", {
+      requestId,
+      route: "/api/github-connections/callback",
+      method: "GET",
+      userId: session.user.id,
+      setupAction,
+      hasInstallationId: Boolean(installationId),
+    });
+    return redirectWithStatus(request, {
+      github_app: "error",
+      error: "invalid_callback",
+      requestId,
+    });
+  }
+
+  const org = await resolveUserOrg(session.user.id);
+  if (!org) {
+    logger.warn("github_app_setup_callback_no_org", {
+      requestId,
+      route: "/api/github-connections/callback",
+      method: "GET",
+      userId: session.user.id,
+    });
+    return redirectWithStatus(request, {
+      github_app: "error",
+      error: "no_org",
+      requestId,
+    });
+  }
+
+  if (org.role !== "admin" && org.role !== "editor") {
+    logger.warn("github_app_setup_callback_forbidden", {
+      requestId,
+      route: "/api/github-connections/callback",
+      method: "GET",
+      userId: session.user.id,
+      role: org.role,
+      orgId: org.orgId,
+    });
+    return redirectWithStatus(request, {
+      github_app: "error",
+      error: "forbidden",
+      requestId,
+    });
+  }
+
+  let repos: GitHubRepo[];
+  try {
+    repos = await hydrateGitHubInstallationRepos(installationId);
+  } catch (error) {
+    logger.error("github_app_setup_callback_hydrate_failed", {
+      requestId,
+      route: "/api/github-connections/callback",
+      method: "GET",
+      orgId: org.orgId,
+      installationId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return redirectWithStatus(request, {
+      github_app: "error",
+      error: "installation_auth_failed",
+      requestId,
+    });
+  }
+
+  const existing = await db
+    .select()
+    .from(githubConnections)
+    .where(eq(githubConnections.installationId, installationId))
+    .limit(1);
+
+  if (existing[0] && existing[0].orgId !== org.orgId) {
+    logger.warn("github_app_setup_callback_installation_conflict", {
+      requestId,
+      route: "/api/github-connections/callback",
+      method: "GET",
+      orgId: org.orgId,
+      existingOrgId: existing[0].orgId,
+      installationId,
+    });
+    return redirectWithStatus(request, {
+      github_app: "error",
+      error: "installation_already_connected",
+      requestId,
+    });
+  }
+
+  if (existing[0]) {
+    const [connection] = await db
+      .update(githubConnections)
+      .set({
+        repos,
+        autoUpdateEnabled: true,
+      })
+      .where(eq(githubConnections.id, existing[0].id))
+      .returning();
+
+    logger.info("github_app_setup_callback_updated", {
+      requestId,
+      route: "/api/github-connections/callback",
+      method: "GET",
+      orgId: org.orgId,
+      connectionId: connection.id,
+      installationId,
+      repoCount: repos.length,
+      setupAction,
+    });
+  } else {
+    const [connection] = await db
+      .insert(githubConnections)
+      .values({
+        orgId: org.orgId,
+        installationId,
+        repos,
+        autoUpdateEnabled: true,
+      })
+      .returning();
+
+    logger.info("github_app_setup_callback_created", {
+      requestId,
+      route: "/api/github-connections/callback",
+      method: "GET",
+      orgId: org.orgId,
+      connectionId: connection.id,
+      installationId,
+      repoCount: repos.length,
+      setupAction,
+    });
+  }
+
+  return redirectWithStatus(request, {
+    github_app: "connected",
+    installation_id: installationId,
+    requestId,
+  });
+}

--- a/src/app/settings/deployment/github/github-app-client.tsx
+++ b/src/app/settings/deployment/github/github-app-client.tsx
@@ -156,7 +156,7 @@ export function GitHubAppSettingsClient({
     setError(null);
     if (!installUrl) {
       setError(
-        "GitHub App installation is not configured. Set GITHUB_APP_SLUG or GITHUB_APP_INSTALL_URL before connecting GitHub.",
+        "GitHub App installation is not configured. Set GITHUB_APP_SLUG or GITHUB_APP_INSTALL_URL, then configure the app setup URL to /api/github-connections/callback.",
       );
       return;
     }

--- a/src/lib/github-app-setup.ts
+++ b/src/lib/github-app-setup.ts
@@ -1,0 +1,65 @@
+import { getGitHubInstallationAccessToken } from "@/lib/github-installation-auth";
+import type { GitHubRepo } from "@/lib/github-webhook";
+
+function permissionFromRepo(
+  repo: GitHubRepositoryResponse,
+): GitHubRepo["permissions"] {
+  if (repo.permissions?.admin) return "admin";
+  if (repo.permissions?.push || repo.permissions?.maintain) return "write";
+  return "read";
+}
+
+interface GitHubRepositoryResponse {
+  full_name?: string;
+  default_branch?: string;
+  permissions?: {
+    admin?: boolean;
+    push?: boolean;
+    pull?: boolean;
+    maintain?: boolean;
+  };
+}
+
+interface InstallationRepositoriesResponse {
+  repositories?: GitHubRepositoryResponse[];
+}
+
+export async function hydrateGitHubInstallationRepos(
+  installationId: string,
+  options?: {
+    fetchImpl?: typeof fetch;
+    getToken?: typeof getGitHubInstallationAccessToken;
+  },
+): Promise<GitHubRepo[]> {
+  const getToken = options?.getToken ?? getGitHubInstallationAccessToken;
+  const fetchImpl = options?.fetchImpl ?? fetch;
+  const { token } = await getToken({ installationId });
+
+  const response = await fetchImpl(
+    "https://api.github.com/installation/repositories?per_page=100",
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to hydrate GitHub installation repositories (status ${response.status})`,
+    );
+  }
+
+  const data = (await response.json()) as InstallationRepositoriesResponse;
+  return (data.repositories ?? [])
+    .filter((repo): repo is GitHubRepositoryResponse & { full_name: string } =>
+      Boolean(repo.full_name),
+    )
+    .map((repo) => ({
+      fullName: repo.full_name,
+      branch: repo.default_branch || "main",
+      permissions: permissionFromRepo(repo),
+    }));
+}

--- a/tests/github-app-callback-route.test.ts
+++ b/tests/github-app-callback-route.test.ts
@@ -1,0 +1,225 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+function makeRequest(url: string): NextRequest {
+  const request = new Request(url) as NextRequest;
+  Object.defineProperty(request, "nextUrl", {
+    value: new URL(url),
+    configurable: true,
+  });
+  return request;
+}
+
+const getSessionMock = vi.fn();
+const headersMock = vi.fn();
+const selectMock = vi.fn();
+const insertMock = vi.fn();
+const updateMock = vi.fn();
+const hydrateReposMock = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: getSessionMock,
+    },
+  },
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: selectMock,
+    insert: insertMock,
+    update: updateMock,
+  },
+}));
+
+vi.mock("@/lib/github-app-setup", () => ({
+  hydrateGitHubInstallationRepos: hydrateReposMock,
+}));
+
+vi.mock("next/headers", () => ({
+  headers: headersMock,
+}));
+
+function mockOrg(role = "admin") {
+  selectMock.mockReturnValueOnce({
+    from: vi.fn().mockReturnThis(),
+    innerJoin: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi
+      .fn()
+      .mockResolvedValue([{ orgId: "org-1", role, orgName: "Org" }]),
+  });
+}
+
+function mockExistingConnection(rows: Array<Record<string, unknown>>) {
+  selectMock.mockReturnValueOnce({
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(rows),
+  });
+}
+
+describe("/api/github-connections/callback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    headersMock.mockResolvedValue(new Headers());
+  });
+
+  it("redirects with an error when unauthenticated", async () => {
+    getSessionMock.mockResolvedValue(null);
+
+    const { GET } = await import("@/app/api/github-connections/callback/route");
+    const response = await GET(
+      makeRequest(
+        "http://localhost:3000/api/github-connections/callback?installation_id=123&setup_action=install",
+      ),
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toContain(
+      "/settings/deployment/github?github_app=error&error=unauthorized",
+    );
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects callbacks without a real numeric installation id", async () => {
+    getSessionMock.mockResolvedValue({ user: { id: "user-1" } });
+
+    const { GET } = await import("@/app/api/github-connections/callback/route");
+    const response = await GET(
+      makeRequest(
+        "http://localhost:3000/api/github-connections/callback?installation_id=inst_fake&setup_action=install",
+      ),
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toContain(
+      "error=invalid_callback",
+    );
+    expect(hydrateReposMock).not.toHaveBeenCalled();
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects users who cannot manage the OpenDocs organization", async () => {
+    getSessionMock.mockResolvedValue({ user: { id: "user-1" } });
+    mockOrg("viewer");
+
+    const { GET } = await import("@/app/api/github-connections/callback/route");
+    const response = await GET(
+      makeRequest(
+        "http://localhost:3000/api/github-connections/callback?installation_id=123&setup_action=install",
+      ),
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toContain("error=forbidden");
+    expect(hydrateReposMock).not.toHaveBeenCalled();
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("hydrates repositories and creates a connection for a real installation", async () => {
+    getSessionMock.mockResolvedValue({ user: { id: "user-1" } });
+    const repos = [
+      {
+        fullName: "namuh-eng/opendocs",
+        branch: "staging",
+        permissions: "admin",
+      },
+    ];
+    mockOrg("admin");
+    hydrateReposMock.mockResolvedValue(repos);
+    mockExistingConnection([]);
+    const valuesMock = vi.fn().mockReturnThis();
+    const returningMock = vi.fn().mockResolvedValue([
+      {
+        id: "conn-1",
+        orgId: "org-1",
+        installationId: "123",
+        repos,
+        autoUpdateEnabled: true,
+      },
+    ]);
+    insertMock.mockReturnValue({
+      values: valuesMock,
+      returning: returningMock,
+    });
+
+    const { GET } = await import("@/app/api/github-connections/callback/route");
+    const response = await GET(
+      makeRequest(
+        "http://localhost:3000/api/github-connections/callback?installation_id=123&setup_action=install",
+      ),
+    );
+
+    expect(hydrateReposMock).toHaveBeenCalledWith("123");
+    expect(valuesMock).toHaveBeenCalledWith({
+      orgId: "org-1",
+      installationId: "123",
+      repos,
+      autoUpdateEnabled: true,
+    });
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toContain("github_app=connected");
+  });
+
+  it("updates an existing same-org connection", async () => {
+    getSessionMock.mockResolvedValue({ user: { id: "user-1" } });
+    const repos = [
+      { fullName: "namuh-eng/opendocs", branch: "main", permissions: "write" },
+    ];
+    mockOrg("editor");
+    hydrateReposMock.mockResolvedValue(repos);
+    mockExistingConnection([
+      { id: "conn-1", orgId: "org-1", installationId: "123" },
+    ]);
+    const setMock = vi.fn().mockReturnThis();
+    const whereMock = vi.fn().mockReturnThis();
+    const returningMock = vi
+      .fn()
+      .mockResolvedValue([
+        { id: "conn-1", orgId: "org-1", installationId: "123", repos },
+      ]);
+    updateMock.mockReturnValue({
+      set: setMock,
+      where: whereMock,
+      returning: returningMock,
+    });
+
+    const { GET } = await import("@/app/api/github-connections/callback/route");
+    const response = await GET(
+      makeRequest(
+        "http://localhost:3000/api/github-connections/callback?installation_id=123&setup_action=update",
+      ),
+    );
+
+    expect(setMock).toHaveBeenCalledWith({ repos, autoUpdateEnabled: true });
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toContain("github_app=connected");
+  });
+
+  it("does not reassign an installation connected to another org", async () => {
+    getSessionMock.mockResolvedValue({ user: { id: "user-1" } });
+    mockOrg("admin");
+    hydrateReposMock.mockResolvedValue([]);
+    mockExistingConnection([
+      { id: "conn-1", orgId: "org-2", installationId: "123" },
+    ]);
+
+    const { GET } = await import("@/app/api/github-connections/callback/route");
+    const response = await GET(
+      makeRequest(
+        "http://localhost:3000/api/github-connections/callback?installation_id=123&setup_action=install",
+      ),
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toContain(
+      "error=installation_already_connected",
+    );
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/github-app-setup.test.ts
+++ b/tests/github-app-setup.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getTokenMock = vi.fn();
+
+describe("github app setup helpers", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("hydrates selected repositories with permissions", async () => {
+    getTokenMock.mockResolvedValue({ token: "installation-token" });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        repositories: [
+          {
+            full_name: "namuh-eng/opendocs",
+            default_branch: "staging",
+            permissions: { admin: true, push: true, pull: true },
+          },
+          {
+            full_name: "namuh-eng/docs-demo",
+            default_branch: "main",
+            permissions: { pull: true },
+          },
+        ],
+      }),
+    });
+
+    const { hydrateGitHubInstallationRepos } = await import(
+      "@/lib/github-app-setup"
+    );
+
+    await expect(
+      hydrateGitHubInstallationRepos("123", {
+        fetchImpl: fetchMock,
+        getToken: getTokenMock,
+      }),
+    ).resolves.toEqual([
+      {
+        fullName: "namuh-eng/opendocs",
+        branch: "staging",
+        permissions: "admin",
+      },
+      {
+        fullName: "namuh-eng/docs-demo",
+        branch: "main",
+        permissions: "read",
+      },
+    ]);
+    expect(getTokenMock).toHaveBeenCalledWith({ installationId: "123" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.github.com/installation/repositories?per_page=100",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer installation-token",
+        }),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary\n- redirects GitHub App install buttons to configured install URL/slug instead of creating synthetic connections\n- adds authenticated setup callback at /api/github-connections/callback that validates org role, mints a real installation token, hydrates selected repos, and creates/updates github_connections\n- documents required GitHub App env and setup callback URL\n\n## Tests\n- npm test -- tests/github-app-setup.test.ts tests/github-app-callback-route.test.ts\n- npm run typecheck\n- npm run lint\n- make check\n- make test\n\nCloses #179\n\nNote: production/staging still need the external GitHub App Setup URL configured to the deployed /api/github-connections/callback path and GITHUB_APP_SLUG or GITHUB_APP_INSTALL_URL set in the environment.