### PR TITLE
Enable promotion codes in Stripe checkout

### DIFF
--- a/src/app/api/billing/stripe/checkout/route.ts
+++ b/src/app/api/billing/stripe/checkout/route.ts
@@ -83,6 +83,7 @@ export async function POST() {
     const checkoutSession = await stripe.checkout.sessions.create({
       mode: "subscription",
       customer: customerId,
+      allow_promotion_codes: true,
       line_items: [{ price: priceId, quantity: 1 }],
       success_url: billingUrl(appUrl, "success"),
       cancel_url: billingUrl(appUrl, "cancelled"),

--- a/tests/stripe-billing-routes.test.ts
+++ b/tests/stripe-billing-routes.test.ts
@@ -108,6 +108,7 @@ describe("Stripe billing routes", () => {
       expect.objectContaining({
         mode: "subscription",
         customer: "cus_1",
+        allow_promotion_codes: true,
         line_items: [{ price: "price_1", quantity: 1 }],
         client_reference_id: "org-1",
         success_url:


### PR DESCRIPTION
## What
Enable Stripe Checkout promotion-code entry for hosted billing subscriptions.

## Why
Coupons created in Stripe Dashboard are not customer-enterable unless the Checkout Session opts into promotion codes.

## Done When
- Checkout Session creation includes `allow_promotion_codes: true`
- Route regression test verifies the parameter is sent
- Typecheck and lint pass

## Not Doing
- Not hardcoding or auto-applying a specific coupon
- Not changing Stripe webhook handling
- Not changing payment method configuration

## Verification
- `npx vitest run tests/stripe-billing-routes.test.ts`
- `make check`

Closes no issue