### PR TITLE
Fix generated GitHub docs rendering in editor

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4291,3 +4291,30 @@ pre.mermaid svg {
 .editor-prose a {
   color: #34d399;
 }
+
+.editor-markdown-table-preview {
+  margin: 1.25rem 0;
+  overflow-x: auto;
+}
+
+.editor-markdown-table-preview table {
+  width: 100%;
+  border-collapse: collapse;
+  color: #d1d5db;
+  font-size: 0.92rem;
+  line-height: 1.6;
+}
+
+.editor-markdown-table-preview th,
+.editor-markdown-table-preview td {
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.editor-markdown-table-preview th {
+  background: rgba(148, 163, 184, 0.12);
+  color: #f8fafc;
+  font-weight: 650;
+}

--- a/src/components/editor/visual-editor.tsx
+++ b/src/components/editor/visual-editor.tsx
@@ -25,6 +25,7 @@ export interface VisualEditorHandle {
 }
 
 const MDX_PREVIEW_TAG = "mdx-preview";
+const MARKDOWN_TABLE_TAG = "markdown-table-preview";
 
 const MdxPreviewNode = Node.create({
   name: "mdxPreview",
@@ -97,6 +98,54 @@ const MdxPreviewNode = Node.create({
       summary.textContent = node.attrs.summary || `${node.attrs.label} preview`;
 
       dom.append(header, summary);
+      return { dom };
+    };
+  },
+});
+
+const MarkdownTablePreviewNode = Node.create({
+  name: "markdownTablePreview",
+  group: "block",
+  atom: true,
+  selectable: true,
+
+  addAttributes() {
+    return {
+      source: {
+        default: "",
+        parseHTML: (element: HTMLElement) =>
+          element.getAttribute("data-source") ?? "",
+        renderHTML: (attributes: Record<string, unknown>) => ({
+          "data-source": attributes.source,
+        }),
+      },
+      html: {
+        default: "",
+        parseHTML: (element: HTMLElement) =>
+          element.getAttribute("data-html") ?? "",
+        renderHTML: (attributes: Record<string, unknown>) => ({
+          "data-html": attributes.html,
+        }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: MARKDOWN_TABLE_TAG }];
+  },
+
+  renderHTML({ HTMLAttributes }: { HTMLAttributes: Record<string, unknown> }) {
+    return [MARKDOWN_TABLE_TAG, mergeAttributes(HTMLAttributes)];
+  },
+
+  addNodeView() {
+    return ({ node }: { node: { attrs: Record<string, string> } }) => {
+      const dom = document.createElement("div");
+      dom.className = "editor-markdown-table-preview";
+      dom.contentEditable = "false";
+      dom.dataset.source = node.attrs.source;
+      dom.dataset.html = node.attrs.html;
+      dom.innerHTML = decodeSource(node.attrs.html);
       return { dom };
     };
   },
@@ -225,75 +274,168 @@ function replaceMdxBlocks(md: string): string {
   );
 }
 
-/** Convert simple markdown to HTML for Tiptap. */
-function markdownToHtml(md: string): string {
-  let html = replaceMdxBlocks(md);
+function createMarkdownTablePreviewTag(source: string): string {
+  const rows = source
+    .trim()
+    .split("\n")
+    .map((line) =>
+      line
+        .trim()
+        .replace(/^\|/, "")
+        .replace(/\|$/, "")
+        .split("|")
+        .map((cell) => cell.trim()),
+    );
+  const [header = [], _separator = [], ...body] = rows;
+  const tableHtml = `<table><thead><tr>${header
+    .map((cell) => `<th>${processInlineMarkdown(cell)}</th>`)
+    .join("")}</tr></thead><tbody>${body
+    .map(
+      (row) =>
+        `<tr>${row
+          .map((cell) => `<td>${processInlineMarkdown(cell)}</td>`)
+          .join("")}</tr>`,
+    )
+    .join("")}</tbody></table>`;
 
-  html = html.replace(/^######\s+(.+)$/gm, "<h6>$1</h6>");
-  html = html.replace(/^#####\s+(.+)$/gm, "<h5>$1</h5>");
-  html = html.replace(/^####\s+(.+)$/gm, "<h4>$1</h4>");
-  html = html.replace(/^###\s+(.+)$/gm, "<h3>$1</h3>");
-  html = html.replace(/^##\s+(.+)$/gm, "<h2>$1</h2>");
-  html = html.replace(/^#\s+(.+)$/gm, "<h1>$1</h1>");
+  return `<${MARKDOWN_TABLE_TAG} data-source="${escapeHtml(
+    encodeSource(source),
+  )}" data-html="${escapeHtml(encodeSource(tableHtml))}"></${MARKDOWN_TABLE_TAG}>`;
+}
 
+function tokenizeBlocks(
+  value: string,
+  pattern: RegExp,
+  replacer: (match: string, ...groups: string[]) => string,
+): { text: string; restore: (text: string) => string } {
+  const blocks: string[] = [];
+  const text = value.replace(pattern, (match, ...groups: string[]) => {
+    const token = `\u0000BLOCK_${blocks.length}\u0000`;
+    blocks.push(replacer(match, ...groups));
+    return token;
+  });
+  return {
+    text,
+    restore: (current) =>
+      blocks.reduce(
+        (result, block, index) =>
+          result.replace(`\u0000BLOCK_${index}\u0000`, block),
+        current,
+      ),
+  };
+}
+
+function isMarkdownTableStart(lines: string[], index: number): boolean {
+  const header = lines[index]?.trim() ?? "";
+  const separator = lines[index + 1]?.trim() ?? "";
+  return (
+    header.startsWith("|") &&
+    header.endsWith("|") &&
+    /^\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?$/.test(separator)
+  );
+}
+
+function replaceMarkdownTables(value: string): string {
+  const lines = value.split("\n");
+  const output: string[] = [];
+
+  for (let index = 0; index < lines.length; index++) {
+    if (!isMarkdownTableStart(lines, index)) {
+      output.push(lines[index]);
+      continue;
+    }
+
+    const tableLines = [lines[index], lines[index + 1]];
+    index += 2;
+    while (index < lines.length && /^\s*\|.*\|\s*$/.test(lines[index] ?? "")) {
+      tableLines.push(lines[index]);
+      index += 1;
+    }
+    index -= 1;
+    output.push(createMarkdownTablePreviewTag(tableLines.join("\n")));
+  }
+
+  return output.join("\n");
+}
+
+function processInlineMarkdown(value: string): string {
+  let html = escapeHtml(value);
   html = html.replace(/\*\*\*(.+?)\*\*\*/g, "<strong><em>$1</em></strong>");
   html = html.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
   html = html.replace(/\*(.+?)\*/g, "<em>$1</em>");
-
   html = html.replace(/`([^`]+)`/g, "<code>$1</code>");
-  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
-  html = html.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img src="$2" alt="$1" />');
-
-  html = html.replace(/^---$/gm, "<hr>");
   html = html.replace(
+    /\[!\[([^\]]*)\]\(([^)]+)\)\]\(([^)]+)\)/g,
+    '<a href="$3"><img src="$2" alt="$1" /></a>',
+  );
+  html = html.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img src="$2" alt="$1" />');
+  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+  return html;
+}
+
+/** Convert simple markdown to HTML for Tiptap. */
+function markdownToHtml(md: string): string {
+  const fencedBlocks = tokenizeBlocks(
+    replaceMdxBlocks(md),
     /```(\w*)\n([\s\S]*?)```/g,
-    (_match, _lang, code) => `<pre><code>${code.trim()}</code></pre>`,
+    (_match, _lang, code) =>
+      `<pre><code>${escapeHtml(code.trim())}</code></pre>`,
   );
 
-  const lines = html.split("\n");
-  const result: string[] = [];
-  let inBlock = false;
+  let html = replaceMarkdownTables(fencedBlocks.text);
+  html = html.replace(
+    /^######\s+(.+)$/gm,
+    (_match, text) => `<h6>${processInlineMarkdown(text)}</h6>`,
+  );
+  html = html.replace(
+    /^#####\s+(.+)$/gm,
+    (_match, text) => `<h5>${processInlineMarkdown(text)}</h5>`,
+  );
+  html = html.replace(
+    /^####\s+(.+)$/gm,
+    (_match, text) => `<h4>${processInlineMarkdown(text)}</h4>`,
+  );
+  html = html.replace(
+    /^###\s+(.+)$/gm,
+    (_match, text) => `<h3>${processInlineMarkdown(text)}</h3>`,
+  );
+  html = html.replace(
+    /^##\s+(.+)$/gm,
+    (_match, text) => `<h2>${processInlineMarkdown(text)}</h2>`,
+  );
+  html = html.replace(
+    /^#\s+(.+)$/gm,
+    (_match, text) => `<h1>${processInlineMarkdown(text)}</h1>`,
+  );
+  html = html.replace(/^---$/gm, "<hr>");
+  html = html.replace(
+    /^>\s?(.+(?:\n>\s?.+)*)$/gm,
+    (match) =>
+      `<blockquote>${match
+        .split("\n")
+        .map((line) => processInlineMarkdown(line.replace(/^>\s?/, "")))
+        .join("<br>")}</blockquote>`,
+  );
 
-  for (const line of lines) {
-    if (
-      line.startsWith("<h") ||
-      line.startsWith("<hr") ||
-      line.startsWith("<pre") ||
-      line.startsWith(`<${MDX_PREVIEW_TAG}`) ||
-      line.startsWith("<img") ||
-      line.startsWith("<ul") ||
-      line.startsWith("<ol")
-    ) {
-      inBlock = true;
-      result.push(line);
-      if (
-        line.includes("</pre>") ||
-        line.includes(`</${MDX_PREVIEW_TAG}>`) ||
-        line.includes("</ul>") ||
-        line.includes("</ol>")
-      ) {
-        inBlock = false;
+  html = html
+    .split("\n")
+    .map((line) => {
+      if (!line.trim()) return "";
+      if (/^<\/?(h[1-6]|hr|pre|blockquote|img|ul|ol|li|a)/.test(line)) {
+        return line;
       }
-    } else if (inBlock) {
-      result.push(line);
       if (
-        line.includes("</pre>") ||
-        line.includes(`</${MDX_PREVIEW_TAG}>`) ||
-        line.includes("</ul>") ||
-        line.includes("</ol>")
+        line.startsWith(`<${MDX_PREVIEW_TAG}`) ||
+        line.startsWith(`<${MARKDOWN_TABLE_TAG}`) ||
+        line.startsWith("\u0000BLOCK_")
       ) {
-        inBlock = false;
+        return line;
       }
-    } else if (line.trim() === "") {
-      result.push("");
-    } else if (!line.startsWith("<")) {
-      result.push(`<p>${line}</p>`);
-    } else {
-      result.push(line);
-    }
-  }
+      return `<p>${processInlineMarkdown(line)}</p>`;
+    })
+    .join("\n");
 
-  return result.join("\n");
+  return fencedBlocks.restore(html);
 }
 
 /** Convert Tiptap HTML back to markdown. */
@@ -305,6 +447,19 @@ function htmlToMarkdown(html: string): string {
   md = md.replace(
     new RegExp(
       `<${MDX_PREVIEW_TAG}[^>]*data-source="([^"]+)"[^>]*><\\/${MDX_PREVIEW_TAG}>`,
+      "gi",
+    ),
+    (_match, source) => {
+      const token = `__MDX_PREVIEW_${previewIndex}__`;
+      previewSources.set(token, decodeSource(source));
+      previewIndex += 1;
+      return `\n\n${token}\n\n`;
+    },
+  );
+
+  md = md.replace(
+    new RegExp(
+      `<${MARKDOWN_TABLE_TAG}[^>]*data-source="([^"]+)"[^>]*><\\/${MARKDOWN_TABLE_TAG}>`,
       "gi",
     ),
     (_match, source) => {
@@ -332,6 +487,10 @@ function htmlToMarkdown(html: string): string {
     "```\n$1\n```\n\n",
   );
 
+  md = md.replace(
+    /<a[^>]*href="([^"]*)"[^>]*>\s*<img[^>]*src="([^"]+)"[^>]*alt="([^"]*)"[^>]*\/?>(?:<\/img>)?\s*<\/a>/gi,
+    "[![$3]($2)]($1)",
+  );
   md = md.replace(/<a[^>]*href="([^"]*)"[^>]*>(.*?)<\/a>/gi, "[$2]($1)");
   md = md.replace(
     /<img[^>]*src="([^"]+)"[^>]*alt="([^"]*)"[^>]*\/?>/gi,
@@ -449,6 +608,7 @@ export const VisualEditor = forwardRef<VisualEditorHandle, VisualEditorProps>(
         }),
         Underline,
         MdxPreviewNode,
+        MarkdownTablePreviewNode,
         Placeholder.configure({
           placeholder: "Start writing your documentation...",
         }),

--- a/tests/editor.test.ts
+++ b/tests/editor.test.ts
@@ -297,6 +297,52 @@ Paragraph text.
     const markdown = "![Diagram](https://placehold.co/600x400/png)";
     expect(htmlToMarkdown(markdownToHtml(markdown))).toBe(markdown);
   });
+
+  it("renders GitHub README tables, blockquotes, linked images, and fenced code without leaking markdown syntax", () => {
+    const markdown = `[![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+
+![Architecture](./docs/architecture.png)
+
+> **Note for AI agents:** Start at [Setup](./docs/setup.md).
+
+| Metric | Result |
+|--------|--------|
+| Features built | **52** |
+| API endpoints | 16+ |
+
+Verify:
+
+\`\`\`bash
+git clone https://github.com/YOUR_USERNAME/ralph-to-ralph.git
+cd ralph-to-ralph
+\`\`\`
+
+### Optional: track upstream for future pipeline improvements`;
+
+    const html = markdownToHtml(markdown);
+
+    expect(html).toContain(
+      '<a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License" /></a>',
+    );
+    expect(html).toContain(
+      '<img src="./docs/architecture.png" alt="Architecture" />',
+    );
+    expect(html).toContain("<blockquote>");
+    expect(html).toContain(
+      '<strong>Note for AI agents:</strong> Start at <a href="./docs/setup.md">Setup</a>.',
+    );
+    expect(html).toContain("markdown-table-preview");
+    expect(html).toContain("<pre><code>");
+    expect(html).toContain(
+      "git clone https://github.com/YOUR_USERNAME/ralph-to-ralph.git",
+    );
+    expect(html).toContain(
+      "<h3>Optional: track upstream for future pipeline improvements</h3>",
+    );
+    expect(html).not.toContain("!Architecture");
+    expect(html).not.toContain("| Metric | Result |");
+    expect(html).not.toContain("<code>bash");
+  });
 });
 
 describe("insertSnippetAtCursor", () => {


### PR DESCRIPTION
## Summary\n- Fix visual editor markdown conversion so GitHub README badges/images render as images/links instead of leaking raw markdown syntax.\n- Add support for blockquotes, fenced code blocks, and GitHub-style markdown tables in imported docs.\n- Add styling and regression coverage for README content matching the Ralph-to-Ralph screenshots.\n\n## Validation\n- npm run lint\n- npm run typecheck\n- npm test