### PR TITLE
Fix docs authentication settings route crash

### DIFF
--- a/src/app/settings/project/authentication/page.tsx
+++ b/src/app/settings/project/authentication/page.tsx
@@ -4,11 +4,11 @@ import { useActiveProject } from "@/hooks/use-active-project";
 import { useProjectUpdater } from "@/hooks/use-project-updater";
 import {
   type ProjectAuthenticationMode,
-  hashDocsPassword,
+  hashDocsPasswordForBrowser,
   mergeProjectAuthenticationSettings,
   readProjectAuthenticationSettings,
   validateProjectAuthenticationSettings,
-} from "@/lib/project-authentication-settings";
+} from "@/lib/project-authentication-browser";
 import { LockKeyhole, ShieldCheck } from "lucide-react";
 import { useEffect, useState } from "react";
 
@@ -52,7 +52,9 @@ export default function AuthenticationSettingsPage() {
       mode,
       password: trimmedPassword,
       passwordHash:
-        mode === "password" ? await hashDocsPassword(trimmedPassword) : "",
+        mode === "password"
+          ? await hashDocsPasswordForBrowser(trimmedPassword)
+          : "",
     };
     const validationError =
       validateProjectAuthenticationSettings(authentication);

--- a/src/lib/project-authentication-browser.ts
+++ b/src/lib/project-authentication-browser.ts
@@ -1,0 +1,89 @@
+import type {
+  ProjectAuthenticationMode,
+  ProjectAuthenticationSettings,
+} from "@/lib/project-authentication-settings";
+
+export type { ProjectAuthenticationMode, ProjectAuthenticationSettings };
+
+interface ProjectSettingsWithAuthentication {
+  authentication?: Partial<ProjectAuthenticationSettings> | null;
+}
+
+const LEGACY_SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/i;
+
+function isLegacySha256PasswordHash(value: string) {
+  return LEGACY_SHA256_HEX_PATTERN.test(value);
+}
+
+async function hashLegacySha256Password(password: string) {
+  const data = new TextEncoder().encode(password);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Browser-safe docs password hashing for the settings UI.
+ *
+ * The server verifier intentionally keeps SHA-256 compatibility for older saved
+ * docs passwords, so the client can save a verifiable password hash without
+ * bundling Node's `crypto` module into the dashboard route.
+ */
+export async function hashDocsPasswordForBrowser(password: string) {
+  return hashLegacySha256Password(password);
+}
+
+export function readProjectAuthenticationSettings(
+  settings: Record<string, unknown> | null | undefined,
+): ProjectAuthenticationSettings {
+  const authSettings = (settings as ProjectSettingsWithAuthentication | null)
+    ?.authentication;
+  const password =
+    typeof authSettings?.password === "string" ? authSettings.password : "";
+  const rawPasswordHash =
+    typeof authSettings?.passwordHash === "string"
+      ? authSettings.passwordHash
+      : "";
+  const passwordHash =
+    rawPasswordHash || isLegacySha256PasswordHash(password)
+      ? rawPasswordHash || password
+      : "";
+
+  return {
+    mode: authSettings?.mode === "password" ? "password" : "public",
+    password: passwordHash ? "" : password,
+    passwordHash,
+  };
+}
+
+export function mergeProjectAuthenticationSettings(
+  settings: Record<string, unknown> | null | undefined,
+  authentication: ProjectAuthenticationSettings,
+) {
+  return {
+    ...(settings ?? {}),
+    authentication: {
+      mode: authentication.mode,
+      password: "",
+      passwordHash:
+        authentication.mode === "password"
+          ? authentication.passwordHash || authentication.password
+          : "",
+    },
+  };
+}
+
+export function validateProjectAuthenticationSettings(
+  authentication: ProjectAuthenticationSettings,
+): string | null {
+  if (
+    authentication.mode === "password" &&
+    !authentication.password.trim() &&
+    !authentication.passwordHash?.trim()
+  ) {
+    return "Password protection requires a password.";
+  }
+
+  return null;
+}

--- a/tests/project-authentication-browser.test.ts
+++ b/tests/project-authentication-browser.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  hashDocsPasswordForBrowser,
+  mergeProjectAuthenticationSettings,
+  readProjectAuthenticationSettings,
+  validateProjectAuthenticationSettings,
+} from "@/lib/project-authentication-browser";
+import { verifyDocsPasswordHash } from "@/lib/project-authentication-settings";
+
+describe("project authentication browser helpers", () => {
+  it("hashes docs passwords without Node crypto and keeps them server-verifiable", async () => {
+    const hash = await hashDocsPasswordForBrowser("secret");
+
+    expect(hash).toBe(
+      "2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b",
+    );
+    expect(await verifyDocsPasswordHash(hash, "secret")).toBe(true);
+    expect(await verifyDocsPasswordHash(hash, "wrong")).toBe(false);
+  });
+
+  it("keeps settings helper behavior aligned with the server module", () => {
+    const settings = mergeProjectAuthenticationSettings(
+      { theme: "dark" },
+      { mode: "password", password: "", passwordHash: "hashed-secret" },
+    );
+
+    expect(settings).toEqual({
+      theme: "dark",
+      authentication: {
+        mode: "password",
+        password: "",
+        passwordHash: "hashed-secret",
+      },
+    });
+    expect(readProjectAuthenticationSettings(settings)).toEqual({
+      mode: "password",
+      password: "",
+      passwordHash: "hashed-secret",
+    });
+    expect(
+      validateProjectAuthenticationSettings({ mode: "password", password: "" }),
+    ).toBe("Password protection requires a password.");
+  });
+});


### PR DESCRIPTION
## Summary
- Move the settings authentication page off the server-only docs auth helper so the client bundle no longer imports `node:crypto`
- Add a browser-safe docs password hash helper that produces server-verifiable legacy hashes
- Cover the browser helper with tests

Fixes #195

## Verification
- `npm test -- project-authentication-browser.test.ts project-authentication-settings.test.ts docs-auth-route.test.ts`
- `npm run typecheck`
- `npm run lint`
- `BETTER_AUTH_URL=http://localhost:3015 BETTER_AUTH_SECRET=0123456789abcdef0123456789abcdef NEXT_PUBLIC_APP_URL=http://localhost:3015 npm run build`

Note: a plain `npm run build` still fails without required production env vars (`BETTER_AUTH_URL`, then `NEXT_PUBLIC_APP_URL`); build passes once those are supplied.