### PR TITLE
Add Stripe billing APIs and webhooks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,12 @@ GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVA
 GITHUB_APP_SLUG=your-github-app-slug
 GITHUB_APP_INSTALL_URL=
 
+
+# Stripe billing -- required only for billing API routes and webhooks
+STRIPE_SECRET_KEY=sk_test_your-stripe-secret-key
+STRIPE_WEBHOOK_SECRET=whsec_your-stripe-webhook-secret
+STRIPE_PRICE_ID=price_your-recurring-price-id
+
 # App
 NEXT_PUBLIC_APP_URL=http://localhost:3015
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,16 @@ GITHUB_APP_PRIVATE_KEY=your-github-app-private-key
 GITHUB_APP_SLUG=your-github-app-slug
 # Optional override if the default slug URL is not correct:
 GITHUB_APP_INSTALL_URL=https://github.com/apps/your-github-app-slug/installations/new
+STRIPE_SECRET_KEY=sk_test_your-stripe-secret-key
+STRIPE_WEBHOOK_SECRET=whsec_your-stripe-webhook-secret
+STRIPE_PRICE_ID=price_your-recurring-price-id
+```
+
+Stripe billing API routes are documented in `docs/deployment/stripe-billing.md`, including local Stripe CLI webhook forwarding with:
+
+```bash
+stripe login
+stripe listen --forward-to localhost:3015/api/billing/stripe/webhook
 ```
 
 Google OAuth must include this production redirect URI:

--- a/docs/deployment/stripe-billing.md
+++ b/docs/deployment/stripe-billing.md
@@ -11,13 +11,15 @@ STRIPE_PRICE_ID=price_...
 NEXT_PUBLIC_APP_URL=http://localhost:3015
 ```
 
-`STRIPE_PRICE_ID` should point to the recurring subscription Price used by `/api/billing/stripe/checkout`. Production/staging must use the deployed `NEXT_PUBLIC_APP_URL` so Checkout and Portal redirects return to the correct origin.
+`STRIPE_PRICE_ID` should point to the recurring subscription Price used by `/api/billing/checkout`. Production/staging must use the deployed `NEXT_PUBLIC_APP_URL` so Checkout and Portal redirects return to the correct origin.
 
 ## API routes
 
-- `POST /api/billing/stripe/checkout` — authenticated org admin creates a Stripe Checkout Session for the configured subscription price.
-- `POST /api/billing/stripe/portal` — authenticated org admin with an existing Stripe customer ID creates a Customer Portal session.
+- `POST /api/billing/checkout` — authenticated org admin creates a Stripe Checkout Session for the configured subscription price.
+- `POST /api/billing/portal` — authenticated org admin with an existing Stripe customer ID creates a Customer Portal session.
 - `POST /api/billing/stripe/webhook` — Stripe forwards signed events here; the route verifies the raw request body with `STRIPE_WEBHOOK_SECRET` before updating local billing state.
+
+The checkout and portal routes are intentionally provider-neutral so the UI does not need to know Stripe is the current billing provider.
 
 Local billing state is stored under `organizations.settings.billing` and mirrors Stripe identifiers/status without storing secrets.
 
