### PR TITLE
Fix assistant search config UX

### DIFF
--- a/src/app/docs/[subdomain]/[...slug]/page.tsx
+++ b/src/app/docs/[subdomain]/[...slug]/page.tsx
@@ -617,7 +617,11 @@ export default async function DocsPage({
 
       {/* Capture Cmd/Ctrl+K before React hydration so fast navigations still open search. */}
       <script src="/docs-search-shortcut.js" />
-      <SearchModal pages={searchablePages} subdomain={subdomain} />
+      <SearchModal
+        pages={searchablePages}
+        subdomain={subdomain}
+        searchPrompt={docsConfig.assistantSearch.searchPrompt}
+      />
       <MobileSidebar
         nav={nav}
         activePath={pagePath}

--- a/src/components/docs/search-modal.tsx
+++ b/src/components/docs/search-modal.tsx
@@ -123,9 +123,14 @@ function groupResults(results: SearchResultItem[]): SearchResultGroup[] {
 interface SearchModalProps {
   pages: SearchablePage[];
   subdomain: string;
+  searchPrompt?: string;
 }
 
-export function SearchModal({ pages, subdomain }: SearchModalProps) {
+export function SearchModal({
+  pages,
+  subdomain,
+  searchPrompt = "Search documentation...",
+}: SearchModalProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchResultItem[]>([]);
@@ -420,7 +425,7 @@ export function SearchModal({ pages, subdomain }: SearchModalProps) {
             aria-controls={listboxId}
             aria-activedescendant={activeDescendant}
             className="search-modal-input"
-            placeholder="Search documentation..."
+            placeholder={searchPrompt}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
           />

--- a/src/components/editor/configs-panel.tsx
+++ b/src/components/editor/configs-panel.tsx
@@ -8,6 +8,7 @@ import {
   CONFIG_SECTIONS,
   type ConfigSectionId,
   type ContentFeaturesConfig,
+  DEFAULT_ASSISTANT_SEARCH,
   type DocsConfig,
   type FooterSocialLink,
   ICON_LIBRARY_OPTIONS,
@@ -379,8 +380,8 @@ function ToggleSwitch({
       >
         <span
           className={clsx(
-            "absolute top-0.5 w-3.5 h-3.5 rounded-full bg-white transition-transform",
-            checked ? "translate-x-[14px]" : "translate-x-0.5",
+            "absolute top-0.5 left-0.5 w-3.5 h-3.5 rounded-full bg-white transition-transform",
+            checked ? "translate-x-[14px]" : "translate-x-0",
           )}
         />
       </button>
@@ -863,6 +864,10 @@ function AssistantSearchForm({ config, updateSection }: SectionProps) {
   const d = config.assistantSearch;
   const update = (patch: Partial<AssistantSearchConfig>) =>
     updateSection("assistantSearch", { ...d, ...patch });
+  const searchPromptValue =
+    d.searchPrompt === DEFAULT_ASSISTANT_SEARCH.searchPrompt
+      ? ""
+      : d.searchPrompt;
 
   return (
     <>
@@ -881,9 +886,9 @@ function AssistantSearchForm({ config, updateSection }: SectionProps) {
       <div>
         <FieldLabel>Search prompt</FieldLabel>
         <TextInput
-          value={d.searchPrompt}
+          value={searchPromptValue}
           onChange={(v) => update({ searchPrompt: v })}
-          placeholder="Ask anything..."
+          placeholder={DEFAULT_ASSISTANT_SEARCH.searchPrompt}
           testId="config-search-prompt"
         />
       </div>

--- a/tests/assistant-search-route.test.ts
+++ b/tests/assistant-search-route.test.ts
@@ -1,0 +1,87 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { authenticateApiKeyMock, selectMock } = vi.hoisted(() => ({
+  authenticateApiKeyMock: vi.fn(),
+  selectMock: vi.fn(),
+}));
+
+vi.mock("@/lib/api-key-auth", () => ({
+  authenticateApiKey: authenticateApiKeyMock,
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: selectMock,
+  },
+}));
+
+function makeRequest(body: unknown): NextRequest {
+  return new Request("http://localhost/api/v1/assistant/search", {
+    method: "POST",
+    headers: { authorization: "Bearer mint_dsc_test" },
+    body: JSON.stringify(body),
+  }) as NextRequest;
+}
+
+function mockOrgProjectLookup(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockResolvedValue(rows),
+  };
+}
+
+function mockPageSearch(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(rows),
+  };
+}
+
+describe("POST /api/v1/assistant/search", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    authenticateApiKeyMock.mockResolvedValue({
+      type: "assistant",
+      orgId: "org-1",
+    });
+  });
+
+  it("searches published docs pages for assistant API keys", async () => {
+    selectMock
+      .mockReturnValueOnce(mockOrgProjectLookup([{ id: "project-1" }]))
+      .mockReturnValueOnce(
+        mockPageSearch([
+          {
+            path: "quickstart",
+            title: "Quickstart",
+            description: "Get started fast",
+            content: "Install the SDK and make your first request.",
+          },
+        ]),
+      );
+
+    const { POST } = await import("@/app/api/v1/assistant/search/route");
+    const response = await POST(makeRequest({ query: "quickstart" }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual([
+      expect.objectContaining({
+        path: "quickstart",
+        content: expect.stringContaining("Install the SDK"),
+        metadata: expect.objectContaining({ title: "Quickstart" }),
+      }),
+    ]);
+  });
+
+  it("rejects non-assistant API keys", async () => {
+    authenticateApiKeyMock.mockResolvedValue({ type: "admin", orgId: "org-1" });
+
+    const { POST } = await import("@/app/api/v1/assistant/search/route");
+    const response = await POST(makeRequest({ query: "quickstart" }));
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/tests/configs-panel.test.tsx
+++ b/tests/configs-panel.test.tsx
@@ -1,0 +1,88 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { updateProjectMock } = vi.hoisted(() => ({
+  updateProjectMock: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-project-updater", () => ({
+  useProjectUpdater: () => ({
+    saving: false,
+    updateProject: updateProjectMock,
+  }),
+}));
+
+// React 19 requires this flag for act() in non-testing-library environments.
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ConfigsPanel", () => {
+  let container: HTMLElement;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    fetchMock = vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue({
+        project: {
+          settings: {
+            docsConfig: {
+              assistantSearch: {
+                assistantEnabled: true,
+                searchEnabled: true,
+                searchPrompt: "Ask anything...",
+              },
+            },
+          },
+        },
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    updateProjectMock.mockReset();
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    vi.unstubAllGlobals();
+  });
+
+  it("centers toggle knobs and treats the default search prompt as placeholder text", async () => {
+    const { ConfigsPanel } = await import("@/components/editor/configs-panel");
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(createElement(ConfigsPanel, { projectId: "project-1" }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const assistantSectionTrigger = Array.from(
+      container.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent?.includes("Assistant & Search"));
+
+    await act(async () => {
+      assistantSectionTrigger?.click();
+      await Promise.resolve();
+    });
+
+    const assistantToggle = container.querySelector<HTMLButtonElement>(
+      '[data-testid="config-assistant-enabled"]',
+    );
+    const searchPrompt = container.querySelector<HTMLInputElement>(
+      '[data-testid="config-search-prompt"]',
+    );
+    const knobClass = assistantToggle?.firstElementChild?.getAttribute("class");
+
+    expect(knobClass).toContain("left-0.5");
+    expect(knobClass).toContain("translate-x-[14px]");
+    expect(searchPrompt?.value).toBe("");
+    expect(searchPrompt?.placeholder).toBe("Ask anything...");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/tests/docs-site-layout.test.ts
+++ b/tests/docs-site-layout.test.ts
@@ -118,6 +118,36 @@ describe("Docs site layout — feature-014", () => {
       expect(filterPages(pages, "quick")).toHaveLength(1);
     });
 
+    it("uses a configurable placeholder without pre-filling the query", async () => {
+      const { SearchModal } = await import("@/components/docs/search-modal");
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          createElement(SearchModal, {
+            subdomain: "test-project",
+            searchPrompt: "Ask anything...",
+            pages: [{ path: "quickstart", title: "Quickstart" }],
+          }),
+        );
+      });
+
+      await act(async () => {
+        document.dispatchEvent(new CustomEvent("open-search"));
+      });
+
+      const input = container.querySelector<HTMLInputElement>(
+        '[data-testid="search-input"]',
+      );
+
+      expect(input?.value).toBe("");
+      expect(input?.placeholder).toBe("Ask anything...");
+
+      await act(async () => {
+        root.unmount();
+      });
+    });
+
     it("renders search dialog with combobox and listbox semantics", async () => {
       const { SearchModal } = await import("@/components/docs/search-modal");
       const root = createRoot(container);


### PR DESCRIPTION
## Summary
- center the Assistant/Search configuration toggle knob inside the switch track
- show the default "Ask anything..." search prompt as placeholder text instead of pre-filled input text, so typing replaces the placeholder instead of appending
- pass the configured search prompt through to the published docs search modal while keeping the actual query empty on open
- add route coverage for the assistant search API path

Closes #213

## Verification
- npm run lint
- npm run typecheck
- npm test -- configs-panel.test.tsx docs-site-layout.test.ts assistant-search-route.test.ts docs-search-route.test.ts assistant-api.test.ts