### PR TITLE
Fix GitHub App org binding and repo pagination

### DIFF
--- a/src/app/api/github-connections/callback/route.ts
+++ b/src/app/api/github-connections/callback/route.ts
@@ -1,32 +1,70 @@
 import { auth } from "@/lib/auth";
 import { db } from "@/lib/db";
-import {
-  githubConnections,
-  orgMemberships,
-  organizations,
-} from "@/lib/db/schema";
+import { githubConnections, orgMemberships } from "@/lib/db/schema";
 import { hydrateGitHubInstallationRepos } from "@/lib/github-app-setup";
 import type { GitHubRepo } from "@/lib/github-webhook";
 import { createRequestId, logger } from "@/lib/logger";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { headers } from "next/headers";
 import { NextResponse } from "next/server";
 
 const SETTINGS_PATH = "/settings/deployment/github";
+const ORG_STATE_PREFIX = "org:";
 
-async function resolveUserOrg(userId: string) {
+type ResolvedUserOrg =
+  | {
+      org: { orgId: string; role: string };
+      error: null;
+    }
+  | {
+      org: null;
+      error: "no_org" | "org_required";
+    };
+
+function parseOrgIdFromState(value: string | null): string | null {
+  const state = value?.trim();
+  if (!state?.startsWith(ORG_STATE_PREFIX)) return null;
+
+  return state.slice(ORG_STATE_PREFIX.length).trim() || null;
+}
+
+async function resolveUserOrg(
+  userId: string,
+  requestedOrgId: string | null,
+): Promise<ResolvedUserOrg> {
+  if (requestedOrgId) {
+    const rows = await db
+      .select({
+        orgId: orgMemberships.orgId,
+        role: orgMemberships.role,
+      })
+      .from(orgMemberships)
+      .where(
+        and(
+          eq(orgMemberships.userId, userId),
+          eq(orgMemberships.orgId, requestedOrgId),
+        ),
+      )
+      .limit(1);
+
+    return rows[0]
+      ? { org: rows[0], error: null }
+      : { org: null, error: "no_org" };
+  }
+
   const rows = await db
     .select({
       orgId: orgMemberships.orgId,
       role: orgMemberships.role,
-      orgName: organizations.name,
     })
     .from(orgMemberships)
-    .innerJoin(organizations, eq(orgMemberships.orgId, organizations.id))
     .where(eq(orgMemberships.userId, userId))
-    .limit(1);
+    .limit(2);
 
-  return rows[0] ?? null;
+  if (rows.length === 0) return { org: null, error: "no_org" };
+  if (rows.length > 1) return { org: null, error: "org_required" };
+
+  return { org: rows[0], error: null };
 }
 
 function redirectWithStatus(request: Request, params: Record<string, string>) {
@@ -73,6 +111,7 @@ export async function GET(request: Request) {
     url.searchParams.get("installation_id"),
   );
   const setupAction = url.searchParams.get("setup_action") ?? "";
+  const requestedOrgId = parseOrgIdFromState(url.searchParams.get("state"));
 
   if (
     !installationId ||
@@ -93,17 +132,20 @@ export async function GET(request: Request) {
     });
   }
 
-  const org = await resolveUserOrg(session.user.id);
+  const resolvedOrg = await resolveUserOrg(session.user.id, requestedOrgId);
+  const org = resolvedOrg.org;
   if (!org) {
     logger.warn("github_app_setup_callback_no_org", {
       requestId,
       route: "/api/github-connections/callback",
       method: "GET",
       userId: session.user.id,
+      requestedOrgId,
+      error: resolvedOrg.error,
     });
     return redirectWithStatus(request, {
       github_app: "error",
-      error: "no_org",
+      error: resolvedOrg.error ?? "no_org",
       requestId,
     });
   }

--- a/src/app/settings/deployment/github/page.tsx
+++ b/src/app/settings/deployment/github/page.tsx
@@ -61,7 +61,9 @@ export default async function GitHubAppSettingsPage() {
       }
       selectedRepoFullName={selectedSource?.repoFullName ?? null}
       selectedSource={selectedSource}
-      installUrl={resolveGitHubAppInstallUrl()}
+      installUrl={resolveGitHubAppInstallUrl(process.env, {
+        state: `org:${orgId}`,
+      })}
     />
   );
 }

