### PR TITLE
Fix analytics empty state styling

### DIFF
--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { EmptyState } from "@/components/empty-state";
+import { AnalyticsEmptyState } from "@/components/analytics/analytics-empty-state";
 import { useActiveProject } from "@/hooks/use-active-project";
 import {
   getDatePresets,
@@ -22,7 +22,6 @@ import {
   truncatePath,
 } from "@/lib/analytics-visitors";
 import { analyticsEmptyState } from "@/lib/empty-states";
-import { BarChart3 } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import {
@@ -340,14 +339,11 @@ function VisitorsContent() {
   // Show empty state when no data exists at all
   if (totalVisitors === 0 && topPages.length === 0 && referrals.length === 0) {
     return (
-      <EmptyState
-        icon={<BarChart3 size={32} className="text-emerald-500" />}
+      <AnalyticsEmptyState
         title={analyticsEmptyState.title}
         description={analyticsEmptyState.description}
-        action={{
-          label: analyticsEmptyState.ctaLabel,
-          href: analyticsEmptyState.ctaHref,
-        }}
+        ctaLabel={analyticsEmptyState.ctaLabel}
+        ctaHref={analyticsEmptyState.ctaHref}
       />
     );
   }

--- a/src/components/analytics/analytics-empty-state.tsx
+++ b/src/components/analytics/analytics-empty-state.tsx
@@ -1,0 +1,38 @@
+import { BarChart3 } from "lucide-react";
+import Link from "next/link";
+
+export function AnalyticsEmptyState({
+  title,
+  description,
+  ctaLabel,
+  ctaHref,
+}: {
+  title: string;
+  description: string;
+  ctaLabel: string;
+  ctaHref?: string;
+}) {
+  return (
+    <div
+      className="flex flex-col items-center justify-center py-20 text-center"
+      data-testid="analytics-empty-state"
+    >
+      <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-emerald-500/10">
+        <BarChart3 size={32} className="text-emerald-500" />
+      </div>
+      <h3 className="mb-1 text-lg font-semibold text-white">{title}</h3>
+      <p className="mb-4 max-w-sm text-sm text-gray-500">{description}</p>
+      {ctaHref ? (
+        <Link
+          href={ctaHref}
+          className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
+          data-testid="analytics-empty-state-cta"
+        >
+          {ctaLabel}
+        </Link>
+      ) : (
+        <span className="text-sm font-medium text-emerald-500">{ctaLabel}</span>
+      )}
+    </div>
+  );
+}

--- a/tests/analytics-empty-state.test.tsx
+++ b/tests/analytics-empty-state.test.tsx
@@ -1,0 +1,52 @@
+import { AnalyticsEmptyState } from "@/components/analytics/analytics-empty-state";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeAll, describe, expect, it } from "vitest";
+
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+function renderEmptyState() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <AnalyticsEmptyState
+        title="No data yet"
+        description="Share your docs URL to start collecting analytics."
+        ctaLabel="Share your docs URL"
+        ctaHref="/settings"
+      />,
+    );
+  });
+
+  return { container, root };
+}
+
+describe("AnalyticsEmptyState", () => {
+  it("uses dark analytics styles instead of theme CSS variables", () => {
+    const { container, root } = renderEmptyState();
+
+    const emptyState = container.querySelector(
+      '[data-testid="analytics-empty-state"]',
+    );
+    const title = container.querySelector("h3");
+    const cta = container.querySelector(
+      '[data-testid="analytics-empty-state-cta"]',
+    );
+
+    expect(emptyState?.textContent).toContain("No data yet");
+    expect(title?.className).toContain("text-white");
+    expect(title?.className).not.toContain("var(--od-text)");
+    expect(cta?.getAttribute("href")).toBe("/settings");
+    expect(cta?.className).toContain("bg-emerald-600");
+
+    act(() => root.unmount());
+    container.remove();
+  });
+});


### PR DESCRIPTION
## Summary
- replace the analytics landing empty state with a dark-theme-safe component
- keep the Share your docs URL CTA visible on the analytics tab
- add a regression test for analytics empty-state styling

## Verification
- npm test
- npm run typecheck
- npm run lint
- BETTER_AUTH_URL=http://localhost:3015 BETTER_AUTH_SECRET=0123456789abcdef0123456789abcdef NEXT_PUBLIC_APP_URL=http://localhost:3015 npm run build

Closes #198