### PR TITLE
Expose organization billing settings UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,3 +49,9 @@ TEST_ACCOUNT_EMAIL=your-google-email@gmail.com
 
 # Dashboard -- simple auth key for the admin dashboard
 DASHBOARD_KEY=your-dashboard-key
+
+# Billing -- optional Stripe settings for commercial hosted plans
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+STRIPE_PRICE_ID_PRO=
+STRIPE_CUSTOMER_PORTAL_RETURN_URL=

--- a/README.md
+++ b/README.md
@@ -160,6 +160,17 @@ GITHUB_APP_SLUG=your-github-app-slug
 GITHUB_APP_INSTALL_URL=https://github.com/apps/your-github-app-slug/installations/new
 ```
 
+### Billing (optional, commercial hosted plans)
+
+The billing settings page calls the application billing API for Stripe Checkout and Customer Portal redirects. Configure these in the billing API lane when paid plans are enabled; local UI tests do not require live Stripe credentials.
+
+```bash
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+STRIPE_PRICE_ID_PRO=
+STRIPE_CUSTOMER_PORTAL_RETURN_URL=
+```
+
 Google OAuth must include this production redirect URI:
 
 ```text

--- a/src/app/settings/organization/billing/billing-settings-client.tsx
+++ b/src/app/settings/organization/billing/billing-settings-client.tsx
@@ -7,7 +7,7 @@ import {
   createBillingRedirect,
   formatBillingLimit,
   getBillingPlanDetails,
-} from "@/lib/billing";
+} from "@/lib/billing-client";
 import { clsx } from "clsx";
 import { ArrowUpRight, CreditCard, Loader2, ShieldCheck } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";