--- a/src/lib/github-app-install.ts
+++ b/src/lib/github-app-install.ts
@@ -7,6 +7,19 @@ export interface GitHubAppInstallEnv {
   NEXT_PUBLIC_GITHUB_APP_SLUG?: string;
 }
 
+interface GitHubAppInstallOptions {
+  state?: string | null;
+}
+
+function withInstallState(url: string, state?: string | null): string {
+  const trimmedState = state?.trim();
+  if (!trimmedState) return url;
+
+  const parsed = new URL(url);
+  parsed.searchParams.set("state", trimmedState);
+  return parsed.toString();
+}
+
 function normalizeExplicitInstallUrl(value: string | undefined): string | null {
   const url = value?.trim();
   if (!url) return null;
@@ -34,14 +47,18 @@ function normalizeAppSlug(value: string | undefined): string | null {
 
 export function resolveGitHubAppInstallUrl(
   env: GitHubAppInstallEnv = process.env,
+  options: GitHubAppInstallOptions = {},
 ): string | null {
   const explicitUrl = normalizeExplicitInstallUrl(env.GITHUB_APP_INSTALL_URL);
-  if (explicitUrl) return explicitUrl;
+  if (explicitUrl) return withInstallState(explicitUrl, options.state);
 
   const slug =
     normalizeAppSlug(env.GITHUB_APP_SLUG) ??
     normalizeAppSlug(env.NEXT_PUBLIC_GITHUB_APP_SLUG);
   if (!slug) return null;
 
-  return `https://github.com/apps/${slug}/installations/new`;
+  return withInstallState(
+    `https://github.com/apps/${slug}/installations/new`,
+    options.state,
+  );
 }

--- a/src/lib/github-app-setup.ts
+++ b/src/lib/github-app-setup.ts
@@ -24,6 +24,15 @@ interface InstallationRepositoriesResponse {
   repositories?: GitHubRepositoryResponse[];
 }
 
+function hasNextPage(response: Response): boolean {
+  const linkHeader = response.headers
+    ?.get("link")
+    ?.split(",")
+    .some((link) => link.includes('rel="next"'));
+
+  return linkHeader ?? false;
+}
+
 export async function hydrateGitHubInstallationRepos(
   installationId: string,
   options?: {
@@ -34,26 +43,35 @@ export async function hydrateGitHubInstallationRepos(
   const getToken = options?.getToken ?? getGitHubInstallationAccessToken;
   const fetchImpl = options?.fetchImpl ?? fetch;
   const { token } = await getToken({ installationId });
+  const repositories: GitHubRepositoryResponse[] = [];
+  let page = 1;
 
-  const response = await fetchImpl(
-    "https://api.github.com/installation/repositories?per_page=100",
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
+  while (true) {
+    const response = await fetchImpl(
+      `https://api.github.com/installation/repositories?per_page=100&page=${page}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
       },
-    },
-  );
-
-  if (!response.ok) {
-    throw new Error(
-      `Failed to hydrate GitHub installation repositories (status ${response.status})`,
     );
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to hydrate GitHub installation repositories (status ${response.status})`,
+      );
+    }
+
+    const data = (await response.json()) as InstallationRepositoriesResponse;
+    repositories.push(...(data.repositories ?? []));
+
+    if (!hasNextPage(response)) break;
+    page += 1;
   }
 
-  const data = (await response.json()) as InstallationRepositoriesResponse;
-  return (data.repositories ?? [])
+  return repositories
     .filter((repo): repo is GitHubRepositoryResponse & { full_name: string } =>
       Boolean(repo.full_name),
     )

--- a/tests/github-app-callback-route.test.ts
+++ b/tests/github-app-callback-route.test.ts
@@ -44,11 +44,16 @@ vi.mock("next/headers", () => ({
 function mockOrg(role = "admin") {
   selectMock.mockReturnValueOnce({
     from: vi.fn().mockReturnThis(),
-    innerJoin: vi.fn().mockReturnThis(),
     where: vi.fn().mockReturnThis(),
-    limit: vi
-      .fn()
-      .mockResolvedValue([{ orgId: "org-1", role, orgName: "Org" }]),
+    limit: vi.fn().mockResolvedValue([{ orgId: "org-1", role }]),
+  });
+}
+
+function mockOrgRows(rows: Array<{ orgId: string; role: string }>) {
+  selectMock.mockReturnValueOnce({
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(rows),
   });
 }
 
@@ -149,7 +154,7 @@ describe("/api/github-connections/callback", () => {
     const { GET } = await import("@/app/api/github-connections/callback/route");
     const response = await GET(
       makeRequest(
-        "http://localhost:3000/api/github-connections/callback?installation_id=123&setup_action=install",
+        "http://localhost:3000/api/github-connections/callback?installation_id=123&setup_action=install&state=org%3Aorg-1",
       ),
     );
 
@@ -162,6 +167,70 @@ describe("/api/github-connections/callback", () => {
     });
     expect(response.status).toBe(303);
     expect(response.headers.get("location")).toContain("github_app=connected");
+  });
+
+  it("uses the state org instead of the first membership when creating a connection", async () => {
+    getSessionMock.mockResolvedValue({ user: { id: "user-1" } });
+    const repos = [
+      {
+        fullName: "namuh-eng/opendocs",
+        branch: "staging",
+        permissions: "admin",
+      },
+    ];
+    mockOrgRows([{ orgId: "org-2", role: "admin" }]);
+    hydrateReposMock.mockResolvedValue(repos);
+    mockExistingConnection([]);
+    const valuesMock = vi.fn().mockReturnThis();
+    const returningMock = vi.fn().mockResolvedValue([
+      {
+        id: "conn-1",
+        orgId: "org-2",
+        installationId: "123",
+        repos,
+        autoUpdateEnabled: true,
+      },
+    ]);
+    insertMock.mockReturnValue({
+      values: valuesMock,
+      returning: returningMock,
+    });
+
+    const { GET } = await import("@/app/api/github-connections/callback/route");
+    const response = await GET(
+      makeRequest(
+        "http://localhost:3000/api/github-connections/callback?installation_id=123&setup_action=install&state=org%3Aorg-2",
+      ),
+    );
+
+    expect(valuesMock).toHaveBeenCalledWith({
+      orgId: "org-2",
+      installationId: "123",
+      repos,
+      autoUpdateEnabled: true,
+    });
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toContain("github_app=connected");
+  });
+
+  it("rejects stateless callbacks when the user has multiple org memberships", async () => {
+    getSessionMock.mockResolvedValue({ user: { id: "user-1" } });
+    mockOrgRows([
+      { orgId: "org-1", role: "admin" },
+      { orgId: "org-2", role: "admin" },
+    ]);
+
+    const { GET } = await import("@/app/api/github-connections/callback/route");
+    const response = await GET(
+      makeRequest(
+        "http://localhost:3000/api/github-connections/callback?installation_id=123&setup_action=install",
+      ),
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toContain("error=org_required");
+    expect(hydrateReposMock).not.toHaveBeenCalled();
+    expect(insertMock).not.toHaveBeenCalled();
   });
 
   it("updates an existing same-org connection", async () => {

--- a/tests/github-app-install.test.ts
+++ b/tests/github-app-install.test.ts
@@ -4,17 +4,27 @@ import { describe, expect, it } from "vitest";
 describe("resolveGitHubAppInstallUrl", () => {
   it("uses an explicit GitHub app install URL", () => {
     expect(
-      resolveGitHubAppInstallUrl({
-        GITHUB_APP_INSTALL_URL:
-          "https://github.com/apps/opendocs/installations/new?state=settings",
-        GITHUB_APP_SLUG: "ignored",
-      }),
-    ).toBe("https://github.com/apps/opendocs/installations/new?state=settings");
+      resolveGitHubAppInstallUrl(
+        {
+          GITHUB_APP_INSTALL_URL:
+            "https://github.com/apps/opendocs/installations/new?state=settings",
+          GITHUB_APP_SLUG: "ignored",
+        },
+        { state: "org:org-1" },
+      ),
+    ).toBe(
+      "https://github.com/apps/opendocs/installations/new?state=org%3Aorg-1",
+    );
   });
 
   it("builds the GitHub installation URL from the app slug", () => {
-    expect(resolveGitHubAppInstallUrl({ GITHUB_APP_SLUG: "open-docs" })).toBe(
-      "https://github.com/apps/open-docs/installations/new",
+    expect(
+      resolveGitHubAppInstallUrl(
+        { GITHUB_APP_SLUG: "open-docs" },
+        { state: "org:org-1" },
+      ),
+    ).toBe(
+      "https://github.com/apps/open-docs/installations/new?state=org%3Aorg-1",
     );
   });
 

--- a/tests/github-app-setup.test.ts
+++ b/tests/github-app-setup.test.ts
@@ -51,12 +51,78 @@ describe("github app setup helpers", () => {
     ]);
     expect(getTokenMock).toHaveBeenCalledWith({ installationId: "123" });
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.github.com/installation/repositories?per_page=100",
+      "https://api.github.com/installation/repositories?per_page=100&page=1",
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: "Bearer installation-token",
         }),
       }),
+    );
+  });
+
+  it("hydrates repositories across every GitHub pagination page", async () => {
+    getTokenMock.mockResolvedValue({ token: "installation-token" });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({
+          link: '<https://api.github.com/installation/repositories?per_page=100&page=2>; rel="next"',
+        }),
+        json: async () => ({
+          repositories: [
+            {
+              full_name: "namuh-eng/repo-1",
+              default_branch: "main",
+              permissions: { pull: true },
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers(),
+        json: async () => ({
+          repositories: [
+            {
+              full_name: "namuh-eng/repo-2",
+              default_branch: "develop",
+              permissions: { maintain: true, pull: true },
+            },
+          ],
+        }),
+      });
+
+    const { hydrateGitHubInstallationRepos } = await import(
+      "@/lib/github-app-setup"
+    );
+
+    await expect(
+      hydrateGitHubInstallationRepos("123", {
+        fetchImpl: fetchMock,
+        getToken: getTokenMock,
+      }),
+    ).resolves.toEqual([
+      {
+        fullName: "namuh-eng/repo-1",
+        branch: "main",
+        permissions: "read",
+      },
+      {
+        fullName: "namuh-eng/repo-2",
+        branch: "develop",
+        permissions: "write",
+      },
+    ]);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.github.com/installation/repositories?per_page=100&page=1",
+      expect.any(Object),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.github.com/installation/repositories?per_page=100&page=2",
+      expect.any(Object),
     );
   });
 });


### PR DESCRIPTION
## Summary\n- carry org context through the GitHub App install URL via state\n- validate callback membership against that explicit org and reject ambiguous stateless multi-org callbacks\n- hydrate all GitHub App installation repository pages instead of only the first 100\n\n## Tests\n- make check\n- NODE_OPTIONS=--localstorage-file=/tmp/opendocs-node-localstorage.json make test\n- vitest run tests/github-app-install.test.ts tests/github-app-callback-route.test.ts tests/github-app-setup.test.ts\n\n## Notes\n- Live GitHub callback not exercised locally because it requires a real GitHub App installation redirect/token flow.\n