### PR TITLE
Fix GitHub App setup disabled state

### DIFF
--- a/src/app/settings/deployment/github/github-app-client.tsx
+++ b/src/app/settings/deployment/github/github-app-client.tsx
@@ -155,23 +155,17 @@ export function GitHubAppSettingsClient({
 
   const handleInstall = useCallback(() => {
     setError(null);
-    if (!installUrl) {
-      setError(
-        "GitHub App installation is not configured. Set GITHUB_APP_SLUG or GITHUB_APP_INSTALL_URL, then configure the app setup URL to /api/github-connections/callback.",
-      );
-      return;
-    }
+    if (!installUrl) return;
 
     setLoading(true);
     window.location.assign(installUrl);
   }, [installUrl]);
 
-  const installActionLabel =
-    hasConnections || (normalizedSelectedRepo && !selectedRepoConnected)
+  const installActionLabel = !installUrl
+    ? "GitHub app setup required"
+    : hasConnections || (normalizedSelectedRepo && !selectedRepoConnected)
       ? "Update GitHub app access"
-      : installUrl
-        ? "Install GitHub app"
-        : "GitHub app setup required";
+      : "Install GitHub app";
 
   const callbackNotice = useMemo(() => {
     if (typeof window === "undefined") return null;
@@ -211,30 +205,40 @@ export function GitHubAppSettingsClient({
     return null;
   }, []);
 
-  const renderInstallAction = (testId: string) => (
-    <button
-      type="button"
-      onClick={handleInstall}
-      disabled={loading || !isAdmin}
-      data-testid={testId}
-      className={clsx(
-        "inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium shadow-sm transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2",
-        isAdmin
-          ? installUrl
+  const renderInstallAction = (testId: string) => {
+    const isActionable = Boolean(installUrl && isAdmin);
+
+    return (
+      <button
+        type="button"
+        onClick={handleInstall}
+        disabled={loading || !isActionable}
+        data-testid={testId}
+        aria-disabled={!isActionable}
+        title={
+          installUrl
+            ? undefined
+            : "Set GITHUB_APP_SLUG or GITHUB_APP_INSTALL_URL in the production environment first."
+        }
+        className={clsx(
+          "inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium shadow-sm transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2",
+          isActionable
             ? "bg-gray-950 text-white hover:bg-gray-800"
-            : "bg-amber-100 text-amber-950 hover:bg-amber-200"
-          : "cursor-not-allowed bg-gray-200 text-gray-500",
-      )}
-    >
-      {loading ? (
-        <Loader2 size={16} className="animate-spin" />
-      ) : (
-        <GitHubIcon size={16} />
-      )}
-      {installActionLabel}
-      {installUrl && <ExternalLink size={14} className="opacity-70" />}
-    </button>
-  );
+            : installUrl
+              ? "cursor-not-allowed bg-gray-200 text-gray-500"
+              : "cursor-not-allowed bg-amber-100 text-amber-950 opacity-80",
+        )}
+      >
+        {loading ? (
+          <Loader2 size={16} className="animate-spin" />
+        ) : (
+          <GitHubIcon size={16} />
+        )}
+        {installActionLabel}
+        {installUrl && <ExternalLink size={14} className="opacity-70" />}
+      </button>
+    );
+  };
 
   return (
     <div
@@ -324,7 +328,9 @@ export function GitHubAppSettingsClient({
                 <p className="mt-2 text-sm leading-6 text-gray-700">
                   {selectedRepoConnected
                     ? "This repository is included in the current GitHub app installation. Auto updates can run when changes land on the selected branch."
-                    : "Auto updates are disabled because this repository is not included in the current GitHub app installation. Update the app installation, grant access to this repository, then select it for this project."}
+                    : installUrl
+                      ? "Auto updates are disabled because this repository is not included in the current GitHub app installation. Update the app installation, grant access to this repository, then select it for this project."
+                      : "Auto updates are disabled because the production GitHub App install URL is not configured yet. Configure the app first, then grant repository access."}
                 </p>
               </div>
 

--- a/tests/github-app-settings-client.test.tsx
+++ b/tests/github-app-settings-client.test.tsx
@@ -34,20 +34,18 @@ function renderClient(
 }
 
 describe("GitHubAppSettingsClient", () => {
-  it("does not create a fake connection when the GitHub App install URL is missing", () => {
+  it("does not expose a clickable install action when the GitHub App install URL is missing", () => {
     const { container, root } = renderClient(null);
     const installButton = container.querySelector(
       '[data-testid="install-github-app-btn"]',
-    );
+    ) as HTMLButtonElement | null;
     expect(installButton).toBeTruthy();
-
-    act(() => {
-      installButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-
-    expect(container.textContent).toContain(
-      "GitHub App installation is not configured",
+    expect(installButton?.disabled).toBe(true);
+    expect(installButton?.getAttribute("aria-disabled")).toBe("true");
+    expect(installButton?.getAttribute("title")).toContain(
+      "Set GITHUB_APP_SLUG or GITHUB_APP_INSTALL_URL",
     );
+
     expect(container.textContent).toContain("GitHub app setup required");
     expect(container.textContent).toContain(
       "will not send users to GitHub Marketplace",
@@ -114,6 +112,34 @@ describe("GitHubAppSettingsClient", () => {
     expect(container.textContent).toContain("Public GitHub repo");
     expect(container.textContent).not.toContain("Selected repository");
     expect(container.textContent).not.toContain("before import");
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("shows setup-required copy instead of update-access when repository access is blocked and the app is unconfigured", () => {
+    const { container, root } = renderClient(null, {
+      selectedRepoFullName: "namuh-eng/opensend",
+      selectedSource: {
+        repoFullName: "namuh-eng/opensend",
+        owner: "namuh-eng",
+        repo: "opensend",
+        branch: "main",
+        path: "/",
+        sourceType: "public_repo",
+      },
+    });
+
+    const updateButton = container.querySelector(
+      '[data-testid="update-github-app-access-btn"]',
+    ) as HTMLButtonElement | null;
+    expect(updateButton).toBeTruthy();
+    expect(updateButton?.disabled).toBe(true);
+    expect(container.textContent).toContain("GitHub app setup required");
+    expect(container.textContent).toContain(
+      "the production GitHub App install URL is not configured yet",
+    );
+    expect(container.textContent).not.toContain("Update GitHub app access");
 
     act(() => root.unmount());
     container.remove();


### PR DESCRIPTION
## Summary
- disable the GitHub App install/update button when production install URL config is missing
- prioritize setup-required copy over misleading “Update GitHub app access” states
- add coverage for unconfigured repo-access blockers

## Evidence
- `npm test -- --run tests/github-app-settings-client.test.tsx tests/github-app-install.test.ts tests/github-app-callback-route.test.ts`
- `npm run typecheck`
- `npx biome check src/app/settings/deployment/github/github-app-client.tsx tests/github-app-settings-client.test.tsx`

Closes #218