--- a/src/app/settings/organization/billing/billing-settings-client.tsx
+++ b/src/app/settings/organization/billing/billing-settings-client.tsx
@@ -1,0 +1,376 @@
+"use client";
+
+import {
+  BILLING_API_CONTRACTS,
+  type BillingUsageSummary,
+  calculateBillingUsagePercent,
+  createBillingRedirect,
+  formatBillingLimit,
+  getBillingPlanDetails,
+} from "@/lib/billing";
+import { clsx } from "clsx";
+import { ArrowUpRight, CreditCard, Loader2, ShieldCheck } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+
+interface BillingSettingsClientProps {
+  initialPlan?: string;
+  redirectTo?: (url: string) => void;
+}
+
+type BillingAction = "checkout" | "portal";
+
+interface OrganizationLike {
+  plan?: string;
+}
+
+interface ProjectLike {
+  id: string;
+}
+
+interface AssistantUsageLike {
+  messagesUsed?: number;
+  messageLimit?: number;
+}
+
+const DEFAULT_USAGE: BillingUsageSummary = {
+  projectsUsed: null,
+  projectLimit: null,
+  assistantMessagesUsed: null,
+  assistantMessageLimit: null,
+};
+
+export function BillingSettingsClient({
+  initialPlan = "free",
+  redirectTo = (url: string) => window.location.assign(url),
+}: BillingSettingsClientProps) {
+  const [plan, setPlan] = useState(initialPlan);
+  const [usage, setUsage] = useState<BillingUsageSummary>(DEFAULT_USAGE);
+  const [loadingState, setLoadingState] = useState(true);
+  const [actionLoading, setActionLoading] = useState<BillingAction | null>(
+    null,
+  );
+  const [message, setMessage] = useState<{
+    type: "info" | "error";
+    text: string;
+  } | null>(null);
+
+  const planDetails = getBillingPlanDetails(plan);
+  const resolvedUsage: BillingUsageSummary = {
+    projectsUsed: usage.projectsUsed,
+    projectLimit: usage.projectLimit ?? planDetails.projectLimit,
+    assistantMessagesUsed: usage.assistantMessagesUsed,
+    assistantMessageLimit:
+      usage.assistantMessageLimit ?? planDetails.assistantMessageLimit,
+  };
+
+  const fetchBillingState = useCallback(async () => {
+    setLoadingState(true);
+    try {
+      const [orgsResult, projectsResult, assistantUsageResult] =
+        await Promise.allSettled([
+          fetch("/api/orgs"),
+          fetch("/api/projects"),
+          fetch("/api/assistant/usage"),
+        ]);
+
+      if (orgsResult.status === "fulfilled" && orgsResult.value.ok) {
+        const data = (await orgsResult.value.json()) as {
+          orgs?: OrganizationLike[];
+        };
+        const orgPlan = data.orgs?.[0]?.plan;
+        if (orgPlan) setPlan(orgPlan);
+      }
+
+      let projectsUsed: number | null = null;
+      if (projectsResult.status === "fulfilled" && projectsResult.value.ok) {
+        const data = (await projectsResult.value.json()) as {
+          projects?: ProjectLike[];
+        };
+        projectsUsed = Array.isArray(data.projects)
+          ? data.projects.length
+          : null;
+      }
+
+      let assistantMessagesUsed: number | null = null;
+      let assistantMessageLimit: number | null = null;
+      if (
+        assistantUsageResult.status === "fulfilled" &&
+        assistantUsageResult.value.ok
+      ) {
+        const data = (await assistantUsageResult.value.json()) as {
+          usage?: AssistantUsageLike;
+        };
+        if (typeof data.usage?.messagesUsed === "number") {
+          assistantMessagesUsed = data.usage.messagesUsed;
+        }
+        if (typeof data.usage?.messageLimit === "number") {
+          assistantMessageLimit = data.usage.messageLimit;
+        }
+      }
+
+      setUsage({
+        projectsUsed,
+        projectLimit: null,
+        assistantMessagesUsed,
+        assistantMessageLimit,
+      });
+    } catch {
+      setMessage({
+        type: "info",
+        text: "Billing state is using plan defaults because live usage could not be loaded.",
+      });
+    } finally {
+      setLoadingState(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchBillingState();
+  }, [fetchBillingState]);
+
+  const startBillingFlow = async (action: BillingAction) => {
+    setActionLoading(action);
+    setMessage(null);
+    const endpoint =
+      action === "checkout" ? "/api/billing/checkout" : "/api/billing/portal";
+    const result = await createBillingRedirect(endpoint);
+    if (!result.ok) {
+      setMessage({ type: "error", text: result.error });
+      setActionLoading(null);
+      return;
+    }
+
+    redirectTo(result.url);
+  };
+
+  return (
+    <div className="p-6 max-w-4xl" data-testid="billing-settings-page">
+      <div className="mb-1 text-sm text-gray-400">
+        Settings / Organization / Billing
+      </div>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-white">Billing</h1>
+          <p className="mt-2 max-w-2xl text-sm text-gray-400">
+            OpenDocs is open-source software. This page manages Namuh commercial
+            billing for hosted plans or supported self-hosted deployments.
+          </p>
+        </div>
+        <span
+          className="inline-flex w-fit items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-sm font-medium text-emerald-300"
+          data-testid="billing-status"
+        >
+          <ShieldCheck size={15} />
+          {planDetails.statusLabel}
+        </span>
+      </div>
+
+      <div className="mt-6 grid gap-4 lg:grid-cols-[1.2fr_0.8fr]">
+        <section className="rounded-xl border border-white/[0.08] bg-[#1a1a1a] p-6">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-sm text-gray-400">Current plan</p>
+              <h2 className="mt-1 text-3xl font-semibold text-white">
+                {planDetails.label}
+              </h2>
+              <p className="mt-2 text-sm text-gray-400">
+                {planDetails.summary}
+              </p>
+            </div>
+            <div className="rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-3 text-right">
+              <p className="text-xs uppercase tracking-wide text-gray-500">
+                Price
+              </p>
+              <p className="text-sm font-medium text-white">
+                {planDetails.monthlyPriceLabel}
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-6 flex flex-wrap gap-3">
+            <BillingButton
+              loading={actionLoading === "checkout"}
+              disabled={actionLoading !== null}
+              onClick={() => startBillingFlow("checkout")}
+              testId="billing-checkout-btn"
+            >
+              {planDetails.plan === "free"
+                ? "Upgrade / Subscribe"
+                : "Change plan"}
+            </BillingButton>
+            <BillingButton
+              variant="secondary"
+              loading={actionLoading === "portal"}
+              disabled={actionLoading !== null}
+              onClick={() => startBillingFlow("portal")}
+              testId="billing-portal-btn"
+            >
+              Manage billing
+            </BillingButton>
+          </div>
+
+          {message && (
+            <p
+              className={clsx(
+                "mt-4 rounded-lg border px-3 py-2 text-sm",
+                message.type === "error"
+                  ? "border-red-500/30 bg-red-500/10 text-red-300"
+                  : "border-amber-500/30 bg-amber-500/10 text-amber-200",
+              )}
+              data-testid="billing-message"
+            >
+              {message.text}
+            </p>
+          )}
+        </section>
+
+        <section className="rounded-xl border border-white/[0.08] bg-[#1a1a1a] p-6">
+          <h2 className="text-lg font-semibold text-white">Included limits</h2>
+          <p className="mt-1 text-sm text-gray-400">
+            Defaults are shown when the billing API lane has not supplied live
+            account limits yet.
+          </p>
+          <ul className="mt-4 space-y-3 text-sm text-gray-300">
+            {planDetails.features.map((feature) => (
+              <li key={feature} className="flex items-center gap-2">
+                <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
+                {feature}
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+
+      <section className="mt-6 rounded-xl border border-white/[0.08] bg-[#1a1a1a] p-6">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold text-white">Usage & limits</h2>
+            <p className="mt-1 text-sm text-gray-400">
+              Usage comes from existing OpenDocs project and assistant endpoints
+              when available.
+            </p>
+          </div>
+          {loadingState && (
+            <span className="inline-flex items-center gap-2 text-sm text-gray-400">
+              <Loader2 size={14} className="animate-spin" /> Loading usage
+            </span>
+          )}
+        </div>
+
+        <div className="mt-5 grid gap-4 md:grid-cols-2">
+          <UsageCard
+            label="Docs projects"
+            used={resolvedUsage.projectsUsed}
+            limit={resolvedUsage.projectLimit}
+            fallback="Project usage is not available yet."
+            noun="projects"
+          />
+          <UsageCard
+            label="Assistant messages"
+            used={resolvedUsage.assistantMessagesUsed}
+            limit={resolvedUsage.assistantMessageLimit}
+            fallback="Assistant usage is not available yet."
+            noun="messages"
+          />
+        </div>
+      </section>
+
+      <section className="mt-6 rounded-xl border border-white/[0.08] bg-[#141414] p-5">
+        <h2 className="text-sm font-semibold text-white">API assumptions</h2>
+        <p className="mt-2 text-sm text-gray-400">
+          Checkout and customer portal redirects intentionally come from the
+          application API, not hardcoded Stripe URLs.
+        </p>
+        <ul className="mt-3 space-y-1 font-mono text-xs text-gray-500">
+          <li>{BILLING_API_CONTRACTS.checkout}</li>
+          <li>{BILLING_API_CONTRACTS.portal}</li>
+        </ul>
+      </section>
+    </div>
+  );
+}
+
+function BillingButton({
+  children,
+  disabled,
+  loading,
+  onClick,
+  testId,
+  variant = "primary",
+}: {
+  children: React.ReactNode;
+  disabled: boolean;
+  loading: boolean;
+  onClick: () => void;
+  testId: string;
+  variant?: "primary" | "secondary";
+}) {
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      disabled={disabled}
+      onClick={onClick}
+      className={clsx(
+        "inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+        variant === "primary"
+          ? "bg-emerald-600 text-white hover:bg-emerald-500"
+          : "border border-white/[0.08] bg-white/[0.04] text-white hover:bg-white/[0.08]",
+      )}
+    >
+      {loading ? (
+        <Loader2 size={15} className="animate-spin" />
+      ) : (
+        <CreditCard size={15} />
+      )}
+      {children}
+      {!loading && <ArrowUpRight size={14} />}
+    </button>
+  );
+}
+
+function UsageCard({
+  fallback,
+  label,
+  limit,
+  noun,
+  used,
+}: {
+  fallback: string;
+  label: string;
+  limit: number | null;
+  noun: string;
+  used: number | null;
+}) {
+  const percent = calculateBillingUsagePercent(used, limit);
+  const hasUsage = used !== null;
+
+  return (
+    <div className="rounded-lg border border-white/[0.08] bg-white/[0.03] p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-medium text-white">{label}</h3>
+          <p className="mt-1 text-xs text-gray-500">
+            {formatBillingLimit(limit, noun)} included
+          </p>
+        </div>
+        <span className="text-sm font-semibold text-white">
+          {hasUsage ? used.toLocaleString() : "—"}
+        </span>
+      </div>
+      {percent === null ? (
+        <p className="mt-4 text-sm text-gray-400">{fallback}</p>
+      ) : (
+        <>
+          <div className="mt-4 h-2 rounded-full bg-white/[0.06]">
+            <div
+              className="h-full rounded-full bg-emerald-500"
+              style={{ width: `${percent}%` }}
+            />
+          </div>
+          <p className="mt-2 text-xs text-gray-500">{percent}% used</p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/settings/organization/billing/page.tsx
+++ b/src/app/settings/organization/billing/page.tsx
@@ -1,0 +1,5 @@
+import { BillingSettingsClient } from "./billing-settings-client";
+
+export default function OrganizationBillingPage() {
+  return <BillingSettingsClient />;
+}

--- a/src/components/layout/top-bar.tsx
+++ b/src/components/layout/top-bar.tsx
@@ -221,7 +221,7 @@ export function TopBar({
               </DropdownMenu.Item>
               <DropdownMenu.Item asChild>
                 <Link
-                  href="/settings"
+                  href="/settings/organization/billing"
                   className={`flex cursor-pointer items-center gap-2.5 px-3 py-2 text-sm outline-none ${shellTheme.menuText}`}
                 >
                   <CreditCard size={14} />

--- a/src/lib/billing-client.ts
+++ b/src/lib/billing-client.ts
@@ -1,0 +1,168 @@
+export const BILLING_PLANS = ["free", "pro", "enterprise"] as const;
+
+export type BillingPlan = (typeof BILLING_PLANS)[number];
+
+export interface BillingPlanDetails {
+  plan: BillingPlan;
+  label: string;
+  statusLabel: string;
+  monthlyPriceLabel: string;
+  summary: string;
+  projectLimit: number | null;
+  assistantMessageLimit: number | null;
+  features: string[];
+}
+
+export interface BillingUsageSummary {
+  projectsUsed: number | null;
+  projectLimit: number | null;
+  assistantMessagesUsed: number | null;
+  assistantMessageLimit: number | null;
+}
+
+export interface BillingRedirectResponse {
+  url: string;
+}
+
+export const BILLING_API_CONTRACTS = {
+  checkout: "POST /api/billing/checkout returns { url: string }",
+  portal: "POST /api/billing/portal returns { url: string }",
+} as const;
+
+export const BILLING_PLAN_DETAILS: Record<BillingPlan, BillingPlanDetails> = {
+  free: {
+    plan: "free",
+    label: "Free",
+    statusLabel: "Self-hosted free",
+    monthlyPriceLabel: "$0/mo",
+    summary:
+      "Run OpenDocs yourself while you evaluate the commercial hosted features.",
+    projectLimit: 1,
+    assistantMessageLimit: 250,
+    features: ["Self-hosted docs", "One active project", "Community support"],
+  },
+  pro: {
+    plan: "pro",
+    label: "Pro",
+    statusLabel: "Active",
+    monthlyPriceLabel: "Managed in Stripe",
+    summary:
+      "Commercial plan for teams that want Namuh-hosted billing, support, and higher limits.",
+    projectLimit: 5,
+    assistantMessageLimit: 5000,
+    features: [
+      "More docs projects",
+      "Higher assistant usage",
+      "Priority support",
+    ],
+  },
+  enterprise: {
+    plan: "enterprise",
+    label: "Enterprise",
+    statusLabel: "Active",
+    monthlyPriceLabel: "Custom",
+    summary:
+      "Custom commercial plan for self-hosted or Namuh-managed deployments with negotiated limits.",
+    projectLimit: null,
+    assistantMessageLimit: null,
+    features: ["Custom limits", "Deployment support", "Commercial terms"],
+  },
+};
+
+export function normalizeBillingPlan(plan: unknown): BillingPlan {
+  return typeof plan === "string" && BILLING_PLANS.includes(plan as BillingPlan)
+    ? (plan as BillingPlan)
+    : "free";
+}
+
+export function getBillingPlanDetails(plan: unknown): BillingPlanDetails {
+  return BILLING_PLAN_DETAILS[normalizeBillingPlan(plan)];
+}
+
+export function calculateBillingUsagePercent(
+  used: number | null,
+  limit: number | null,
+): number | null {
+  if (used === null || limit === null) return null;
+  if (limit <= 0) return 0;
+  return Math.min(100, Math.round((used / limit) * 100));
+}
+
+export function formatBillingLimit(limit: number | null, noun: string): string {
+  if (limit === null) return `Unlimited ${noun}`;
+  return `${limit.toLocaleString()} ${noun}`;
+}
+
+export function isBillingRedirectResponse(
+  value: unknown,
+): value is BillingRedirectResponse {
+  if (!value || typeof value !== "object") return false;
+  const url = (value as Record<string, unknown>).url;
+  if (typeof url !== "string" || url.length === 0) return false;
+
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" || parsed.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+export async function readBillingApiError(
+  response: Response,
+  fallback: string,
+): Promise<string> {
+  try {
+    const data = (await response.json()) as { error?: unknown };
+    if (typeof data.error === "string" && data.error.trim()) {
+      return data.error;
+    }
+  } catch {
+    // Some placeholder API lanes may return an empty body or HTML 404.
+  }
+
+  if (response.status === 404) {
+    return `${fallback} Billing API is not configured yet.`;
+  }
+
+  return fallback;
+}
+
+export async function createBillingRedirect(
+  endpoint: "/api/billing/checkout" | "/api/billing/portal",
+): Promise<{ ok: true; url: string } | { ok: false; error: string }> {
+  const contract =
+    endpoint === "/api/billing/checkout"
+      ? BILLING_API_CONTRACTS.checkout
+      : BILLING_API_CONTRACTS.portal;
+  const fallback = `Expected ${contract}.`;
+
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: await readBillingApiError(response, fallback),
+      };
+    }
+
+    const data = await response.json();
+    if (!isBillingRedirectResponse(data)) {
+      return {
+        ok: false,
+        error: `${fallback} The response did not include a valid redirect URL.`,
+      };
+    }
+
+    return { ok: true, url: data.url };
+  } catch {
+    return {
+      ok: false,
+      error: `${fallback} Could not reach the billing API.`,
+    };
+  }
+}

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -1,0 +1,164 @@
+export type BillingPlan = "free" | "pro" | "enterprise";
+
+export interface BillingPlanDetails {
+  plan: BillingPlan;
+  label: string;
+  statusLabel: string;
+  monthlyPriceLabel: string;
+  summary: string;
+  projectLimit: number | null;
+  assistantMessageLimit: number | null;
+  features: string[];
+}
+
+export interface BillingUsageSummary {
+  projectsUsed: number | null;
+  projectLimit: number | null;
+  assistantMessagesUsed: number | null;
+  assistantMessageLimit: number | null;
+}
+
+export interface BillingRedirectResponse {
+  url: string;
+}
+
+export const BILLING_API_CONTRACTS = {
+  checkout: "POST /api/billing/checkout returns { url: string }",
+  portal: "POST /api/billing/portal returns { url: string }",
+} as const;
+
+export const BILLING_PLAN_DETAILS: Record<BillingPlan, BillingPlanDetails> = {
+  free: {
+    plan: "free",
+    label: "Free",
+    statusLabel: "Self-hosted free",
+    monthlyPriceLabel: "$0/mo",
+    summary:
+      "Run OpenDocs yourself while you evaluate the commercial hosted features.",
+    projectLimit: 1,
+    assistantMessageLimit: 250,
+    features: ["Self-hosted docs", "One active project", "Community support"],
+  },
+  pro: {
+    plan: "pro",
+    label: "Pro",
+    statusLabel: "Active",
+    monthlyPriceLabel: "Managed in Stripe",
+    summary:
+      "Commercial plan for teams that want Namuh-hosted billing, support, and higher limits.",
+    projectLimit: 5,
+    assistantMessageLimit: 5000,
+    features: [
+      "More docs projects",
+      "Higher assistant usage",
+      "Priority support",
+    ],
+  },
+  enterprise: {
+    plan: "enterprise",
+    label: "Enterprise",
+    statusLabel: "Active",
+    monthlyPriceLabel: "Custom",
+    summary:
+      "Custom commercial plan for self-hosted or Namuh-managed deployments with negotiated limits.",
+    projectLimit: null,
+    assistantMessageLimit: null,
+    features: ["Custom limits", "Deployment support", "Commercial terms"],
+  },
+};
+
+export function normalizeBillingPlan(plan: unknown): BillingPlan {
+  return plan === "pro" || plan === "enterprise" ? plan : "free";
+}
+
+export function getBillingPlanDetails(plan: unknown): BillingPlanDetails {
+  return BILLING_PLAN_DETAILS[normalizeBillingPlan(plan)];
+}
+
+export function calculateBillingUsagePercent(
+  used: number | null,
+  limit: number | null,
+): number | null {
+  if (used === null || limit === null) return null;
+  if (limit <= 0) return 0;
+  return Math.min(100, Math.round((used / limit) * 100));
+}
+
+export function formatBillingLimit(limit: number | null, noun: string): string {
+  if (limit === null) return `Unlimited ${noun}`;
+  return `${limit.toLocaleString()} ${noun}`;
+}
+
+export function isBillingRedirectResponse(
+  value: unknown,
+): value is BillingRedirectResponse {
+  if (!value || typeof value !== "object") return false;
+  const url = (value as Record<string, unknown>).url;
+  if (typeof url !== "string" || url.length === 0) return false;
+
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" || parsed.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+export async function readBillingApiError(
+  response: Response,
+  fallback: string,
+): Promise<string> {
+  try {
+    const data = (await response.json()) as { error?: unknown };
+    if (typeof data.error === "string" && data.error.trim()) {
+      return data.error;
+    }
+  } catch {
+    // Some placeholder API lanes may return an empty body or HTML 404.
+  }
+
+  if (response.status === 404) {
+    return `${fallback} Billing API is not configured yet.`;
+  }
+
+  return fallback;
+}
+
+export async function createBillingRedirect(
+  endpoint: "/api/billing/checkout" | "/api/billing/portal",
+): Promise<{ ok: true; url: string } | { ok: false; error: string }> {
+  const contract =
+    endpoint === "/api/billing/checkout"
+      ? BILLING_API_CONTRACTS.checkout
+      : BILLING_API_CONTRACTS.portal;
+  const fallback = `Expected ${contract}.`;
+
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: await readBillingApiError(response, fallback),
+      };
+    }
+
+    const data = await response.json();
+    if (!isBillingRedirectResponse(data)) {
+      return {
+        ok: false,
+        error: `${fallback} The response did not include a valid redirect URL.`,
+      };
+    }
+
+    return { ok: true, url: data.url };
+  } catch {
+    return {
+      ok: false,
+      error: `${fallback} Could not reach the billing API.`,
+    };
+  }
+}

--- a/src/lib/settings-nav.ts
+++ b/src/lib/settings-nav.ts
@@ -1,6 +1,7 @@
 import type { LucideIcon } from "lucide-react";
 import {
   AlertTriangle,
+  CreditCard,
   FileDown,
   GitBranch,
   GitFork,
@@ -65,6 +66,11 @@ export const SETTINGS_NAV: SettingsNavGroup[] = [
     heading: "Workspace",
     items: [
       { label: "Members", href: "/settings/workspace/members", icon: Users },
+      {
+        label: "Billing",
+        href: "/settings/organization/billing",
+        icon: CreditCard,
+      },
       {
         label: "My profile",
         href: "/settings/workspace/profile",

--- a/tests/billing-settings-client.test.tsx
+++ b/tests/billing-settings-client.test.tsx
@@ -1,0 +1,138 @@
+import { BillingSettingsClient } from "@/app/settings/organization/billing/billing-settings-client";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+function okJson(data: unknown) {
+  return { ok: true, status: 200, json: async () => data };
+}
+
+function errorJson(status: number, data: unknown) {
+  return { ok: false, status, json: async () => data };
+}
+
+async function renderBilling(
+  fetchMock: ReturnType<typeof vi.fn>,
+  redirectTo = vi.fn(),
+) {
+  vi.stubGlobal("fetch", fetchMock);
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      <BillingSettingsClient initialPlan="free" redirectTo={redirectTo} />,
+    );
+  });
+
+  return { container, root, redirectTo };
+}
+
+describe("BillingSettingsClient", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders plan and usage from existing org/project/assistant endpoints", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(okJson({ orgs: [{ plan: "pro" }] }))
+      .mockResolvedValueOnce(okJson({ projects: [{ id: "p1" }, { id: "p2" }] }))
+      .mockResolvedValueOnce(
+        okJson({ usage: { messagesUsed: 125, messageLimit: 500 } }),
+      );
+
+    const { container, root } = await renderBilling(fetchMock);
+
+    expect(container.textContent).toContain("Billing");
+    expect(container.textContent).toContain("Pro");
+    expect(container.textContent).toContain("Active");
+    expect(container.textContent).toContain("2");
+    expect(container.textContent).toContain("125");
+    expect(container.textContent).toContain("25% used");
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("redirects to the checkout URL returned by the billing API", async () => {
+    const redirectTo = vi.fn();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(okJson({ orgs: [{ plan: "free" }] }))
+      .mockResolvedValueOnce(okJson({ projects: [] }))
+      .mockResolvedValueOnce(
+        okJson({ usage: { messagesUsed: 0, messageLimit: 250 } }),
+      )
+      .mockResolvedValueOnce(
+        okJson({ url: "https://checkout.stripe.com/c/test" }),
+      );
+
+    const { container, root } = await renderBilling(fetchMock, redirectTo);
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="billing-checkout-btn"]',
+        )
+        ?.click();
+    });
+
+    expect(fetchMock).toHaveBeenLastCalledWith("/api/billing/checkout", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(redirectTo).toHaveBeenCalledWith(
+      "https://checkout.stripe.com/c/test",
+    );
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("shows a readable error when the portal API is not merged yet", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(okJson({ orgs: [{ plan: "free" }] }))
+      .mockResolvedValueOnce(okJson({ projects: [] }))
+      .mockResolvedValueOnce(
+        okJson({ usage: { messagesUsed: 0, messageLimit: 250 } }),
+      )
+      .mockResolvedValueOnce(errorJson(404, {}));
+
+    const { container, root } = await renderBilling(fetchMock);
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="billing-portal-btn"]')
+        ?.click();
+    });
+
+    expect(container.textContent).toContain("POST /api/billing/portal");
+    expect(container.textContent).toContain(
+      "Billing API is not configured yet",
+    );
+
+    act(() => root.unmount());
+    container.remove();
+  });
+});

