### PR TITLE
Remove fake GitHub star count

### DIFF
--- a/src/components/layout/top-bar.tsx
+++ b/src/components/layout/top-bar.tsx
@@ -157,11 +157,6 @@ export function TopBar({
         >
           <Star size={14} />
           <span className="font-medium">Star</span>
-          <span
-            className={`rounded-full px-1.5 text-xs ${shellTheme.keyboard}`}
-          >
-            128
-          </span>
         </a>
 
         <button

--- a/tests/top-bar.test.tsx
+++ b/tests/top-bar.test.tsx
@@ -1,0 +1,32 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    signOut: vi.fn(),
+  },
+}));
+
+describe("TopBar", () => {
+  it("links to GitHub without showing a hard-coded star count", async () => {
+    const { TopBar } = await import("@/components/layout/top-bar");
+    const html = renderToStaticMarkup(
+      <TopBar
+        onThemeChange={vi.fn()}
+        resolvedTheme="light"
+        theme="light"
+        userEmail="user@example.com"
+        userName="Test User"
+      />,
+    );
+
+    expect(html).toContain('href="https://github.com/namuh-eng/opendocs"');
+    expect(html).toContain('aria-label="Star OpenDocs on GitHub"');
+    expect(html).toContain(">Star<");
+    expect(html).not.toContain(">128<");
+  });
+});


### PR DESCRIPTION
## Summary
- removes the hard-coded GitHub star count from the dashboard top bar
- keeps the GitHub Star CTA/link intact
- adds a regression test that renders the top bar and rejects the static 128 count

## Verification
- npx vitest run tests/top-bar.test.tsx
- make check
- NODE_OPTIONS=--no-experimental-webstorage make test
- git diff --check

## Notes
- Raw local `make test` on this machine failed before the env override because Node 25 experimental webstorage exposes a broken global `localStorage` that shadows jsdom storage. Disabling Node webstorage lets jsdom own localStorage and the full suite passes.

Related: PR #183 cleanup finding #2