### PR TITLE
fix: improve new documentation warning contrast

### DIFF
--- a/src/components/github/connected-repo-select.tsx
+++ b/src/components/github/connected-repo-select.tsx
@@ -103,7 +103,16 @@ export function ConnectedRepoSelect({
           </div>
         </div>
       ) : (
-        <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
+        <div
+          className="rounded-lg border px-4 py-3 text-sm font-medium"
+          data-testid="empty-connected-repos-notice"
+          style={{
+            background: "var(--od-warning-soft)",
+            borderColor:
+              "color-mix(in srgb, var(--od-warning) 35%, transparent)",
+            color: "var(--od-text)",
+          }}
+        >
           No connected GitHub repositories yet. Connect GitHub first to import a
           private repository.
         </div>

--- a/tests/connected-repo-select.test.tsx
+++ b/tests/connected-repo-select.test.tsx
@@ -1,0 +1,17 @@
+import { ConnectedRepoSelect } from "@/components/github/connected-repo-select";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+describe("ConnectedRepoSelect", () => {
+  it("uses readable theme colors for the empty connected repos notice", () => {
+    const html = renderToStaticMarkup(
+      <ConnectedRepoSelect repos={[]} value="" onChange={vi.fn()} />,
+    );
+
+    expect(html).toContain('data-testid="empty-connected-repos-notice"');
+    expect(html).toContain("No connected GitHub repositories yet");
+    expect(html).toContain("color:var(--od-text)");
+    expect(html).toContain("background:var(--od-warning-soft)");
+    expect(html).not.toContain("text-amber-200");
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the low-contrast pale amber empty GitHub repositories notice with theme-aware warning surface colors
- Keep the notice readable on the light dashboard theme while preserving warning styling
- Add a regression render test to ensure the old text-amber-200 class does not come back

## Test Plan
- npm test -- connected-repo-select.test.tsx
- make check
- make test

Note: Ever browser verification was attempted, but the Ever extension was not connected in this environment; local browser navigation reached the auth gate before dashboard rendering.