### PR TITLE
Constrain same-app server fetch origin

### DIFF
--- a/src/lib/app-url.ts
+++ b/src/lib/app-url.ts
@@ -1,6 +1,10 @@
+function normalizeConfiguredUrl(url: string) {
+  return url.trim().replace(/\/+$/, "");
+}
+
 export function getPublicAppUrl() {
   const url = process.env.NEXT_PUBLIC_APP_URL?.trim();
-  if (url) return url.replace(/\/+$/, "");
+  if (url) return normalizeConfiguredUrl(url);
   if (process.env.NODE_ENV === "production") {
     throw new Error("NEXT_PUBLIC_APP_URL is required in production");
   }
@@ -11,19 +15,60 @@ function firstForwardedValue(value: string | null): string | null {
   return value?.split(",")[0]?.trim() || null;
 }
 
-/** Build the app origin for the current request, preferring proxy headers. */
-export function getRequestAppUrl(headers: Headers) {
+function isLocalhost(hostname: string) {
+  return (
+    hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]"
+  );
+}
+
+function normalizeOrigin(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:")
+      return null;
+    return parsed.origin;
+  } catch {
+    return null;
+  }
+}
+
+function buildRequestOrigin(headers: Headers): string | null {
   const forwardedHost = firstForwardedValue(headers.get("x-forwarded-host"));
   const host = forwardedHost ?? headers.get("host")?.trim();
 
-  if (!host) return getPublicAppUrl();
+  if (!host) return null;
 
   const forwardedProto = firstForwardedValue(headers.get("x-forwarded-proto"));
   const protocol =
-    forwardedProto ??
-    (host.startsWith("localhost") || host.startsWith("127.0.0.1")
-      ? "http"
-      : "https");
+    forwardedProto === "http" || forwardedProto === "https"
+      ? forwardedProto
+      : host.startsWith("localhost") || host.startsWith("127.0.0.1")
+        ? "http"
+        : "https";
 
-  return `${protocol}://${host}`.replace(/\/+$/, "");
+  return normalizeOrigin(`${protocol}://${host}`);
+}
+
+/**
+ * Resolve a same-app origin without trusting arbitrary request Host headers.
+ *
+ * Production server fetches must not derive their credential-bearing target from
+ * x-forwarded-host/host. Only the configured app URL is trusted there. In local
+ * development, localhost request ports are allowed so multiple dev servers can
+ * call their own route handlers without rewriting NEXT_PUBLIC_APP_URL.
+ */
+export function getRequestAppUrl(headers: Headers) {
+  const configuredUrl = getPublicAppUrl();
+  const configuredOrigin = normalizeOrigin(configuredUrl) ?? configuredUrl;
+  const requestOrigin = buildRequestOrigin(headers);
+
+  if (!requestOrigin) return configuredUrl;
+  if (requestOrigin === configuredOrigin) return requestOrigin;
+
+  if (process.env.NODE_ENV !== "production") {
+    const parsedRequestOrigin = new URL(requestOrigin);
+    if (isLocalhost(parsedRequestOrigin.hostname)) return requestOrigin;
+  }
+
+  return configuredUrl;
 }

--- a/tests/app-url.test.ts
+++ b/tests/app-url.test.ts
@@ -42,7 +42,9 @@ describe("getRequestAppUrl", () => {
     );
   });
 
-  it("prefers forwarded proxy origin", () => {
+  it("prefers forwarded proxy origin when it matches the configured app URL", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://opendocs.namuh.co");
+
     expect(
       getRequestAppUrl(
         new Headers({
@@ -52,6 +54,29 @@ describe("getRequestAppUrl", () => {
         }),
       ),
     ).toBe("https://opendocs.namuh.co");
+  });
+
+  it("falls back to the configured app URL for spoofed forwarded hosts", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://opendocs.namuh.co");
+
+    expect(
+      getRequestAppUrl(
+        new Headers({
+          host: "opendocs.namuh.co",
+          "x-forwarded-host": "evil.example",
+          "x-forwarded-proto": "https",
+        }),
+      ),
+    ).toBe("https://opendocs.namuh.co");
+  });
+
+  it("does not trust localhost request hosts in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://opendocs.namuh.co");
+
+    expect(getRequestAppUrl(new Headers({ host: "localhost:3016" }))).toBe(
+      "https://opendocs.namuh.co",
+    );
   });
 
   it("falls back to public app URL when request host is unavailable", () => {


### PR DESCRIPTION
## What
- Fixes AI cleanup finding #1 by preventing request Host / x-forwarded-host from becoming a trusted server-fetch origin in production.
- Keeps localhost request ports available for local dev only.
- Adds regression coverage for spoofed forwarded hosts and production localhost rejection.

## Why
Dashboard analytics requests forward the user Cookie header, so their absolute same-app URL must come from an allowlisted/trusted origin rather than arbitrary request headers.

## Validation
- `npx vitest run tests/app-url.test.ts`
- `make check`
- `NODE_OPTIONS=--no-experimental-webstorage make test`
- `git diff --check`
- `BETTER_AUTH_URL=http://localhost:3015 NEXT_PUBLIC_APP_URL=http://localhost:3015 BETTER_AUTH_SECRET=local-build-secret-local-build-secret npm run build`

## Notes
- Build still logs missing Google OAuth env warnings in local dummy-env mode; build exits 0.

Closes cleanup finding #1 from PR #183 review.