### PR TITLE
Promote staging to main

### DIFF
--- a/src/app/api/billing/stripe/checkout/route.ts
+++ b/src/app/api/billing/stripe/checkout/route.ts
@@ -83,6 +83,7 @@ export async function POST() {
     const checkoutSession = await stripe.checkout.sessions.create({
       mode: "subscription",
       customer: customerId,
+      allow_promotion_codes: true,
       line_items: [{ price: priceId, quantity: 1 }],
       success_url: billingUrl(appUrl, "success"),
       cancel_url: billingUrl(appUrl, "cancelled"),

--- a/tests/stripe-billing-routes.test.ts
+++ b/tests/stripe-billing-routes.test.ts
@@ -108,6 +108,7 @@ describe("Stripe billing routes", () => {
       expect.objectContaining({
         mode: "subscription",
         customer: "cus_1",
+        allow_promotion_codes: true,
         line_items: [{ price: "price_1", quantity: 1 }],
         client_reference_id: "org-1",
         success_url:


### PR DESCRIPTION
## What
Promote the current staging release to main so production can be redeployed with Stripe promotion-code support.

## Why
GitHub branch protection requires main updates through a PR.

## Done When
- PR #193 is included
- Main contains `allow_promotion_codes: true` in Stripe Checkout Session creation
- Production is redeployed from the merged main SHA

## Not Doing
- Not changing Stripe dashboard coupon configuration
- Not auto-applying a specific coupon

## Verification
- `npx vitest run tests/stripe-billing-routes.test.ts`
- `make check`