@@ -43,7 +45,7 @@ You can trigger a basic fixture event with:
 stripe trigger checkout.session.completed
 ```
 
-Caveat: the generated fixture will not automatically include OpenDocs metadata like `orgId`, `orgSlug`, `userId`, or the exact Checkout Session/customer created by the app. For end-to-end local mapping, create a Checkout Session through `POST /api/billing/stripe/checkout`, complete it in Stripe Checkout, and let the forwarded webhook carry the app metadata back to OpenDocs.
+Caveat: the generated fixture will not automatically include OpenDocs metadata like `orgId`, `orgSlug`, `userId`, or the exact Checkout Session/customer created by the app. For end-to-end local mapping, create a Checkout Session through `POST /api/billing/checkout`, complete it in Stripe Checkout, and let the forwarded webhook carry the app metadata back to OpenDocs.
 
 ## Live-account validation blocker
 

--- a/docs/deployment/stripe-billing.md
+++ b/docs/deployment/stripe-billing.md
@@ -1,0 +1,50 @@
+# Stripe billing local runbook
+
+OpenDocs billing uses Stripe Checkout, the Stripe Customer Portal, and a signed webhook endpoint. Keep all Stripe keys in local `.env` files or the deployment secrets manager; never commit or paste real secret values into logs or PRs.
+
+## Required environment variables
+
+```bash
+STRIPE_SECRET_KEY=sk_test_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+STRIPE_PRICE_ID=price_...
+NEXT_PUBLIC_APP_URL=http://localhost:3015
+```
+
+`STRIPE_PRICE_ID` should point to the recurring subscription Price used by `/api/billing/stripe/checkout`. Production/staging must use the deployed `NEXT_PUBLIC_APP_URL` so Checkout and Portal redirects return to the correct origin.
+
+## API routes
+
+- `POST /api/billing/stripe/checkout` — authenticated org admin creates a Stripe Checkout Session for the configured subscription price.
+- `POST /api/billing/stripe/portal` — authenticated org admin with an existing Stripe customer ID creates a Customer Portal session.
+- `POST /api/billing/stripe/webhook` — Stripe forwards signed events here; the route verifies the raw request body with `STRIPE_WEBHOOK_SECRET` before updating local billing state.
+
+Local billing state is stored under `organizations.settings.billing` and mirrors Stripe identifiers/status without storing secrets.
+
+## Stripe CLI local testing
+
+Install/login once per machine:
+
+```bash
+stripe login
+```
+
+Forward signed webhook events to the local Next.js dev server:
+
+```bash
+stripe listen --forward-to localhost:3015/api/billing/stripe/webhook
+```
+
+Copy the `whsec_...` value printed by `stripe listen` into `STRIPE_WEBHOOK_SECRET` for the same local shell/dev server. The CLI secret is different from a Dashboard webhook endpoint secret.
+
+You can trigger a basic fixture event with:
+
+```bash
+stripe trigger checkout.session.completed
+```
+
+Caveat: the generated fixture will not automatically include OpenDocs metadata like `orgId`, `orgSlug`, `userId`, or the exact Checkout Session/customer created by the app. For end-to-end local mapping, create a Checkout Session through `POST /api/billing/stripe/checkout`, complete it in Stripe Checkout, and let the forwarded webhook carry the app metadata back to OpenDocs.
+
+## Live-account validation blocker
+
+Unit tests mock Stripe network calls and do not require a live Stripe account. A real live-mode smoke test requires a valid Stripe account login, secret key, webhook secret, and recurring price ID.

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "recharts": "^3.8.1",
         "rehype-slug": "^6.0.0",
         "remark-gfm": "^4.0.1",
+        "stripe": "^22.1.1",
         "uuid": "^14.0.0"
       },
       "devDependencies": {
@@ -12816,6 +12817,23 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stripe": {
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.1.tgz",
+      "integrity": "sha512-cmodIYP27tBkJ8G7DuGgWw0PFuemlFZbuF3Wwr1TrjFjUa3T7NIgCe6TVwX8BO2ynu+xtTuDGfHafNDCPt9lXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
     },
     "node_modules/strnum": {
       "version": "2.2.3",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "recharts": "^3.8.1",
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
+    "stripe": "^22.1.1",
     "uuid": "^14.0.0"
   },
   "devDependencies": {

--- a/src/app/api/billing/checkout/route.ts
+++ b/src/app/api/billing/checkout/route.ts
@@ -1,0 +1,1 @@
+export { POST } from "../stripe/checkout/route";

--- a/src/app/api/billing/portal/route.ts
+++ b/src/app/api/billing/portal/route.ts
@@ -1,0 +1,1 @@
+export { POST } from "../stripe/portal/route";

--- a/src/app/api/billing/stripe/checkout/route.ts
+++ b/src/app/api/billing/stripe/checkout/route.ts
@@ -1,0 +1,125 @@
+import { auth } from "@/lib/auth";
+import { createRequestId, logger } from "@/lib/logger";
+import {
+  getStripeAppUrl,
+  getStripeClient,
+  getStripePriceId,
+} from "@/lib/stripe";
+import {
+  canManageBilling,
+  getBillingOrgForUser,
+  readBillingSettings,
+  updateOrgBillingState,
+} from "@/lib/stripe-billing";
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+
+const route = "/api/billing/stripe/checkout";
+
+function billingUrl(appUrl: string, status: "success" | "cancelled") {
+  const url = new URL("/settings", appUrl);
+  url.searchParams.set("billing", status);
+  if (status === "success") {
+    url.searchParams.set("session_id", "{CHECKOUT_SESSION_ID}");
+  }
+  return url
+    .toString()
+    .replace("%7BCHECKOUT_SESSION_ID%7D", "{CHECKOUT_SESSION_ID}");
+}
+
+export async function POST() {
+  const requestId = createRequestId();
+  const session = await auth.api.getSession({ headers: await headers() });
+
+  if (!session) {
+    logger.warn("stripe_checkout_unauthorized", {
+      requestId,
+      route,
+      method: "POST",
+    });
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const org = await getBillingOrgForUser(session.user.id);
+  if (!org) {
+    return NextResponse.json(
+      { error: "You must belong to an organization" },
+      { status: 403 },
+    );
+  }
+
+  if (!canManageBilling(org.role)) {
+    return NextResponse.json({ error: "Admin role required" }, { status: 403 });
+  }
+
+  try {
+    const stripe = getStripeClient();
+    const priceId = getStripePriceId();
+    const appUrl = getStripeAppUrl();
+    const billing = readBillingSettings(org.settings);
+
+    let customerId = billing.stripeCustomerId;
+    if (!customerId) {
+      const customer = await stripe.customers.create({
+        name: org.name,
+        email: session.user.email ?? undefined,
+        metadata: {
+          orgId: org.id,
+          orgSlug: org.slug,
+          userId: session.user.id,
+        },
+      });
+      customerId = customer.id;
+      await updateOrgBillingState(org, { stripeCustomerId: customerId });
+    }
+
+    const metadata = {
+      orgId: org.id,
+      orgSlug: org.slug,
+      userId: session.user.id,
+      priceId,
+    };
+
+    const checkoutSession = await stripe.checkout.sessions.create({
+      mode: "subscription",
+      customer: customerId,
+      line_items: [{ price: priceId, quantity: 1 }],
+      success_url: billingUrl(appUrl, "success"),
+      cancel_url: billingUrl(appUrl, "cancelled"),
+      client_reference_id: org.id,
+      metadata,
+      subscription_data: { metadata },
+    });
+
+    if (!checkoutSession.url) {
+      logger.error("stripe_checkout_missing_url", {
+        requestId,
+        route,
+        method: "POST",
+        orgId: org.id,
+      });
+      return NextResponse.json(
+        { error: "Stripe checkout did not return a URL" },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json({
+      url: checkoutSession.url,
+      sessionId: checkoutSession.id,
+      requestId,
+    });
+  } catch (error) {
+    logger.error("stripe_checkout_failed", {
+      requestId,
+      route,
+      method: "POST",
+      orgId: org.id,
+      error: error instanceof Error ? error.message : "unknown",
+    });
+    return NextResponse.json(
+      { error: "Stripe checkout is not available" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/billing/stripe/portal/route.ts
+++ b/src/app/api/billing/stripe/portal/route.ts
@@ -1,0 +1,75 @@
+import { auth } from "@/lib/auth";
+import { createRequestId, logger } from "@/lib/logger";
+import { getStripeAppUrl, getStripeClient } from "@/lib/stripe";
+import {
+  canManageBilling,
+  getBillingOrgForUser,
+  readBillingSettings,
+} from "@/lib/stripe-billing";
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+
+const route = "/api/billing/stripe/portal";
+
+export async function POST() {
+  const requestId = createRequestId();
+  const session = await auth.api.getSession({ headers: await headers() });
+
+  if (!session) {
+    logger.warn("stripe_portal_unauthorized", {
+      requestId,
+      route,
+      method: "POST",
+    });
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const org = await getBillingOrgForUser(session.user.id);
+  if (!org) {
+    return NextResponse.json(
+      { error: "You must belong to an organization" },
+      { status: 403 },
+    );
+  }
+
+  if (!canManageBilling(org.role)) {
+    return NextResponse.json({ error: "Admin role required" }, { status: 403 });
+  }
+
+  const customerId = readBillingSettings(org.settings).stripeCustomerId;
+  if (!customerId) {
+    return NextResponse.json(
+      { error: "No Stripe customer is linked to this organization" },
+      { status: 409 },
+    );
+  }
+
+  try {
+    const stripe = getStripeClient();
+    const returnUrl = new URL("/settings", getStripeAppUrl());
+    returnUrl.searchParams.set("billing", "portal_return");
+
+    const portalSession = await stripe.billingPortal.sessions.create({
+      customer: customerId,
+      return_url: returnUrl.toString(),
+    });
+
+    return NextResponse.json({
+      url: portalSession.url,
+      sessionId: portalSession.id,
+      requestId,
+    });
+  } catch (error) {
+    logger.error("stripe_portal_failed", {
+      requestId,
+      route,
+      method: "POST",
+      orgId: org.id,
+      error: error instanceof Error ? error.message : "unknown",
+    });
+    return NextResponse.json(
+      { error: "Stripe customer portal is not available" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/billing/stripe/webhook/route.ts
+++ b/src/app/api/billing/stripe/webhook/route.ts
@@ -1,0 +1,73 @@
+import { createRequestId, logger } from "@/lib/logger";
+import { getStripeClient, getStripeWebhookSecret } from "@/lib/stripe";
+import { applyStripeWebhookEvent } from "@/lib/stripe-billing";
+import { NextResponse } from "next/server";
+import type Stripe from "stripe";
+
+const route = "/api/billing/stripe/webhook";
+
+export async function POST(request: Request) {
+  const requestId = createRequestId();
+  const signature = request.headers.get("stripe-signature");
+
+  if (!signature) {
+    logger.warn("stripe_webhook_missing_signature", {
+      requestId,
+      route,
+      method: "POST",
+    });
+    return NextResponse.json(
+      { error: "Stripe signature is required" },
+      { status: 400 },
+    );
+  }
+
+  const rawBody = await request.text();
+
+  let event: Stripe.Event;
+  try {
+    event = getStripeClient().webhooks.constructEvent(
+      rawBody,
+      signature,
+      getStripeWebhookSecret(),
+    );
+  } catch (error) {
+    logger.warn("stripe_webhook_invalid_signature", {
+      requestId,
+      route,
+      method: "POST",
+      error: error instanceof Error ? error.message : "unknown",
+    });
+    return NextResponse.json(
+      { error: "Invalid Stripe webhook signature" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await applyStripeWebhookEvent(event);
+    logger.info("stripe_webhook_processed", {
+      requestId,
+      route,
+      method: "POST",
+      eventId: event.id,
+      eventType: event.type,
+      handled: result.handled,
+      mapped: result.mapped,
+    });
+    return NextResponse.json({ received: true, ...result, requestId });
+  } catch (error) {
+    logger.error("stripe_webhook_processing_failed", {
+      requestId,
+      route,
+      method: "POST",
+      eventId: event.id,
+      eventType: event.type,
+      error: error instanceof Error ? error.message : "unknown",
+    });
+    return NextResponse.json(
+      { error: "Stripe webhook processing failed" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/stripe-billing.ts
+++ b/src/lib/stripe-billing.ts
@@ -1,0 +1,273 @@
+import { db } from "@/lib/db";
+import { orgMemberships, organizations } from "@/lib/db/schema";
+import { eq, sql } from "drizzle-orm";
+import type Stripe from "stripe";
+
+type OrgPlan = "free" | "pro" | "enterprise";
+
+export type BillingSettings = {
+  stripeCustomerId?: string;
+  stripeSubscriptionId?: string;
+  stripeSubscriptionStatus?: string;
+  stripePriceId?: string;
+  stripeCurrentPeriodEnd?: string | null;
+  stripeLatestInvoiceId?: string;
+  stripeLatestInvoiceStatus?: string | null;
+  stripeLastPaymentStatus?: "succeeded" | "failed";
+  stripeLastEventId?: string;
+  stripeLastEventType?: string;
+  stripeLastUpdatedAt?: string;
+};
+
+type OrgSettings = Record<string, unknown> & { billing?: BillingSettings };
+
+export type BillingOrgContext = {
+  id: string;
+  name: string;
+  slug: string;
+  plan: OrgPlan;
+  role: "admin" | "editor" | "viewer";
+  settings: OrgSettings;
+};
+
+export function readBillingSettings(settings: unknown): BillingSettings {
+  if (!settings || typeof settings !== "object") return {};
+  const billing = (settings as { billing?: unknown }).billing;
+  if (!billing || typeof billing !== "object") return {};
+  return billing as BillingSettings;
+}
+
+export function mergeBillingSettings(
+  settings: unknown,
+  updates: BillingSettings,
+): OrgSettings {
+  const base =
+    settings && typeof settings === "object"
+      ? ({ ...(settings as Record<string, unknown>) } as OrgSettings)
+      : ({} as OrgSettings);
+
+  base.billing = {
+    ...readBillingSettings(base),
+    ...updates,
+    stripeLastUpdatedAt:
+      updates.stripeLastUpdatedAt ?? new Date().toISOString(),
+  };
+
+  return base;
+}
+
+export function canManageBilling(role: BillingOrgContext["role"]) {
+  return role === "admin";
+}
+
+export async function getBillingOrgForUser(
+  userId: string,
+): Promise<BillingOrgContext | null> {
+  const rows = await db
+    .select({
+      orgId: orgMemberships.orgId,
+      role: orgMemberships.role,
+      org: {
+        id: organizations.id,
+        name: organizations.name,
+        slug: organizations.slug,
+        plan: organizations.plan,
+        settings: organizations.settings,
+      },
+    })
+    .from(orgMemberships)
+    .innerJoin(organizations, eq(orgMemberships.orgId, organizations.id))
+    .where(eq(orgMemberships.userId, userId))
+    .limit(1);
+
+  if (rows.length === 0) return null;
+  return {
+    ...rows[0].org,
+    role: rows[0].role,
+    settings: (rows[0].org.settings ?? {}) as OrgSettings,
+  };
+}
+
+export async function updateOrgBillingState(
+  org: Pick<BillingOrgContext, "id" | "settings">,
+  updates: BillingSettings,
+  plan?: OrgPlan,
+) {
+  const settings = mergeBillingSettings(org.settings, updates);
+  await db
+    .update(organizations)
+    .set({
+      settings,
+      ...(plan ? { plan } : {}),
+      updatedAt: new Date(),
+    })
+    .where(eq(organizations.id, org.id));
+  return settings.billing ?? {};
+}
+
+export async function findOrgByStripeCustomerId(customerId: string) {
+  const rows = await db
+    .select({
+      id: organizations.id,
+      plan: organizations.plan,
+      settings: organizations.settings,
+    })
+    .from(organizations)
+    .where(
+      sql`${organizations.settings}->'billing'->>'stripeCustomerId' = ${customerId}`,
+    )
+    .limit(1);
+
+  return rows[0] ?? null;
+}
+
+function getCustomerId(
+  customer: string | Stripe.Customer | Stripe.DeletedCustomer | null,
+) {
+  if (!customer) return null;
+  return typeof customer === "string" ? customer : customer.id;
+}
+
+function unixToIso(seconds: number | null | undefined) {
+  return typeof seconds === "number"
+    ? new Date(seconds * 1000).toISOString()
+    : null;
+}
+
+function subscriptionPlan(status: string | null | undefined): OrgPlan {
+  return status === "active" || status === "trialing" ? "pro" : "free";
+}
+
+function subscriptionCustomerId(subscription: Stripe.Subscription) {
+  return getCustomerId(subscription.customer);
+}
+
+function subscriptionUpdates(
+  subscription: Stripe.Subscription,
+  event: Stripe.Event,
+): BillingSettings {
+  const firstItem = subscription.items.data[0];
+  return {
+    stripeCustomerId: subscriptionCustomerId(subscription) ?? undefined,
+    stripeSubscriptionId: subscription.id,
+    stripeSubscriptionStatus: subscription.status,
+    stripePriceId: firstItem?.price?.id,
+    stripeCurrentPeriodEnd: unixToIso(firstItem?.current_period_end),
+    stripeLastEventId: event.id,
+    stripeLastEventType: event.type,
+  };
+}
+
+async function updateOrgForSubscription(
+  subscription: Stripe.Subscription,
+  event: Stripe.Event,
+) {
+  const customerId = subscriptionCustomerId(subscription);
+  if (!customerId) return false;
+
+  const org = await findOrgByStripeCustomerId(customerId);
+  if (!org) return false;
+
+  await updateOrgBillingState(
+    { id: org.id, settings: (org.settings ?? {}) as OrgSettings },
+    subscriptionUpdates(subscription, event),
+    subscriptionPlan(subscription.status),
+  );
+  return true;
+}
+
+async function updateOrgForInvoice(
+  invoice: Stripe.Invoice,
+  event: Stripe.Event,
+) {
+  const customerId = getCustomerId(invoice.customer);
+  if (!customerId) return false;
+
+  const org = await findOrgByStripeCustomerId(customerId);
+  if (!org) return false;
+
+  await updateOrgBillingState(
+    { id: org.id, settings: (org.settings ?? {}) as OrgSettings },
+    {
+      stripeCustomerId: customerId,
+      stripeLatestInvoiceId: invoice.id,
+      stripeLatestInvoiceStatus: invoice.status,
+      stripeLastPaymentStatus:
+        event.type === "invoice.payment_succeeded" ? "succeeded" : "failed",
+      stripeLastEventId: event.id,
+      stripeLastEventType: event.type,
+    },
+  );
+  return true;
+}
+
+async function updateOrgForCompletedCheckout(
+  session: Stripe.Checkout.Session,
+  event: Stripe.Event,
+) {
+  const orgId = session.metadata?.orgId;
+  const customerId = getCustomerId(session.customer);
+  if (!orgId || !customerId) return false;
+
+  const rows = await db
+    .select({
+      id: organizations.id,
+      settings: organizations.settings,
+    })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+
+  const org = rows[0];
+  if (!org) return false;
+
+  await updateOrgBillingState(
+    { id: org.id, settings: (org.settings ?? {}) as OrgSettings },
+    {
+      stripeCustomerId: customerId,
+      stripeSubscriptionId:
+        typeof session.subscription === "string"
+          ? session.subscription
+          : session.subscription?.id,
+      stripeSubscriptionStatus: "checkout_completed",
+      stripePriceId: session.metadata?.priceId,
+      stripeLastEventId: event.id,
+      stripeLastEventType: event.type,
+    },
+    "pro",
+  );
+  return true;
+}
+
+export async function applyStripeWebhookEvent(event: Stripe.Event) {
+  switch (event.type) {
+    case "checkout.session.completed":
+      return {
+        handled: true,
+        mapped: await updateOrgForCompletedCheckout(
+          event.data.object as Stripe.Checkout.Session,
+          event,
+        ),
+      };
+    case "customer.subscription.created":
+    case "customer.subscription.updated":
+    case "customer.subscription.deleted": {
+      const subscription = event.data.object as Stripe.Subscription;
+      return {
+        handled: true,
+        mapped: await updateOrgForSubscription(subscription, event),
+      };
+    }
+    case "invoice.payment_succeeded":
+    case "invoice.payment_failed":
+      return {
+        handled: true,
+        mapped: await updateOrgForInvoice(
+          event.data.object as Stripe.Invoice,
+          event,
+        ),
+      };
+    default:
+      return { handled: false, mapped: false };
+  }
+}

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,0 +1,45 @@
+import { getPublicAppUrl } from "@/lib/app-url";
+import Stripe from "stripe";
+
+let cachedStripeClient: Stripe | null = null;
+let cachedStripeSecretKey: string | null = null;
+
+function getRequiredEnv(name: string) {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`Missing required Stripe environment variable: ${name}`);
+  }
+  return value;
+}
+
+export function getStripeSecretKey() {
+  return getRequiredEnv("STRIPE_SECRET_KEY");
+}
+
+export function getStripeWebhookSecret() {
+  return getRequiredEnv("STRIPE_WEBHOOK_SECRET");
+}
+
+export function getStripePriceId() {
+  return getRequiredEnv("STRIPE_PRICE_ID");
+}
+
+export function getStripeAppUrl() {
+  return getPublicAppUrl();
+}
+
+export function getStripeClient() {
+  const secretKey = getStripeSecretKey();
+  if (cachedStripeClient && cachedStripeSecretKey === secretKey) {
+    return cachedStripeClient;
+  }
+
+  cachedStripeClient = new Stripe(secretKey);
+  cachedStripeSecretKey = secretKey;
+  return cachedStripeClient;
+}
+
+export function resetStripeClientForTests() {
+  cachedStripeClient = null;
+  cachedStripeSecretKey = null;
+}

--- a/tests/stripe-billing-routes.test.ts
+++ b/tests/stripe-billing-routes.test.ts
@@ -156,6 +156,18 @@ describe("Stripe billing routes", () => {
     });
   });
 
+  it("keeps provider-neutral checkout and portal aliases available for the UI", async () => {
+    const checkoutRoute = await import("@/app/api/billing/checkout/route");
+    const stripeCheckoutRoute = await import(
+      "@/app/api/billing/stripe/checkout/route"
+    );
+    const portalRoute = await import("@/app/api/billing/portal/route");
+    const stripePortalRoute = await import("@/app/api/billing/stripe/portal/route");
+
+    expect(checkoutRoute.POST).toBe(stripeCheckoutRoute.POST);
+    expect(portalRoute.POST).toBe(stripePortalRoute.POST);
+  });
+
   it("rejects webhooks without a Stripe signature", async () => {
     const { POST } = await import("@/app/api/billing/stripe/webhook/route");
     const response = await POST(

--- a/tests/stripe-billing-routes.test.ts
+++ b/tests/stripe-billing-routes.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSessionMock = vi.fn();
+const headersMock = vi.fn();
+const getBillingOrgForUserMock = vi.fn();
+const updateOrgBillingStateMock = vi.fn();
+const applyStripeWebhookEventMock = vi.fn();
+const getStripeClientMock = vi.fn();
+const getStripePriceIdMock = vi.fn();
+const getStripeAppUrlMock = vi.fn();
+const getStripeWebhookSecretMock = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: getSessionMock,
+    },
+  },
+}));
+
+vi.mock("next/headers", () => ({
+  headers: headersMock,
+}));
+
+vi.mock("@/lib/stripe-billing", () => ({
+  applyStripeWebhookEvent: applyStripeWebhookEventMock,
+  canManageBilling: (role: string) => role === "admin",
+  getBillingOrgForUser: getBillingOrgForUserMock,
+  readBillingSettings: (settings: { billing?: Record<string, unknown> }) =>
+    settings?.billing ?? {},
+  updateOrgBillingState: updateOrgBillingStateMock,
+}));
+
+vi.mock("@/lib/stripe", () => ({
+  getStripeAppUrl: getStripeAppUrlMock,
+  getStripeClient: getStripeClientMock,
+  getStripePriceId: getStripePriceIdMock,
+  getStripeWebhookSecret: getStripeWebhookSecretMock,
+}));
+
+function mockUserSession() {
+  getSessionMock.mockResolvedValue({
+    user: { id: "user-1", email: "founder@example.com" },
+  });
+}
+
+function mockOrg(settings: Record<string, unknown> = {}) {
+  getBillingOrgForUserMock.mockResolvedValue({
+    id: "org-1",
+    name: "Acme Docs",
+    slug: "acme",
+    plan: "free",
+    role: "admin",
+    settings,
+  });
+}
+
+describe("Stripe billing routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    headersMock.mockResolvedValue(new Headers());
+    getStripePriceIdMock.mockReturnValue("price_1");
+    getStripeAppUrlMock.mockReturnValue("http://localhost:3015");
+    getStripeWebhookSecretMock.mockReturnValue("whsec_test");
+  });
+
+  it("requires authentication before creating checkout sessions", async () => {
+    getSessionMock.mockResolvedValue(null);
+
+    const { POST } = await import("@/app/api/billing/stripe/checkout/route");
+    const response = await POST();
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(getBillingOrgForUserMock).not.toHaveBeenCalled();
+  });
+
+  it("creates a Stripe customer and checkout session for org admins", async () => {
+    mockUserSession();
+    mockOrg({});
+    const createCustomerMock = vi.fn().mockResolvedValue({ id: "cus_1" });
+    const createCheckoutMock = vi.fn().mockResolvedValue({
+      id: "cs_1",
+      url: "https://checkout.stripe.test/cs_1",
+    });
+    getStripeClientMock.mockReturnValue({
+      customers: { create: createCustomerMock },
+      checkout: { sessions: { create: createCheckoutMock } },
+    });
+
+    const { POST } = await import("@/app/api/billing/stripe/checkout/route");
+    const response = await POST();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.url).toBe("https://checkout.stripe.test/cs_1");
+    expect(createCustomerMock).toHaveBeenCalledWith({
+      name: "Acme Docs",
+      email: "founder@example.com",
+      metadata: { orgId: "org-1", orgSlug: "acme", userId: "user-1" },
+    });
+    expect(updateOrgBillingStateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "org-1" }),
+      { stripeCustomerId: "cus_1" },
+    );
+    expect(createCheckoutMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "subscription",
+        customer: "cus_1",
+        line_items: [{ price: "price_1", quantity: 1 }],
+        client_reference_id: "org-1",
+        success_url:
+          "http://localhost:3015/settings?billing=success&session_id={CHECKOUT_SESSION_ID}",
+        cancel_url: "http://localhost:3015/settings?billing=cancelled",
+        metadata: {
+          orgId: "org-1",
+          orgSlug: "acme",
+          userId: "user-1",
+          priceId: "price_1",
+        },
+      }),
+    );
+  });
+
+  it("requires authentication before creating portal sessions", async () => {
+    getSessionMock.mockResolvedValue(null);
+
+    const { POST } = await import("@/app/api/billing/stripe/portal/route");
+    const response = await POST();
+
+    expect(response.status).toBe(401);
+    expect(getBillingOrgForUserMock).not.toHaveBeenCalled();
+  });
+
+  it("creates a customer portal session for orgs with a Stripe customer id", async () => {
+    mockUserSession();
+    mockOrg({ billing: { stripeCustomerId: "cus_1" } });
+    const createPortalMock = vi.fn().mockResolvedValue({
+      id: "bps_1",
+      url: "https://billing.stripe.test/session/bps_1",
+    });
+    getStripeClientMock.mockReturnValue({
+      billingPortal: { sessions: { create: createPortalMock } },
+    });
+
+    const { POST } = await import("@/app/api/billing/stripe/portal/route");
+    const response = await POST();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.url).toBe("https://billing.stripe.test/session/bps_1");
+    expect(createPortalMock).toHaveBeenCalledWith({
+      customer: "cus_1",
+      return_url: "http://localhost:3015/settings?billing=portal_return",
+    });
+  });
+
+  it("rejects webhooks without a Stripe signature", async () => {
+    const { POST } = await import("@/app/api/billing/stripe/webhook/route");
+    const response = await POST(
+      new Request("http://localhost/api/billing/stripe/webhook", {
+        method: "POST",
+        body: "{}",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(getStripeClientMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects webhooks when signature verification fails", async () => {
+    getStripeClientMock.mockReturnValue({
+      webhooks: {
+        constructEvent: vi.fn(() => {
+          throw new Error("No signatures found matching");
+        }),
+      },
+    });
+
+    const { POST } = await import("@/app/api/billing/stripe/webhook/route");
+    const response = await POST(
+      new Request("http://localhost/api/billing/stripe/webhook", {
+        method: "POST",
+        headers: { "stripe-signature": "bad" },
+        body: "{}",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid Stripe webhook signature",
+    });
+    expect(applyStripeWebhookEventMock).not.toHaveBeenCalled();
+  });
+
+  it("acknowledges verified unknown webhook events", async () => {
+    const event = {
+      id: "evt_1",
+      type: "customer.created",
+      data: { object: {} },
+    };
+    getStripeClientMock.mockReturnValue({
+      webhooks: { constructEvent: vi.fn().mockReturnValue(event) },
+    });
+    applyStripeWebhookEventMock.mockResolvedValue({
+      handled: false,
+      mapped: false,
+    });
+
+    const { POST } = await import("@/app/api/billing/stripe/webhook/route");
+    const response = await POST(
+      new Request("http://localhost/api/billing/stripe/webhook", {
+        method: "POST",
+        headers: { "stripe-signature": "good" },
+        body: "{}",
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toMatchObject({
+      received: true,
+      handled: false,
+      mapped: false,
+    });
+    expect(applyStripeWebhookEventMock).toHaveBeenCalledWith(event);
+  });
+});

--- a/tests/stripe-billing-routes.test.ts
+++ b/tests/stripe-billing-routes.test.ts
@@ -162,7 +162,9 @@ describe("Stripe billing routes", () => {
       "@/app/api/billing/stripe/checkout/route"
     );
     const portalRoute = await import("@/app/api/billing/portal/route");
-    const stripePortalRoute = await import("@/app/api/billing/stripe/portal/route");
+    const stripePortalRoute = await import(
+      "@/app/api/billing/stripe/portal/route"
+    );
 
     expect(checkoutRoute.POST).toBe(stripeCheckoutRoute.POST);
     expect(portalRoute.POST).toBe(stripePortalRoute.POST);

--- a/tests/stripe-billing.test.ts
+++ b/tests/stripe-billing.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const selectMock = vi.fn();
+const updateMock = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: selectMock,
+    update: updateMock,
+  },
+}));
+
+function mockSelectRows(rows: Array<Record<string, unknown>>) {
+  selectMock.mockReturnValueOnce({
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(rows),
+  });
+}
+
+function mockUpdate() {
+  const whereMock = vi.fn().mockResolvedValue(undefined);
+  const setMock = vi.fn().mockReturnValue({ where: whereMock });
+  updateMock.mockReturnValueOnce({ set: setMock });
+  return { setMock, whereMock };
+}
+
+describe("stripe billing helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("merges billing settings without losing existing org settings", async () => {
+    const { mergeBillingSettings } = await import("@/lib/stripe-billing");
+
+    expect(
+      mergeBillingSettings(
+        { theme: "dark", billing: { stripeCustomerId: "cus_1" } },
+        { stripeSubscriptionId: "sub_1" },
+      ),
+    ).toMatchObject({
+      theme: "dark",
+      billing: {
+        stripeCustomerId: "cus_1",
+        stripeSubscriptionId: "sub_1",
+        stripeLastUpdatedAt: expect.any(String),
+      },
+    });
+  });
+
+  it("maps completed checkout sessions back to org metadata", async () => {
+    mockSelectRows([{ id: "org-1", settings: { existing: true } }]);
+    const { setMock } = mockUpdate();
+
+    const { applyStripeWebhookEvent } = await import("@/lib/stripe-billing");
+    const result = await applyStripeWebhookEvent({
+      id: "evt_1",
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          customer: "cus_1",
+          subscription: "sub_1",
+          metadata: {
+            orgId: "org-1",
+            priceId: "price_1",
+          },
+        },
+      },
+    } as never);
+
+    expect(result).toEqual({ handled: true, mapped: true });
+    expect(setMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plan: "pro",
+        settings: expect.objectContaining({
+          existing: true,
+          billing: expect.objectContaining({
+            stripeCustomerId: "cus_1",
+            stripeSubscriptionId: "sub_1",
+            stripeSubscriptionStatus: "checkout_completed",
+            stripePriceId: "price_1",
+            stripeLastEventId: "evt_1",
+          }),
+        }),
+        updatedAt: expect.any(Date),
+      }),
+    );
+  });
+
+  it("maps subscription updates through the stored Stripe customer id", async () => {
+    mockSelectRows([
+      {
+        id: "org-1",
+        plan: "free",
+        settings: { billing: { stripeCustomerId: "cus_1" } },
+      },
+    ]);
+    const { setMock } = mockUpdate();
+
+    const { applyStripeWebhookEvent } = await import("@/lib/stripe-billing");
+    const result = await applyStripeWebhookEvent({
+      id: "evt_2",
+      type: "customer.subscription.updated",
+      data: {
+        object: {
+          id: "sub_1",
+          customer: "cus_1",
+          status: "active",
+          current_period_end: 1_799_856_000,
+          items: {
+            data: [
+              { current_period_end: 1_799_856_000, price: { id: "price_1" } },
+            ],
+          },
+        },
+      },
+    } as never);
+
+    expect(result).toEqual({ handled: true, mapped: true });
+    expect(setMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plan: "pro",
+        settings: expect.objectContaining({
+          billing: expect.objectContaining({
+            stripeCustomerId: "cus_1",
+            stripeSubscriptionId: "sub_1",
+            stripeSubscriptionStatus: "active",
+            stripePriceId: "price_1",
+            stripeCurrentPeriodEnd: "2027-01-13T16:00:00.000Z",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("acknowledges unknown events without database writes", async () => {
+    const { applyStripeWebhookEvent } = await import("@/lib/stripe-billing");
+
+    await expect(
+      applyStripeWebhookEvent({
+        id: "evt_3",
+        type: "customer.created",
+        data: { object: {} },
+      } as never),
+    ).resolves.toEqual({ handled: false, mapped: false });
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/stripe-config.test.ts
+++ b/tests/stripe-config.test.ts
@@ -1,0 +1,42 @@
+import {
+  getStripeAppUrl,
+  getStripePriceId,
+  getStripeSecretKey,
+  getStripeWebhookSecret,
+} from "@/lib/stripe";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("Stripe config", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("validates the secret key only when requested", () => {
+    expect(() => getStripeSecretKey()).toThrow(
+      "Missing required Stripe environment variable: STRIPE_SECRET_KEY",
+    );
+
+    vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_123");
+    expect(getStripeSecretKey()).toBe("sk_test_123");
+  });
+
+  it("validates webhook secret and price id independently", () => {
+    expect(() => getStripeWebhookSecret()).toThrow(
+      "Missing required Stripe environment variable: STRIPE_WEBHOOK_SECRET",
+    );
+    expect(() => getStripePriceId()).toThrow(
+      "Missing required Stripe environment variable: STRIPE_PRICE_ID",
+    );
+
+    vi.stubEnv("STRIPE_WEBHOOK_SECRET", "whsec_123");
+    vi.stubEnv("STRIPE_PRICE_ID", "price_123");
+
+    expect(getStripeWebhookSecret()).toBe("whsec_123");
+    expect(getStripePriceId()).toBe("price_123");
+  });
+
+  it("uses the existing app URL helper for Stripe redirects", () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_URL", "https://opendocs.example.com///");
+    expect(getStripeAppUrl()).toBe("https://opendocs.example.com");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds Stripe server helpers for lazy env validation and cached Stripe client creation.
- Adds authenticated org-admin billing APIs for subscription Checkout and Customer Portal sessions.
- Adds signed Stripe webhook handling for Checkout, subscription, and invoice payment events, updating local org billing state under `organizations.settings.billing`.
- Adds docs and `.env.example` entries for local Stripe CLI webhook forwarding without committing secrets.

## Routes

- `POST /api/billing/stripe/checkout`
  - Requires authenticated org admin.
  - Creates/reuses a Stripe customer and returns a subscription Checkout Session URL.
  - Attaches `orgId`, `orgSlug`, `userId`, and `priceId` metadata.
- `POST /api/billing/stripe/portal`
  - Requires authenticated org admin and an existing `stripeCustomerId` in org billing settings.
  - Returns a Stripe Customer Portal session URL.
- `POST /api/billing/stripe/webhook`
  - Verifies `stripe-signature` against the raw body and `STRIPE_WEBHOOK_SECRET`.
  - Handles `checkout.session.completed`, `customer.subscription.created`, `customer.subscription.updated`, `customer.subscription.deleted`, `invoice.payment_succeeded`, and `invoice.payment_failed`.
  - Acknowledges unknown event types without crashing.

## Environment variables

- `STRIPE_SECRET_KEY`
- `STRIPE_WEBHOOK_SECRET`
- `STRIPE_PRICE_ID`
- `NEXT_PUBLIC_APP_URL`

## Stripe CLI local commands

```bash
stripe login
stripe listen --forward-to localhost:3015/api/billing/stripe/webhook
stripe trigger checkout.session.completed
```

Note: `stripe trigger checkout.session.completed` uses Stripe fixture data and will not include OpenDocs-specific metadata unless the event comes from a Checkout Session created by `POST /api/billing/stripe/checkout`.

## Test plan

- `npm test -- --run tests/stripe-config.test.ts tests/stripe-billing.test.ts tests/stripe-billing-routes.test.ts`
- `make check`
- `make test`

## Live-account blocker

needs human: Stripe login/API key/price id required for live Stripe-account validation. Unit tests mock Stripe network calls and pass without a live Stripe account.
