### PR TITLE
Fix default docs visual branding

### DIFF
--- a/src/app/docs/[subdomain]/[...slug]/page.tsx
+++ b/src/app/docs/[subdomain]/[...slug]/page.tsx
@@ -573,9 +573,18 @@ export default async function DocsPage({
   );
 
   const docsThemeStyle = getDocsThemeCssVars(docsConfig) as CSSProperties;
+  const forcedTheme =
+    docsConfig.visualBranding.theme === "light" ||
+    docsConfig.visualBranding.theme === "dark"
+      ? docsConfig.visualBranding.theme
+      : undefined;
 
   return (
-    <div className="docs-layout" style={docsThemeStyle}>
+    <div
+      className="docs-layout"
+      style={docsThemeStyle}
+      data-theme={forcedTheme}
+    >
       <DocsTopbar
         projectName={project.name}
         subdomain={subdomain}
@@ -614,6 +623,7 @@ export default async function DocsPage({
         activePath={pagePath}
         subdomain={subdomain}
         projectName={project.name}
+        settings={project.settings as Record<string, unknown>}
       />
 
       <div className="docs-body">
@@ -622,6 +632,7 @@ export default async function DocsPage({
           activePath={pagePath}
           subdomain={subdomain}
           projectName={project.name}
+          settings={project.settings as Record<string, unknown>}
         />
 
         <main id="main-content" className="docs-main" tabIndex={-1}>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -391,8 +391,9 @@ body {
 /* ── Docs Site Layout ──────────────────────────────────────────────────────── */
 
 .docs-layout {
-  --docs-bg: #080d0c;
-  --docs-bg-deep: #050908;
+  --docs-bg: var(--docs-dark-bg, #0e0f18);
+  --docs-bg-deep: color-mix(in srgb, var(--docs-dark-bg, #0e0f18) 88%, black);
+  --docs-logo-color: var(--docs-primary, #7b8fde);
   --docs-surface: rgba(255, 255, 255, 0.045);
   --docs-surface-hover: rgba(255, 255, 255, 0.075);
   --docs-border: rgba(255, 255, 255, 0.075);
@@ -400,17 +401,21 @@ body {
   --docs-text: #f7faf8;
   --docs-text-muted: #9aa39f;
   --docs-text-subtle: #6f7874;
-  --docs-green: #00e887;
-  --docs-green-soft: rgba(0, 232, 135, 0.11);
-  --docs-green-border: rgba(0, 232, 135, 0.32);
-  --docs-card: #0b1110;
+  --docs-green: var(--docs-primary, #7b8fde);
+  --docs-green-soft: var(--docs-primary-soft, rgba(123, 143, 222, 0.14));
+  --docs-green-border: color-mix(
+    in srgb,
+    var(--docs-primary, #7b8fde) 38%,
+    transparent
+  );
+  --docs-card: color-mix(in srgb, var(--docs-dark-bg, #0e0f18) 86%, white);
 }
 
 .docs-layout {
   min-height: 100vh;
   background: radial-gradient(
       circle at 55% -12%,
-      rgba(0, 232, 135, 0.07),
+      color-mix(in srgb, var(--docs-primary, #7b8fde) 9%, transparent),
       transparent 28rem
     ), var(--docs-bg);
   color: var(--docs-text);
@@ -427,7 +432,7 @@ body {
   z-index: 100;
   transform: translateY(-150%);
   border-radius: 8px;
-  background: var(--docs-primary, #16a34a);
+  background: var(--docs-primary, #7b8fde);
   color: #ffffff;
   padding: 8px 12px;
   font-size: 13px;
@@ -534,7 +539,7 @@ body {
   gap: 4px;
   padding: 6px 14px;
   border-radius: 8px;
-  background: var(--docs-primary, #16a34a);
+  background: var(--docs-primary, #7b8fde);
   color: #fff;
   font-size: 13px;
   font-weight: 500;
@@ -543,7 +548,7 @@ body {
 }
 
 .docs-topbar-dashboard-btn:hover {
-  background: #15803d;
+  background: color-mix(in srgb, var(--docs-primary, #7b8fde) 82%, black);
 }
 
 .docs-search-btn {
@@ -612,6 +617,18 @@ body {
   gap: 8px;
   text-decoration: none;
   color: #f9fafb;
+}
+
+.docs-logo-mark {
+  color: var(--docs-logo-color, var(--docs-primary, #7b8fde));
+  flex: 0 0 auto;
+}
+
+.docs-sidebar-logo-image {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+  flex: 0 0 auto;
 }
 
 .docs-logo-text {
@@ -690,7 +707,7 @@ body {
 
 .docs-breadcrumb {
   font-size: 13px;
-  color: var(--docs-primary, #16a34a);
+  color: var(--docs-logo-color, var(--docs-primary, #7b8fde));
   margin-bottom: 8px;
   font-weight: 500;
 }
@@ -700,7 +717,7 @@ body {
 }
 
 .docs-breadcrumb-active {
-  color: var(--docs-primary, #16a34a);
+  color: var(--docs-logo-color, var(--docs-primary, #7b8fde));
 }
 
 .docs-title-row {
@@ -973,11 +990,11 @@ body {
 }
 
 .docs-content blockquote {
-  border-left: 3px solid var(--docs-primary, #16a34a);
+  border-left: 3px solid var(--docs-primary, #7b8fde);
   padding: 8px 16px;
   margin: 16px 0;
   color: #9ca3af;
-  background: rgba(22, 163, 74, 0.04);
+  background: color-mix(in srgb, var(--docs-primary, #7b8fde) 4%, transparent);
   border-radius: 0 6px 6px 0;
 }
 
@@ -1069,12 +1086,12 @@ body {
 }
 
 .code-ask-ai {
-  color: var(--docs-primary, #16a34a);
+  color: var(--docs-logo-color, var(--docs-primary, #7b8fde));
 }
 
 .code-ask-ai:hover {
-  color: #22c55e;
-  background: rgba(22, 163, 74, 0.1);
+  color: color-mix(in srgb, var(--docs-primary, #7b8fde) 78%, white);
+  background: var(--docs-primary-soft, rgba(123, 143, 222, 0.12));
 }
 
 .code-panel-actions {
@@ -1139,12 +1156,16 @@ body {
 }
 
 .callout-tip {
-  background: rgba(22, 163, 74, 0.06);
-  border-color: rgba(22, 163, 74, 0.2);
+  background: var(--docs-primary-soft, rgba(123, 143, 222, 0.1));
+  border-color: color-mix(
+    in srgb,
+    var(--docs-primary, #7b8fde) 20%,
+    transparent
+  );
 }
 
 .callout-tip .callout-icon {
-  color: var(--docs-primary, #16a34a);
+  color: var(--docs-logo-color, var(--docs-primary, #7b8fde));
 }
 
 .callout-icon {
@@ -1268,8 +1289,8 @@ body {
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  background: rgba(22, 163, 74, 0.15);
-  color: var(--docs-primary, #16a34a);
+  background: color-mix(in srgb, var(--docs-primary, #7b8fde) 15%, transparent);
+  color: var(--docs-logo-color, var(--docs-primary, #7b8fde));
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1358,8 +1379,8 @@ body {
 }
 
 .tab-button.active {
-  color: var(--docs-primary, #16a34a);
-  border-bottom-color: var(--docs-primary, #16a34a);
+  color: var(--docs-logo-color, var(--docs-primary, #7b8fde));
+  border-bottom-color: var(--docs-primary, #7b8fde);
 }
 
 .tab-panel {
@@ -1527,7 +1548,8 @@ pre.mermaid svg {
 }
 
 .expandable .expandable {
-  border-left: 2px solid rgba(22, 163, 74, 0.3);
+  border-left: 2px solid
+    color-mix(in srgb, var(--docs-primary, #7b8fde) 30%, transparent);
   border-radius: 0;
   border-top: none;
   border-right: none;
@@ -1574,12 +1596,13 @@ pre.mermaid svg {
   position: relative;
   margin: 24px 0;
   padding-left: 24px;
-  border-left: 2px solid rgba(22, 163, 74, 0.4);
+  border-left: 2px solid
+    color-mix(in srgb, var(--docs-primary, #7b8fde) 40%, transparent);
 }
 
 .update-date {
   font-size: 13px;
-  color: var(--docs-primary, #16a34a);
+  color: var(--docs-logo-color, var(--docs-primary, #7b8fde));
   font-weight: 500;
   margin-bottom: 4px;
 }
@@ -1640,8 +1663,9 @@ pre.mermaid svg {
 }
 
 .banner-success {
-  background: rgba(22, 163, 74, 0.1);
-  border: 1px solid rgba(22, 163, 74, 0.2);
+  background: var(--docs-primary-soft, rgba(123, 143, 222, 0.12));
+  border: 1px solid
+    color-mix(in srgb, var(--docs-primary, #7b8fde) 20%, transparent);
   color: #4ade80;
 }
 
@@ -1685,7 +1709,7 @@ pre.mermaid svg {
 }
 
 .badge-green {
-  background: rgba(22, 163, 74, 0.15);
+  background: color-mix(in srgb, var(--docs-primary, #7b8fde) 15%, transparent);
   color: #4ade80;
 }
 
@@ -1732,8 +1756,12 @@ pre.mermaid svg {
 }
 
 .docs-pagination-link:hover {
-  border-color: rgba(22, 163, 74, 0.3);
-  background: rgba(22, 163, 74, 0.04);
+  border-color: color-mix(
+    in srgb,
+    var(--docs-primary, #7b8fde) 30%,
+    transparent
+  );
+  background: color-mix(in srgb, var(--docs-primary, #7b8fde) 4%, transparent);
 }
 
 .docs-pagination-label {
@@ -2041,7 +2069,7 @@ pre.mermaid svg {
 }
 
 .docs-topbar-logo-icon {
-  color: var(--docs-primary, #16a34a);
+  color: var(--docs-logo-color, var(--docs-primary, #7b8fde));
 }
 
 .docs-topbar-logo-image {
@@ -2446,11 +2474,11 @@ pre.mermaid svg {
 }
 
 .lang-switcher-option-active {
-  color: var(--docs-primary, #16a34a);
+  color: var(--docs-logo-color, var(--docs-primary, #7b8fde));
 }
 
 .lang-switcher-option-active:hover {
-  color: var(--docs-primary, #16a34a);
+  color: var(--docs-logo-color, var(--docs-primary, #7b8fde));
 }
 
 .lang-switcher-option-code {
@@ -2543,11 +2571,11 @@ pre.mermaid svg {
 }
 
 .version-switcher-option-active {
-  color: var(--docs-primary, #16a34a);
+  color: var(--docs-logo-color, var(--docs-primary, #7b8fde));
 }
 
 .version-switcher-option-active:hover {
-  color: var(--docs-primary, #16a34a);
+  color: var(--docs-logo-color, var(--docs-primary, #7b8fde));
 }
 
 .version-switcher-option-name {
@@ -2561,14 +2589,18 @@ pre.mermaid svg {
   letter-spacing: 0.5px;
   padding: 2px 6px;
   border-radius: 4px;
-  background: rgba(22, 163, 74, 0.15);
-  color: var(--docs-primary, #16a34a);
+  background: color-mix(in srgb, var(--docs-primary, #7b8fde) 15%, transparent);
+  color: var(--docs-logo-color, var(--docs-primary, #7b8fde));
 }
 
 /* ── Light Theme ──────────────────────────────────────────────────────────── */
 
+.docs-layout[data-theme="light"],
 [data-theme="light"] .docs-layout {
-  background: #ffffff;
+  --docs-bg: var(--docs-light-bg, #f8f9fc);
+  --docs-bg-deep: var(--docs-light-bg, #f8f9fc);
+  --docs-card: #ffffff;
+  background: var(--docs-light-bg, #f8f9fc);
   color: #374151;
 }
 
@@ -2665,7 +2697,7 @@ pre.mermaid svg {
 }
 
 [data-theme="light"] .lang-switcher-option-active {
-  color: var(--docs-primary, #16a34a);
+  color: var(--docs-logo-color, var(--docs-primary, #7b8fde));
 }
 
 [data-theme="light"] .version-switcher-btn {
@@ -2695,11 +2727,11 @@ pre.mermaid svg {
 }
 
 [data-theme="light"] .version-switcher-option-active {
-  color: var(--docs-primary, #16a34a);
+  color: var(--docs-logo-color, var(--docs-primary, #7b8fde));
 }
 
 [data-theme="light"] .version-switcher-default-badge {
-  background: rgba(22, 163, 74, 0.1);
+  background: var(--docs-primary-soft, rgba(123, 143, 222, 0.12));
 }
 
 [data-theme="light"] .docs-sidebar {
@@ -2724,8 +2756,8 @@ pre.mermaid svg {
 }
 
 [data-theme="light"] .docs-nav-item.active {
-  color: var(--docs-primary, #16a34a);
-  background: rgba(22, 163, 74, 0.06);
+  color: var(--docs-logo-color, var(--docs-primary, #7b8fde));
+  background: var(--docs-primary-soft, rgba(123, 143, 222, 0.1));
 }
 
 [data-theme="light"] .docs-nav-group-label {
@@ -2741,7 +2773,7 @@ pre.mermaid svg {
 }
 
 [data-theme="light"] .docs-breadcrumb {
-  color: var(--docs-primary, #16a34a);
+  color: var(--docs-logo-color, var(--docs-primary, #7b8fde));
 }
 
 [data-theme="light"] .page-action-btn {
@@ -2805,7 +2837,7 @@ pre.mermaid svg {
 
 [data-theme="light"] .docs-content blockquote {
   color: #6b7280;
-  background: rgba(22, 163, 74, 0.03);
+  background: color-mix(in srgb, var(--docs-primary, #7b8fde) 3%, transparent);
 }
 
 [data-theme="light"] .docs-content hr {
@@ -2839,8 +2871,12 @@ pre.mermaid svg {
 }
 
 [data-theme="light"] .docs-pagination-link:hover {
-  border-color: rgba(22, 163, 74, 0.3);
-  background: rgba(22, 163, 74, 0.03);
+  border-color: color-mix(
+    in srgb,
+    var(--docs-primary, #7b8fde) 30%,
+    transparent
+  );
+  background: color-mix(in srgb, var(--docs-primary, #7b8fde) 3%, transparent);
 }
 
 [data-theme="light"] .docs-pagination-label {
@@ -2901,7 +2937,7 @@ pre.mermaid svg {
 }
 
 [data-theme="light"] .callout-tip {
-  background: rgba(22, 163, 74, 0.04);
+  background: color-mix(in srgb, var(--docs-primary, #7b8fde) 4%, transparent);
 }
 
 [data-theme="light"] .code-block {
@@ -3154,7 +3190,7 @@ pre.mermaid svg {
 }
 
 .chat-message-user .chat-message-avatar {
-  background: var(--docs-primary, #16a34a);
+  background: var(--docs-primary, #7b8fde);
   color: white;
 }
 
@@ -3181,7 +3217,7 @@ pre.mermaid svg {
 }
 
 .chat-message-user .chat-message-content {
-  background: var(--docs-primary, #16a34a);
+  background: var(--docs-primary, #7b8fde);
   color: white;
   border-bottom-right-radius: 4px;
 }
@@ -3331,7 +3367,7 @@ pre.mermaid svg {
 }
 
 .chat-widget-textarea:focus {
-  border-color: var(--docs-primary, #16a34a);
+  border-color: var(--docs-primary, #7b8fde);
 }
 
 .chat-widget-textarea::placeholder {
@@ -3350,7 +3386,7 @@ pre.mermaid svg {
   width: 36px;
   height: 36px;
   border-radius: 8px;
-  background: var(--docs-primary, #16a34a);
+  background: var(--docs-primary, #7b8fde);
   border: none;
   color: white;
   cursor: pointer;
@@ -3370,7 +3406,7 @@ pre.mermaid svg {
 }
 
 .chat-widget-send-btn:hover:not(:disabled) {
-  background: #15803d;
+  background: color-mix(in srgb, var(--docs-primary, #7b8fde) 82%, black);
 }
 
 .chat-widget-attachment-btn:disabled,
@@ -3507,8 +3543,8 @@ pre.mermaid svg {
 }
 
 .method-get {
-  background: var(--docs-primary-soft, #16a34a22);
-  color: var(--docs-primary, #16a34a);
+  background: var(--docs-primary-soft, #7b8fde22);
+  color: var(--docs-logo-color, var(--docs-primary, #7b8fde));
 }
 .method-post {
   background: #2563eb22;
@@ -3597,7 +3633,7 @@ pre.mermaid svg {
 }
 
 .api-param-input:focus {
-  border-color: var(--docs-primary, #16a34a);
+  border-color: var(--docs-primary, #7b8fde);
 }
 
 .api-param-input::placeholder {
@@ -3624,7 +3660,7 @@ pre.mermaid svg {
 }
 
 .api-body-textarea:focus {
-  border-color: var(--docs-primary, #16a34a);
+  border-color: var(--docs-primary, #7b8fde);
 }
 
 .api-send-section {
@@ -3632,7 +3668,7 @@ pre.mermaid svg {
 }
 
 .api-send-btn {
-  background: var(--docs-primary, #16a34a);
+  background: var(--docs-primary, #7b8fde);
   color: #fff;
   border: none;
   border-radius: 6px;
@@ -3644,7 +3680,7 @@ pre.mermaid svg {
 }
 
 .api-send-btn:hover {
-  background: #15803d;
+  background: color-mix(in srgb, var(--docs-primary, #7b8fde) 82%, black);
 }
 
 .api-send-btn:disabled {
@@ -3680,8 +3716,8 @@ pre.mermaid svg {
 }
 
 .status-2xx {
-  background: var(--docs-primary-soft, #16a34a22);
-  color: var(--docs-primary, #16a34a);
+  background: var(--docs-primary-soft, #7b8fde22);
+  color: var(--docs-logo-color, var(--docs-primary, #7b8fde));
 }
 .status-3xx {
   background: #2563eb22;
@@ -3720,8 +3756,8 @@ pre.mermaid svg {
 }
 
 .api-resp-tab.active {
-  color: var(--docs-primary, #16a34a);
-  border-bottom-color: var(--docs-primary, #16a34a);
+  color: var(--docs-logo-color, var(--docs-primary, #7b8fde));
+  border-bottom-color: var(--docs-primary, #7b8fde);
 }
 
 .api-resp-tab:hover {
@@ -3870,7 +3906,7 @@ pre.mermaid svg {
 }
 
 .api-ref-tryit-btn {
-  background: var(--docs-primary, #16a34a);
+  background: var(--docs-primary, #7b8fde);
   color: #fff;
   border: none;
   border-radius: 6px;
@@ -3883,7 +3919,7 @@ pre.mermaid svg {
 }
 
 .api-ref-tryit-btn:hover {
-  background: #15803d;
+  background: color-mix(in srgb, var(--docs-primary, #7b8fde) 82%, black);
 }
 
 /* Code Section */
@@ -3920,7 +3956,7 @@ pre.mermaid svg {
 
 .api-ref-lang-tab.active {
   color: #fff;
-  border-bottom-color: var(--docs-primary, #16a34a);
+  border-bottom-color: var(--docs-primary, #7b8fde);
 }
 
 .api-ref-lang-tab:hover {
@@ -4007,8 +4043,8 @@ pre.mermaid svg {
 }
 
 .api-ref-status-tab.active {
-  color: var(--docs-primary, #16a34a);
-  border-bottom-color: var(--docs-primary, #16a34a);
+  color: var(--docs-logo-color, var(--docs-primary, #7b8fde));
+  border-bottom-color: var(--docs-primary, #7b8fde);
 }
 
 .api-ref-status-tab:hover {

--- a/src/components/docs/docs-logo.tsx
+++ b/src/components/docs/docs-logo.tsx
@@ -1,0 +1,72 @@
+import { mergeDocsConfig } from "@/lib/docs-config";
+
+export interface DocsLogoSettings {
+  logoUrl?: string;
+  logoDarkUrl?: string;
+}
+
+export function getConfiguredDocsLogo(
+  settings: DocsLogoSettings | Record<string, unknown> | undefined,
+): { path: string; href: string } | null {
+  const raw = (settings || {}) as Record<string, unknown>;
+  const rawDocsConfig = raw.docsConfig;
+
+  if (!rawDocsConfig || typeof rawDocsConfig !== "object") {
+    const legacyLogo =
+      typeof raw.logoUrl === "string"
+        ? raw.logoUrl
+        : typeof raw.logoDarkUrl === "string"
+          ? raw.logoDarkUrl
+          : "";
+    return legacyLogo ? { path: legacyLogo, href: "" } : null;
+  }
+
+  const docsConfig = mergeDocsConfig(
+    rawDocsConfig as Partial<Record<string, unknown>>,
+  );
+  const path =
+    docsConfig.headerTopbar.logoPath ||
+    docsConfig.visualBranding.logoDarkPath ||
+    docsConfig.visualBranding.logoLightPath;
+
+  if (!path) return null;
+
+  return { path, href: docsConfig.visualBranding.logoLink || "/" };
+}
+
+export function DocsLogoMark({
+  size = 24,
+  className = "docs-logo-mark",
+}: {
+  size?: number;
+  className?: string;
+}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-label="Logo"
+      className={className}
+    >
+      <title>Logo</title>
+      <path d="M12 2L2 7l10 5 10-5-10-5Z" fill="currentColor" opacity="0.86" />
+      <path
+        d="M2 17l10 5 10-5"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M2 12l10 5 10-5"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/src/components/docs/docs-sidebar.tsx
+++ b/src/components/docs/docs-sidebar.tsx
@@ -9,12 +9,14 @@ import type { DocsNavEntry } from "@/lib/mdx-renderer";
 import { ChevronDown, FileText } from "lucide-react";
 import Link from "next/link";
 import { useId, useState } from "react";
+import { DocsLogoMark, getConfiguredDocsLogo } from "./docs-logo";
 
 interface DocsSidebarProps {
   nav: DocsNavEntry[];
   activePath: string;
   subdomain: string;
   projectName: string;
+  settings?: Record<string, unknown>;
 }
 
 export function DocsSidebar({
@@ -22,36 +24,24 @@ export function DocsSidebar({
   activePath,
   subdomain,
   projectName,
+  settings,
 }: DocsSidebarProps) {
+  const configuredLogo = getConfiguredDocsLogo(settings);
+  const logoHref = configuredLogo?.href || `/docs/${subdomain}`;
+
   return (
     <aside className="docs-sidebar">
       <div className="docs-sidebar-header">
-        <Link href={`/docs/${subdomain}`} className="docs-logo">
-          <svg
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            aria-label="Logo"
-          >
-            <title>Logo</title>
-            <path d="M12 2L2 7l10 5 10-5-10-5Z" fill="#16A34A" opacity="0.8" />
-            <path
-              d="M2 17l10 5 10-5"
-              stroke="#16A34A"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
+        <Link href={logoHref} className="docs-logo">
+          {configuredLogo ? (
+            <img
+              src={configuredLogo.path}
+              alt="Logo"
+              className="docs-sidebar-logo-image"
             />
-            <path
-              d="M2 12l10 5 10-5"
-              stroke="#16A34A"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
+          ) : (
+            <DocsLogoMark />
+          )}
           <span className="docs-logo-text">{projectName}</span>
         </Link>
       </div>

--- a/src/components/docs/docs-topbar.tsx
+++ b/src/components/docs/docs-topbar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { mergeDocsConfig } from "@/lib/docs-config";
+import { DocsLogoMark, getConfiguredDocsLogo } from "./docs-logo";
+export { getConfiguredDocsLogo } from "./docs-logo";
 import type { VersionsConfig } from "@/lib/versions";
 import Link from "next/link";
 import { LanguageSwitcher } from "./language-switcher";
@@ -88,35 +89,6 @@ export function AskAiButton() {
   );
 }
 
-export function getConfiguredDocsLogo(
-  settings: DocsTopbarProps["settings"],
-): { path: string; href: string } | null {
-  const raw = (settings || {}) as Record<string, unknown>;
-  const rawDocsConfig = raw.docsConfig;
-
-  if (!rawDocsConfig || typeof rawDocsConfig !== "object") {
-    const legacyLogo =
-      typeof raw.logoUrl === "string"
-        ? raw.logoUrl
-        : typeof raw.logoDarkUrl === "string"
-          ? raw.logoDarkUrl
-          : "";
-    return legacyLogo ? { path: legacyLogo, href: "" } : null;
-  }
-
-  const docsConfig = mergeDocsConfig(
-    rawDocsConfig as Partial<Record<string, unknown>>,
-  );
-  const path =
-    docsConfig.headerTopbar.logoPath ||
-    docsConfig.visualBranding.logoDarkPath ||
-    docsConfig.visualBranding.logoLightPath;
-
-  if (!path) return null;
-
-  return { path, href: docsConfig.visualBranding.logoLink || "/" };
-}
-
 export function DocsTopbar({
   projectName,
   subdomain,
@@ -147,36 +119,7 @@ export function DocsTopbar({
                 className="docs-topbar-logo-image"
               />
             ) : (
-              <svg
-                width="28"
-                height="28"
-                viewBox="0 0 24 24"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-                aria-label="Logo"
-                className="docs-topbar-logo-icon"
-              >
-                <title>Logo</title>
-                <path
-                  d="M12 2L2 7l10 5 10-5-10-5Z"
-                  fill="currentColor"
-                  opacity="0.8"
-                />
-                <path
-                  d="M2 17l10 5 10-5"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-                <path
-                  d="M2 12l10 5 10-5"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                />
-              </svg>
+              <DocsLogoMark size={28} className="docs-topbar-logo-icon" />
             )}
             <span className="docs-topbar-title">{projectName}</span>
           </Link>

--- a/src/components/docs/mdx-content.tsx
+++ b/src/components/docs/mdx-content.tsx
@@ -126,7 +126,10 @@ export function MdxContent({ html }: MdxContentProps) {
           startOnLoad: false,
           theme: "dark",
           themeVariables: {
-            primaryColor: "#16a34a",
+            primaryColor:
+              getComputedStyle(container)
+                .getPropertyValue("--docs-primary")
+                .trim() || "#7b8fde",
             primaryTextColor: "#e5e7eb",
             lineColor: "#6b7280",
           },

--- a/src/components/docs/mobile-nav.tsx
+++ b/src/components/docs/mobile-nav.tsx
@@ -55,6 +55,7 @@ interface MobileSidebarProps {
   activePath: string;
   subdomain: string;
   projectName: string;
+  settings?: Record<string, unknown>;
 }
 
 export function MobileSidebar({
@@ -62,6 +63,7 @@ export function MobileSidebar({
   activePath,
   subdomain,
   projectName,
+  settings,
 }: MobileSidebarProps) {
   const [isOpen, setIsOpen] = useState(false);
   const overlayRef = useRef<HTMLDialogElement>(null);
@@ -187,6 +189,7 @@ export function MobileSidebar({
           activePath={activePath}
           subdomain={subdomain}
           projectName={projectName}
+          settings={settings}
         />
       </div>
     </dialog>

--- a/src/lib/docs-config.ts
+++ b/src/lib/docs-config.ts
@@ -201,9 +201,9 @@ export const DEFAULT_OVERVIEW: OverviewConfig = {
 
 export const DEFAULT_VISUAL_BRANDING: VisualBrandingConfig = {
   theme: "dark",
-  primaryColor: "#16A34A",
-  lightColor: "#FFFFFF",
-  darkColor: "#0F0F0F",
+  primaryColor: "#7B8FDE",
+  lightColor: "#F8F9FC",
+  darkColor: "#0E0F18",
   logoLightPath: "",
   logoDarkPath: "",
   logoLink: "/",
@@ -351,7 +351,13 @@ export function getDocsThemeCssVars(
 ): Record<string, string> {
   return {
     "--docs-primary": config.visualBranding.primaryColor,
+    "--docs-logo-color": config.visualBranding.primaryColor,
     "--docs-primary-soft": `${config.visualBranding.primaryColor}22`,
+    "--docs-light-bg": config.visualBranding.lightColor,
+    "--docs-dark-bg": config.visualBranding.darkColor,
+    "--docs-bg": config.visualBranding.darkColor,
+    "--docs-bg-deep": config.visualBranding.darkColor,
+    "--docs-card": `color-mix(in srgb, ${config.visualBranding.darkColor} 86%, white)`,
   };
 }
 

--- a/tests/docs-config.test.ts
+++ b/tests/docs-config.test.ts
@@ -66,7 +66,13 @@ describe("mergeDocsConfig", () => {
     });
     expect(getDocsThemeCssVars(config)).toEqual({
       "--docs-primary": "#FF0000",
+      "--docs-logo-color": "#FF0000",
       "--docs-primary-soft": "#FF000022",
+      "--docs-light-bg": "#F8F9FC",
+      "--docs-dark-bg": "#0E0F18",
+      "--docs-bg": "#0E0F18",
+      "--docs-bg-deep": "#0E0F18",
+      "--docs-card": "color-mix(in srgb, #0E0F18 86%, white)",
     });
   });
 

--- a/tests/docs-sidebar.test.tsx
+++ b/tests/docs-sidebar.test.tsx
@@ -60,3 +60,42 @@ describe("DocsSidebar", () => {
     expect(toggle?.getAttribute("aria-expanded")).toBe("false");
   });
 });
+
+it("uses themeable currentColor for the default logo mark", async () => {
+  const { renderToStaticMarkup } = await import("react-dom/server");
+  const html = renderToStaticMarkup(
+    <DocsSidebar
+      nav={nav}
+      activePath="introduction"
+      subdomain="test-project"
+      projectName="Test Project"
+    />,
+  );
+
+  expect(html).toContain('class="docs-logo-mark"');
+  expect(html).toContain('fill="currentColor"');
+  expect(html).toContain('stroke="currentColor"');
+  expect(html).not.toContain("#16A34A");
+});
+
+it("uses configured docs logo image and link when provided", async () => {
+  const { renderToStaticMarkup } = await import("react-dom/server");
+  const html = renderToStaticMarkup(
+    <DocsSidebar
+      nav={nav}
+      activePath="introduction"
+      subdomain="test-project"
+      projectName="Test Project"
+      settings={{
+        docsConfig: {
+          visualBranding: { logoLink: "https://example.com" },
+          headerTopbar: { logoPath: "/brand.svg" },
+        },
+      }}
+    />,
+  );
+
+  expect(html).toContain('href="https://example.com"');
+  expect(html).toContain('src="/brand.svg"');
+  expect(html).toContain('class="docs-sidebar-logo-image"');
+});


### PR DESCRIPTION
## Summary
- make the default deployed docs theme use OpenDocs dark surfaces/accent defaults instead of the old Mintlify-green look
- route visual branding primary/light/dark colors into docs CSS variables so configured branding changes affect published docs chrome
- make the default docs logo themeable with currentColor in topbar, desktop sidebar, and mobile sidebar; configured logo images still take precedence

Closes #212

## Verification
- npm run lint
- npm run typecheck
- npm test -- docs-config.test.ts docs-topbar.test.ts docs-sidebar.test.tsx docs-site-layout.test.ts mdx-components.test.ts