--- a/tests/billing.test.ts
+++ b/tests/billing.test.ts
@@ -1,0 +1,77 @@
+import {
+  calculateBillingUsagePercent,
+  createBillingRedirect,
+  formatBillingLimit,
+  getBillingPlanDetails,
+  isBillingRedirectResponse,
+  normalizeBillingPlan,
+} from "@/lib/billing";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("billing utilities", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("normalizes unknown plans to free", () => {
+    expect(normalizeBillingPlan("pro")).toBe("pro");
+    expect(normalizeBillingPlan("enterprise")).toBe("enterprise");
+    expect(normalizeBillingPlan("starter")).toBe("free");
+    expect(getBillingPlanDetails("starter").label).toBe("Free");
+  });
+
+  it("formats limits and usage percentages", () => {
+    expect(formatBillingLimit(5, "projects")).toBe("5 projects");
+    expect(formatBillingLimit(null, "projects")).toBe("Unlimited projects");
+    expect(calculateBillingUsagePercent(2, 5)).toBe(40);
+    expect(calculateBillingUsagePercent(9, 5)).toBe(100);
+    expect(calculateBillingUsagePercent(null, 5)).toBeNull();
+    expect(calculateBillingUsagePercent(5, null)).toBeNull();
+    expect(calculateBillingUsagePercent(5, 0)).toBe(0);
+  });
+
+  it("validates billing redirect responses", () => {
+    expect(
+      isBillingRedirectResponse({ url: "https://checkout.stripe.com/c/test" }),
+    ).toBe(true);
+    expect(isBillingRedirectResponse({ url: "not a url" })).toBe(false);
+    expect(isBillingRedirectResponse({})).toBe(false);
+  });
+
+  it("posts to the checkout endpoint and returns redirect URL", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ url: "https://checkout.stripe.com/c/test" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      createBillingRedirect("/api/billing/checkout"),
+    ).resolves.toEqual({
+      ok: true,
+      url: "https://checkout.stripe.com/c/test",
+    });
+    expect(fetchMock).toHaveBeenCalledWith("/api/billing/checkout", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+
+  it("turns missing API routes into readable contract errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({}),
+      }),
+    );
+
+    const result = await createBillingRedirect("/api/billing/portal");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("POST /api/billing/portal");
+      expect(result.error).toContain("Billing API is not configured yet");
+    }
+  });
+});

