### PR TITLE
Fix docs auth cookie credential

### DIFF
--- a/src/app/api/docs/[subdomain]/auth/route.ts
+++ b/src/app/api/docs/[subdomain]/auth/route.ts
@@ -1,5 +1,6 @@
 import { db } from "@/lib/db";
 import { projects } from "@/lib/db/schema";
+import { readProjectAuthenticationSettings } from "@/lib/project-authentication-settings";
 import {
   createDocsAccessToken,
   getDocsAccessCookieName,
@@ -13,6 +14,14 @@ export function normalizeDocsReturnTo(returnTo: string, subdomain: string) {
   if (!returnTo.startsWith(fallback)) return fallback;
   if (returnTo.startsWith("//") || returnTo.includes("://")) return fallback;
   return returnTo;
+}
+
+export function getDocsAccessCredential(
+  settings: Record<string, unknown> | null | undefined,
+  fallbackPassword: string,
+) {
+  const auth = readProjectAuthenticationSettings(settings);
+  return auth.passwordHash || auth.password || fallbackPassword;
 }
 
 export async function POST(
@@ -47,11 +56,7 @@ export async function POST(
   try {
     accessToken = createDocsAccessToken(
       subdomain,
-      (
-        project.settings as {
-          authentication?: { passwordHash?: string; password?: string };
-        }
-      )?.authentication?.passwordHash || password,
+      getDocsAccessCredential(project.settings, password),
     );
   } catch {
     return NextResponse.json(

--- a/tests/docs-auth-route.test.ts
+++ b/tests/docs-auth-route.test.ts
@@ -1,7 +1,34 @@
-import { normalizeDocsReturnTo } from "@/app/api/docs/[subdomain]/auth/route";
+import {
+  getDocsAccessCredential,
+  normalizeDocsReturnTo,
+} from "@/app/api/docs/[subdomain]/auth/route";
 import { describe, expect, it } from "vitest";
 
 describe("docs auth route", () => {
+  it("uses the normalized stored credential when minting access cookies", () => {
+    const legacyHash =
+      "2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b";
+
+    expect(
+      getDocsAccessCredential(
+        { authentication: { mode: "password", password: legacyHash } },
+        "secret",
+      ),
+    ).toBe(legacyHash);
+    expect(
+      getDocsAccessCredential(
+        {
+          authentication: {
+            mode: "password",
+            password: "",
+            passwordHash: "hashed-secret",
+          },
+        },
+        "secret",
+      ),
+    ).toBe("hashed-secret");
+  });
+
   it("allows same-site docs return paths", () => {
     expect(normalizeDocsReturnTo("/docs/acme/intro", "acme")).toBe(
       "/docs/acme/intro",


### PR DESCRIPTION
## Summary
- Fix the docs auth POST route to mint access cookies from the normalized stored credential, not only `authentication.passwordHash` or the submitted password
- Covers legacy SHA-256 hashes stored in `authentication.password`, which verified successfully but produced an invalid access cookie and sent users back to the password gate
- Add route-level regression coverage for the credential selection

Fixes #195

## Verification
- `npm test -- docs-auth-route.test.ts project-authentication-settings.test.ts project-authentication-browser.test.ts`
- `npm run typecheck`
- `npm run lint`
- `BETTER_AUTH_URL=http://localhost:3015 BETTER_AUTH_SECRET=0123456789abcdef0123456789abcdef NEXT_PUBLIC_APP_URL=http://localhost:3015 npm run build`