### PR TITLE
Fix AI assistant Bedrock model id

### DIFF
--- a/src/app/api/docs/[subdomain]/chat/route.ts
+++ b/src/app/api/docs/[subdomain]/chat/route.ts
@@ -14,6 +14,7 @@ import {
   buildSearchQuery,
   validateCreateMessageRequest,
 } from "@/lib/assistant";
+import { getAssistantBedrockModelId } from "@/lib/assistant-model";
 import { db } from "@/lib/db";
 import { assistantConversations, pages, projects } from "@/lib/db/schema";
 import {
@@ -28,7 +29,7 @@ import { and, eq, ilike, or } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 
 const bedrock = new BedrockRuntimeClient({ region: "us-east-1" });
-const MODEL_ID = "us.anthropic.claude-sonnet-4-20250514";
+const MODEL_ID = getAssistantBedrockModelId();
 
 export async function POST(
   request: NextRequest,

--- a/src/app/api/v1/assistant/create-message/route.ts
+++ b/src/app/api/v1/assistant/create-message/route.ts
@@ -16,6 +16,7 @@ import {
   buildSearchQuery,
   validateCreateMessageRequest,
 } from "@/lib/assistant";
+import { getAssistantBedrockModelId } from "@/lib/assistant-model";
 import { db } from "@/lib/db";
 import { assistantConversations, pages, projects } from "@/lib/db/schema";
 import {
@@ -26,7 +27,7 @@ import { and, eq, ilike, inArray, or } from "drizzle-orm";
 import { type NextRequest, NextResponse } from "next/server";
 
 const bedrock = new BedrockRuntimeClient({ region: "us-east-1" });
-const MODEL_ID = "us.anthropic.claude-sonnet-4-20250514";
+const MODEL_ID = getAssistantBedrockModelId();
 
 export async function POST(request: NextRequest) {
   // ── Auth ────────────────────────────────────────────────────────────────────

--- a/src/lib/assistant-model.ts
+++ b/src/lib/assistant-model.ts
@@ -1,0 +1,9 @@
+export const DEFAULT_ASSISTANT_BEDROCK_MODEL_ID =
+  "us.anthropic.claude-sonnet-4-20250514-v1:0";
+
+export function getAssistantBedrockModelId() {
+  return (
+    process.env.ASSISTANT_BEDROCK_MODEL_ID?.trim() ||
+    DEFAULT_ASSISTANT_BEDROCK_MODEL_ID
+  );
+}

--- a/tests/assistant-model.test.ts
+++ b/tests/assistant-model.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  DEFAULT_ASSISTANT_BEDROCK_MODEL_ID,
+  getAssistantBedrockModelId,
+} from "@/lib/assistant-model";
+
+describe("assistant Bedrock model id", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("defaults to the valid Bedrock inference profile id", () => {
+    expect(DEFAULT_ASSISTANT_BEDROCK_MODEL_ID).toBe(
+      "us.anthropic.claude-sonnet-4-20250514-v1:0",
+    );
+    expect(getAssistantBedrockModelId()).toBe(
+      "us.anthropic.claude-sonnet-4-20250514-v1:0",
+    );
+  });
+
+  it("allows an explicit model override", () => {
+    vi.stubEnv("ASSISTANT_BEDROCK_MODEL_ID", "custom-model-id");
+
+    expect(getAssistantBedrockModelId()).toBe("custom-model-id");
+  });
+});


### PR DESCRIPTION
## Summary
- Fix the docs AI assistant Bedrock model identifier by using the valid Claude Sonnet 4 inference profile id (`us.anthropic.claude-sonnet-4-20250514-v1:0`)
- Centralize the assistant model id and allow `ASSISTANT_BEDROCK_MODEL_ID` override
- Apply the same model id fix to both public docs chat and the assistant API endpoint

Fixes #196

## Verification
- `npm test -- assistant-model.test.ts`
- `npm run typecheck`
- `npm run lint`
- `BETTER_AUTH_URL=http://localhost:3015 BETTER_AUTH_SECRET=0123456789abcdef0123456789abcdef NEXT_PUBLIC_APP_URL=http://localhost:3015 npm run build`