--- a/tests/dashboard-layout.test.ts
+++ b/tests/dashboard-layout.test.ts
@@ -120,7 +120,7 @@ describe("Dashboard Layout — User Menu Items", () => {
   const menuItems = [
     { label: "Your profile", href: "/settings/workspace/profile" },
     { label: "Invite members", href: "/settings/workspace/members" },
-    { label: "Billing", href: "/settings" },
+    { label: "Billing", href: "/settings/organization/billing" },
     { label: "Documentation", href: "/docs", external: true },
     { label: "Contact support", href: "mailto:support@example.com" },
     { label: "Log Out", action: "logout" },

--- a/tests/settings-nav.test.ts
+++ b/tests/settings-nav.test.ts
@@ -54,9 +54,12 @@ describe("settings-nav", () => {
       expect(group?.items).toHaveLength(1);
     });
 
-    it("Workspace has 2 items", () => {
+    it("Workspace has 3 items including billing", () => {
       const group = SETTINGS_NAV.find((g) => g.heading === "Workspace");
-      expect(group?.items).toHaveLength(2);
+      expect(group?.items).toHaveLength(3);
+      expect(group?.items.map((item) => item.href)).toContain(
+        "/settings/organization/billing",
+      );
     });
 
     it("Advanced has 2 items", () => {


### PR DESCRIPTION
## Summary
- Adds `/settings/organization/billing` with current plan/status display, usage/limits cards, and honest OpenDocs/Namuh commercial billing copy.
- Wires Upgrade/Subscribe and Manage billing actions to application-owned billing endpoints, with loading/disabled states and readable fallback errors when backend routes are not merged yet.
- Adds settings/sidebar and profile-menu navigation to the billing page, plus billing env var name documentation.

## Test plan
- `make check`
- `make test` (1844 passed)
- Targeted preflight: `npx vitest run tests/billing.test.ts tests/billing-settings-client.test.tsx tests/settings-nav.test.ts tests/dashboard-layout.test.ts` (40 passed)

## Route/API assumptions
- Billing page route: `/settings/organization/billing`
- Checkout contract: `POST /api/billing/checkout` returns `{ url: string }`
- Customer portal contract: `POST /api/billing/portal` returns `{ url: string }`
- Live plan/usage currently derives opportunistically from existing `/api/orgs`, `/api/projects`, and `/api/assistant/usage`; when those are unavailable, the UI shows plan defaults/placeholders instead of requiring live Stripe credentials.
- This PR intentionally does not add webhook handling, DB migrations, or hardcoded Stripe-hosted URLs.

## Browser evidence
- Ever browser verification not run: no dev server was already listening on `localhost:3015` when checked (`curl` could not connect).
