### PR TITLE
Polish Hosted Pro billing pricing display

### DIFF
--- a/src/app/settings/organization/billing/billing-settings-client.tsx
+++ b/src/app/settings/organization/billing/billing-settings-client.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  BILLING_API_CONTRACTS,
   type BillingUsageSummary,
   calculateBillingUsagePercent,
   createBillingRedirect,
@@ -177,13 +176,14 @@ export function BillingSettingsClient({
                 {planDetails.summary}
               </p>
             </div>
-            <div className="rounded-lg border border-white/[0.08] bg-white/[0.04] px-4 py-3 text-right">
+            <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/[0.06] px-4 py-3 text-right shadow-[0_0_30px_rgba(16,185,129,0.08)]">
               <p className="text-xs uppercase tracking-wide text-gray-500">
-                Price
+                Monthly
               </p>
-              <p className="text-sm font-medium text-white">
+              <p className="mt-1 text-lg font-semibold tracking-tight text-white">
                 {planDetails.monthlyPriceLabel}
               </p>
+              <p className="mt-0.5 text-xs text-gray-500">per workspace</p>
             </div>
           </div>
 
@@ -273,18 +273,6 @@ export function BillingSettingsClient({
             noun="messages"
           />
         </div>
-      </section>
-
-      <section className="mt-6 rounded-xl border border-white/[0.08] bg-[#141414] p-5">
-        <h2 className="text-sm font-semibold text-white">API assumptions</h2>
-        <p className="mt-2 text-sm text-gray-400">
-          Checkout and customer portal redirects intentionally come from the
-          application API, not hardcoded Stripe URLs.
-        </p>
-        <ul className="mt-3 space-y-1 font-mono text-xs text-gray-500">
-          <li>{BILLING_API_CONTRACTS.checkout}</li>
-          <li>{BILLING_API_CONTRACTS.portal}</li>
-        </ul>
       </section>
     </div>
   );

--- a/src/lib/billing-client.ts
+++ b/src/lib/billing-client.ts
@@ -43,16 +43,16 @@ export const BILLING_PLAN_DETAILS: Record<BillingPlan, BillingPlanDetails> = {
   },
   pro: {
     plan: "pro",
-    label: "Pro",
+    label: "Hosted Pro",
     statusLabel: "Active",
-    monthlyPriceLabel: "Managed in Stripe",
+    monthlyPriceLabel: "$49/mo",
     summary:
-      "Commercial plan for teams that want Namuh-hosted billing, support, and higher limits.",
+      "Managed OpenDocs hosting for teams that want higher limits, support, and less infrastructure work.",
     projectLimit: 5,
     assistantMessageLimit: 5000,
     features: [
-      "More docs projects",
-      "Higher assistant usage",
+      "5 docs projects included",
+      "5,000 assistant messages included",
       "Priority support",
     ],
   },

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -131,16 +131,16 @@ export const BILLING_PLAN_DETAILS: Record<BillingPlan, BillingPlanDetails> = {
   },
   pro: {
     plan: "pro",
-    label: "Pro",
+    label: "Hosted Pro",
     statusLabel: "Active",
-    monthlyPriceLabel: "Managed in Stripe",
+    monthlyPriceLabel: "$49/mo",
     summary:
-      "Commercial plan for teams that want Namuh-hosted billing, support, and higher limits.",
+      "Managed OpenDocs hosting for teams that want higher limits, support, and less infrastructure work.",
     projectLimit: 5,
     assistantMessageLimit: 5000,
     features: [
-      "More docs projects",
-      "Higher assistant usage",
+      "5 docs projects included",
+      "5,000 assistant messages included",
       "Priority support",
     ],
   },

--- a/tests/billing-settings-client.test.tsx
+++ b/tests/billing-settings-client.test.tsx
@@ -64,7 +64,8 @@ describe("BillingSettingsClient", () => {
     const { container, root } = await renderBilling(fetchMock);
 
     expect(container.textContent).toContain("Billing");
-    expect(container.textContent).toContain("Pro");
+    expect(container.textContent).toContain("Hosted Pro");
+    expect(container.textContent).toContain("$49/mo");
     expect(container.textContent).toContain("Active");
     expect(container.textContent).toContain("2");
     expect(container.textContent).toContain("125");


### PR DESCRIPTION
## Summary
- Rename the paid plan display from Pro to Hosted Pro
- Show 9/mo as the small monthly price treatment instead of Stripe implementation copy
- Remove the internal API assumptions card from the customer-facing billing page

## Test Plan
- npm test -- --run tests/billing.test.ts tests/billing-settings-client.test.tsx
- make check
- npm run build with CI-like local env