### PR TITLE
Fix dashboard theme compatibility cleanup

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -211,22 +211,21 @@ body {
   border-color: var(--od-border);
 }
 
+/* Temporary bridge for legacy dark utility classes inside the app shell.
+   Keep this list shrinking: migrate touched surfaces to od-* tokens instead of
+   adding new Tailwind dark selectors here. */
 .od-app-shell .text-white,
-.od-app-shell .text-white\/80,
-.od-app-shell .text-zinc-200,
-.od-app-shell .text-zinc-300 {
+.od-app-shell .text-white\/80 {
   color: var(--od-text);
 }
 
 .od-app-shell .text-gray-300,
-.od-app-shell .text-gray-400,
-.od-app-shell .text-zinc-400 {
+.od-app-shell .text-gray-400 {
   color: var(--od-text-muted);
 }
 
 .od-app-shell .text-gray-500,
-.od-app-shell .text-gray-600,
-.od-app-shell .text-zinc-500 {
+.od-app-shell .text-gray-600 {
   color: var(--od-text-subtle);
 }
 
@@ -235,14 +234,12 @@ body {
 .od-app-shell .border-white\/\[0\.04\],
 .od-app-shell .border-white\/10,
 .od-app-shell .border-gray-700,
-.od-app-shell .border-gray-800,
-.od-app-shell .border-zinc-700 {
+.od-app-shell .border-gray-800 {
   border-color: var(--od-border);
 }
 
 .od-app-shell .divide-white\/\[0\.04\] > :not([hidden]) ~ :not([hidden]),
-.od-app-shell .divide-white\/\[0\.06\] > :not([hidden]) ~ :not([hidden]),
-.od-app-shell .divide-zinc-700\/50 > :not([hidden]) ~ :not([hidden]) {
+.od-app-shell .divide-white\/\[0\.06\] > :not([hidden]) ~ :not([hidden]) {
   border-color: var(--od-border-light);
 }
 
@@ -253,11 +250,6 @@ body {
 .od-app-shell .bg-\[\#161616\],
 .od-app-shell .bg-\[\#1e1e1e\],
 .od-app-shell .bg-\[\#2a2a2a\],
-.od-app-shell .bg-zinc-800,
-.od-app-shell .bg-zinc-800\/10,
-.od-app-shell .bg-zinc-800\/20,
-.od-app-shell .bg-zinc-800\/40,
-.od-app-shell .bg-zinc-800\/60,
 .od-app-shell .bg-gray-900\/50,
 .od-app-shell .bg-white\/\[0\.03\],
 .od-app-shell .bg-white\/\[0\.04\],
@@ -281,8 +273,7 @@ body {
 .od-app-shell .hover\:bg-white\/\[0\.04\]:hover,
 .od-app-shell .hover\:bg-white\/\[0\.06\]:hover,
 .od-app-shell .hover\:bg-white\/\[0\.08\]:hover,
-.od-app-shell .hover\:bg-white\/10:hover,
-.od-app-shell .hover\:bg-zinc-700\/50:hover {
+.od-app-shell .hover\:bg-white\/10:hover {
   background-color: var(--od-panel-muted);
 }
 

--- a/src/app/products/mcp/mcp-page-client.tsx
+++ b/src/app/products/mcp/mcp-page-client.tsx
@@ -40,20 +40,22 @@ export function McpPageClient({ projectSlug }: { projectSlug: string }) {
   return (
     <div className="mx-auto max-w-3xl space-y-8 p-6">
       {/* Breadcrumb + Beta badge */}
-      <div className="flex items-center gap-2 text-sm text-zinc-400">
+      <div className="flex items-center gap-2 text-sm text-[var(--od-text-muted)]">
         <span>Agents</span>
         <span>/</span>
-        <span className="text-white font-medium">MCP</span>
-        <span className="ml-1 rounded bg-emerald-600/20 px-1.5 py-0.5 text-[11px] font-semibold uppercase tracking-wider text-emerald-400">
+        <span className="font-medium text-[var(--od-text)]">MCP</span>
+        <span className="ml-1 rounded bg-[var(--od-accent-soft)] px-1.5 py-0.5 text-[11px] font-semibold uppercase tracking-wider text-[var(--od-accent-text)]">
           Beta
         </span>
       </div>
 
       {/* Hosted MCP server */}
       <section className="space-y-3">
-        <h2 className="text-xl font-semibold text-white">Hosted MCP server</h2>
+        <h2 className="text-xl font-semibold text-[var(--od-text)]">
+          Hosted MCP server
+        </h2>
         <div className="flex items-center gap-3">
-          <p className="text-sm text-zinc-400">
+          <p className="text-sm text-[var(--od-text-muted)]">
             Access your MCP server and preview available tools
           </p>
           <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-emerald-500/10 text-emerald-500 text-[10px] font-medium border border-emerald-500/20">
@@ -65,26 +67,26 @@ export function McpPageClient({ projectSlug }: { projectSlug: string }) {
           href="https://mintlify.com/docs/mcp"
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 text-sm text-emerald-400 hover:text-emerald-300"
+          className="inline-flex items-center gap-1 text-sm text-[var(--od-accent)] hover:text-[var(--od-accent-strong)]"
         >
           Learn more
           <ExternalLink size={14} />
         </a>
 
         {/* URL bar */}
-        <div className="flex items-center gap-0 overflow-hidden rounded-lg border border-zinc-700 bg-zinc-800/60">
-          <span className="shrink-0 border-r border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-400">
+        <div className="flex items-center gap-0 overflow-hidden rounded-lg border border-[var(--od-border)] bg-[var(--od-panel)] shadow-[var(--od-shadow)]">
+          <span className="shrink-0 border-r border-[var(--od-border)] bg-[var(--od-panel-muted)] px-3 py-2 text-sm text-[var(--od-text-muted)]">
             https://
           </span>
           <input
             readOnly
             value={`${projectSlug}.mintlify.app/mcp`}
-            className="min-w-0 flex-1 bg-transparent px-3 py-2 text-sm text-zinc-200 outline-none"
+            className="min-w-0 flex-1 bg-transparent px-3 py-2 text-sm text-[var(--od-text)] outline-none"
           />
           <button
             type="button"
             onClick={handleCopy}
-            className="shrink-0 border-l border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-300 hover:bg-zinc-700/50 hover:text-white transition-colors flex items-center gap-1.5"
+            className="shrink-0 border-l border-[var(--od-border)] px-4 py-2 text-sm font-medium text-[var(--od-text-muted)] transition-colors hover:bg-[var(--od-panel-muted)] hover:text-[var(--od-text)] flex items-center gap-1.5"
           >
             {copied ? (
               <>
@@ -99,7 +101,7 @@ export function McpPageClient({ projectSlug }: { projectSlug: string }) {
             )}
           </button>
         </div>
-        <p className="text-xs text-zinc-500">
+        <p className="text-xs text-[var(--od-text-subtle)]">
           Use the above URL to connect AI applications to your content
         </p>
       </section>
@@ -107,8 +109,10 @@ export function McpPageClient({ projectSlug }: { projectSlug: string }) {
       {/* Available tools */}
       <section className="space-y-4">
         <div>
-          <h2 className="text-xl font-semibold text-white">Available tools</h2>
-          <p className="mt-1 text-sm text-zinc-400">
+          <h2 className="text-xl font-semibold text-[var(--od-text)]">
+            Available tools
+          </h2>
+          <p className="mt-1 text-sm text-[var(--od-text-muted)]">
             Tools exposed to connected AI clients
           </p>
         </div>
@@ -117,15 +121,15 @@ export function McpPageClient({ projectSlug }: { projectSlug: string }) {
           {tools.map((tool) => (
             <div
               key={tool.name}
-              className="rounded-lg border border-zinc-700 bg-zinc-800/40 p-4"
+              className="rounded-lg border border-[var(--od-border)] bg-[var(--od-panel)] shadow-[var(--od-shadow)] p-4"
             >
               <div className="mb-2 flex items-center gap-2">
-                <Sparkles size={16} className="text-zinc-400" />
-                <span className="font-mono text-sm font-semibold text-white">
+                <Sparkles size={16} className="text-[var(--od-text-muted)]" />
+                <span className="font-mono text-sm font-semibold text-[var(--od-text)]">
                   {tool.name}
                 </span>
               </div>
-              <p className="text-sm leading-relaxed text-zinc-400">
+              <p className="text-sm leading-relaxed text-[var(--od-text-muted)]">
                 {tool.description}
               </p>
             </div>
@@ -136,26 +140,28 @@ export function McpPageClient({ projectSlug }: { projectSlug: string }) {
       {/* Analytics integrated into MCP dashboard */}
       <section className="space-y-4">
         <div>
-          <h2 className="text-xl font-semibold text-white">Recent activity</h2>
-          <p className="mt-1 text-sm text-zinc-400">
+          <h2 className="text-xl font-semibold text-[var(--od-text)]">
+            Recent activity
+          </h2>
+          <p className="mt-1 text-sm text-[var(--od-text-muted)]">
             Monitor search requests processed via MCP
           </p>
         </div>
 
         {loadingAnalytics ? (
-          <div className="h-24 rounded-lg border border-dashed border-zinc-700 animate-pulse bg-zinc-800/20" />
+          <div className="h-24 rounded-lg border border-dashed border-[var(--od-border)] animate-pulse bg-[var(--od-panel-muted)]" />
         ) : searches.length > 0 ? (
-          <div className="rounded-lg border border-zinc-700 bg-zinc-800/20 overflow-hidden">
-            <div className="divide-y divide-zinc-700/50">
+          <div className="rounded-lg border border-[var(--od-border)] bg-[var(--od-panel)] shadow-[var(--od-shadow)] overflow-hidden">
+            <div className="divide-y divide-[var(--od-border-light)]">
               {searches.map((s) => (
                 <div
                   key={`${s.createdAt}:${s.query}`}
                   className="px-4 py-3 text-sm flex items-center justify-between"
                 >
-                  <span className="text-zinc-300 truncate max-w-[400px] font-mono text-xs">
+                  <span className="truncate max-w-[400px] font-mono text-xs text-[var(--od-text-muted)]">
                     {s.query}
                   </span>
-                  <span className="text-zinc-500 text-[11px]">
+                  <span className="text-[11px] text-[var(--od-text-subtle)]">
                     {new Date(s.createdAt).toLocaleTimeString()}
                   </span>
                 </div>
@@ -163,8 +169,8 @@ export function McpPageClient({ projectSlug }: { projectSlug: string }) {
             </div>
           </div>
         ) : (
-          <div className="rounded-lg border border-dashed border-zinc-700 p-8 text-center bg-zinc-800/10">
-            <p className="text-sm text-zinc-500">
+          <div className="rounded-lg border border-dashed border-[var(--od-border)] p-8 text-center bg-[var(--od-panel-muted)]">
+            <p className="text-sm text-[var(--od-text-subtle)]">
               No recent MCP activity recorded
             </p>
           </div>

--- a/tests/dashboard-theme-css.test.ts
+++ b/tests/dashboard-theme-css.test.ts
@@ -1,22 +1,127 @@
 import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 const globalsCss = readFileSync("src/app/globals.css", "utf8");
+const mcpPageSource = readFileSync(
+  "src/app/products/mcp/mcp-page-client.tsx",
+  "utf8",
+);
+const dashboardCss = globalsCss.slice(
+  globalsCss.indexOf(":root"),
+  globalsCss.indexOf("/* ── Docs Site Layout"),
+);
+
+function injectDashboardCss() {
+  const style = document.createElement("style");
+  style.textContent = dashboardCss;
+  document.head.append(style);
+}
+
+function matchedDeclaration(element: Element, property: string) {
+  const values: string[] = [];
+
+  for (const sheet of Array.from(document.styleSheets)) {
+    for (const rule of Array.from(sheet.cssRules)) {
+      if (!(rule instanceof CSSStyleRule)) continue;
+
+      try {
+        if (element.matches(rule.selectorText)) {
+          const value = rule.style.getPropertyValue(property).trim();
+          if (value) values.push(value);
+        }
+      } catch {
+        // Ignore selectors unsupported by jsdom; they are not part of this
+        // behavior check.
+      }
+    }
+  }
+
+  return values.at(-1);
+}
 
 describe("dashboard shell theme CSS", () => {
-  it("maps editor dark canvas classes to dashboard design tokens", () => {
-    expect(globalsCss).toContain(".od-app-shell .bg-\\[\\#0c0c0c\\]");
-    expect(globalsCss).toContain(".od-app-shell .bg-\\[\\#0a0a0a\\]");
-    expect(globalsCss).toContain(".od-app-shell .bg-\\[\\#101010\\]");
-    expect(globalsCss).toContain(".od-app-shell .text-emerald-200");
+  beforeEach(() => {
+    document.head.innerHTML = "";
+    document.body.innerHTML = "";
   });
 
-  it("maps zinc-based product panels to dashboard design tokens", () => {
-    expect(globalsCss).toContain(".od-app-shell .bg-zinc-800\\/60");
-    expect(globalsCss).toContain(".od-app-shell .border-zinc-700");
-    expect(globalsCss).toContain(".od-app-shell .text-zinc-400");
-    expect(globalsCss).toContain(
-      ".od-app-shell .hover\\:bg-zinc-700\\/50:hover",
+  it("applies od-token surface utilities to rendered dashboard elements", () => {
+    injectDashboardCss();
+    document.body.innerHTML = `
+      <main class="od-app-shell">
+        <section data-testid="card" class="od-card">
+          <p data-testid="muted" class="od-muted">Muted copy</p>
+        </section>
+        <table>
+          <thead>
+            <tr data-testid="table-head" class="od-table-head"></tr>
+          </thead>
+          <tbody>
+            <tr data-testid="row" class="od-row-divider"></tr>
+          </tbody>
+        </table>
+      </main>
+    `;
+
+    const card = document.querySelector("[data-testid='card']");
+    const muted = document.querySelector("[data-testid='muted']");
+    const tableHead = document.querySelector("[data-testid='table-head']");
+    const row = document.querySelector("[data-testid='row']");
+
+    expect(card).not.toBeNull();
+    expect(matchedDeclaration(card as Element, "background")).toBe(
+      "var(--od-panel)",
     );
+    expect(matchedDeclaration(card as Element, "border")).toBe(
+      "1px solid var(--od-border)",
+    );
+    expect(muted).not.toBeNull();
+    expect(getComputedStyle(muted as Element).color).toBe(
+      "var(--od-text-muted)",
+    );
+    expect(tableHead).not.toBeNull();
+    expect(matchedDeclaration(tableHead as Element, "background")).toBe(
+      "var(--od-panel-muted)",
+    );
+    expect(row).not.toBeNull();
+    expect(matchedDeclaration(row as Element, "border-color")).toBe(
+      "var(--od-border)",
+    );
+  });
+
+  it("keeps remaining legacy dark utility bridge behavior scoped to old classes", () => {
+    injectDashboardCss();
+    document.body.innerHTML = `
+      <main class="od-app-shell">
+        <section
+          data-testid="legacy-card"
+          class="bg-[#0c0c0c] border-white/[0.08] text-white"
+        >
+          Legacy surface
+        </section>
+      </main>
+    `;
+
+    const legacyCard = document.querySelector("[data-testid='legacy-card']");
+
+    expect(legacyCard).not.toBeNull();
+    expect(matchedDeclaration(legacyCard as Element, "background-color")).toBe(
+      "var(--od-panel)",
+    );
+    expect(matchedDeclaration(legacyCard as Element, "border-color")).toBe(
+      "var(--od-border)",
+    );
+    expect(getComputedStyle(legacyCard as Element).color).toBe(
+      "var(--od-text)",
+    );
+  });
+
+  it("does not keep zinc compatibility selectors after migrating the MCP surface", () => {
+    expect(globalsCss).not.toMatch(/\.od-app-shell \.bg-zinc-/);
+    expect(globalsCss).not.toMatch(/\.od-app-shell \.border-zinc-/);
+    expect(globalsCss).not.toMatch(/\.od-app-shell \.divide-zinc-/);
+    expect(globalsCss).not.toMatch(/\.od-app-shell \.text-zinc-/);
+    expect(globalsCss).not.toMatch(/\.od-app-shell \.hover\\:bg-zinc-/);
+    expect(mcpPageSource).not.toMatch(/\bzinc-/);
   });
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,49 @@
+function createMemoryStorage(): Storage {
+  const entries = new Map<string, string>();
+
+  return {
+    get length() {
+      return entries.size;
+    },
+    clear() {
+      entries.clear();
+    },
+    getItem(key: string) {
+      return entries.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(entries.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      entries.delete(key);
+    },
+    setItem(key: string, value: string) {
+      entries.set(key, value);
+    },
+  };
+}
+
+function getUsableStorage(storage: Storage | undefined): Storage {
+  return typeof storage?.getItem === "function" &&
+    typeof storage.setItem === "function" &&
+    typeof storage.clear === "function"
+    ? storage
+    : createMemoryStorage();
+}
+
+function installStorageGlobal(name: "localStorage" | "sessionStorage") {
+  if (typeof window === "undefined") return;
+
+  const storage = getUsableStorage(window[name]);
+  Object.defineProperty(window, name, {
+    configurable: true,
+    value: storage,
+  });
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    value: storage,
+  });
+}
+
+installStorageGlobal("localStorage");
+installStorageGlobal("sessionStorage");

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: "jsdom",
-    setupFiles: [],
+    setupFiles: ["./tests/setup.ts"],
     include: ["tests/**/*.test.{ts,tsx}"],
   },
   resolve: {


### PR DESCRIPTION
## Summary\n- migrate the MCP dashboard surface from legacy zinc/dark Tailwind utilities to OpenDocs design tokens\n- remove the now-unused zinc selectors from the temporary .od-app-shell compatibility bridge and mark the bridge as shrinking-only\n- replace selector-presence CSS coverage with rendered selector/declaration checks and guard against reintroducing zinc shim coverage\n- add a Vitest setup shim so local Node 25's incomplete global localStorage does not override jsdom storage during tests\n\n## Verification\n- npm test -- tests/dashboard-theme-css.test.ts\n- npm test -- tests/dashboard-shell-preferences.test.ts tests/docs-site-layout.test.ts tests/new-project-page.test.tsx tests/dashboard-theme-css.test.ts\n- make check\n- make test (1831 passed)\n\n## Notes\n- Ever browser visual QA was not run for this CSS-only cleanup; automated CSS and full unit gates are green.