### PR TITLE
Fix analytics visibility in light theme

### DIFF
--- a/src/app/analytics/analytics-shell.tsx
+++ b/src/app/analytics/analytics-shell.tsx
@@ -326,7 +326,10 @@ export function AnalyticsShell({
   }
 
   return (
-    <div className="px-8 py-6">
+    <div
+      className="od-analytics-shell min-h-full bg-[#0e0f18] px-8 py-6 text-white"
+      data-testid="analytics-shell"
+    >
       {/* Header */}
       <h1 className="text-xl font-semibold text-white mb-5">Analytics</h1>
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -382,6 +382,78 @@ body {
   background-color: var(--od-accent-strong);
 }
 
+/* Analytics was built with dark utilities. Keep it dark inside the themed app
+   shell so light-mode token bridges do not turn the tab content invisible. */
+.od-app-shell .od-analytics-shell {
+  background-color: #0e0f18;
+  color: #ffffff;
+}
+
+.od-app-shell .od-analytics-shell .text-white,
+.od-app-shell .od-analytics-shell .text-white\/80 {
+  color: #ffffff;
+}
+
+.od-app-shell .od-analytics-shell .text-gray-300 {
+  color: #d1d5db;
+}
+
+.od-app-shell .od-analytics-shell .text-gray-400 {
+  color: #9ca3af;
+}
+
+.od-app-shell .od-analytics-shell .text-gray-500 {
+  color: #6b7280;
+}
+
+.od-app-shell .od-analytics-shell .text-gray-600 {
+  color: #4b5563;
+}
+
+.od-app-shell .od-analytics-shell .bg-\[\#1a1a1a\] {
+  background-color: #1a1a1a;
+}
+
+.od-app-shell .od-analytics-shell .bg-white\/\[0\.02\] {
+  background-color: rgba(255, 255, 255, 0.02);
+}
+
+.od-app-shell .od-analytics-shell .bg-white\/\[0\.04\] {
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+.od-app-shell .od-analytics-shell .bg-white\/\[0\.06\] {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.od-app-shell .od-analytics-shell .bg-white\/\[0\.1\] {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.od-app-shell .od-analytics-shell .bg-white\/\[0\.12\] {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.od-app-shell .od-analytics-shell .border-white\/\[0\.04\] {
+  border-color: rgba(255, 255, 255, 0.04);
+}
+
+.od-app-shell .od-analytics-shell .border-white\/\[0\.08\] {
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.od-app-shell .od-analytics-shell .hover\:bg-white\/\[0\.02\]:hover {
+  background-color: rgba(255, 255, 255, 0.02);
+}
+
+.od-app-shell .od-analytics-shell .hover\:bg-white\/\[0\.06\]:hover {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.od-app-shell .od-analytics-shell .hover\:bg-white\/\[0\.08\]:hover {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
 @media (max-width: 768px) {
   .od-page {
     padding: 18px;

--- a/tests/e2e/analytics.spec.ts
+++ b/tests/e2e/analytics.spec.ts
@@ -16,15 +16,34 @@ test.describe("Analytics layout shell", () => {
     await expect(page.getByRole("button", { name: "Agents" })).toBeVisible();
   });
 
+  test("analytics content stays readable in light dashboard theme", async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      document.documentElement.setAttribute("data-theme", "light");
+      localStorage.setItem("opendocs-dashboard-theme", "light");
+    });
+    await page.reload();
+
+    const shell = page.getByTestId("analytics-shell");
+    await expect(shell).toBeVisible();
+    await expect(shell).toHaveCSS("background-color", "rgb(14, 15, 24)");
+    await expect(shell.getByRole("heading", { name: "Analytics" })).toHaveCSS(
+      "color",
+      "rgb(255, 255, 255)",
+    );
+  });
+
   test("Humans mode is active by default with 5 sub-tabs", async ({ page }) => {
-    const humansBtn = page.getByRole("button", { name: "Humans" });
+    const shell = page.getByTestId("analytics-shell");
+    const humansBtn = shell.getByRole("button", { name: "Humans" });
     await expect(humansBtn).toHaveAttribute("data-active", "true");
 
-    await expect(page.getByRole("link", { name: /Visitors/ })).toBeVisible();
-    await expect(page.getByRole("link", { name: /Views/ })).toBeVisible();
-    await expect(page.getByRole("link", { name: /Assistant/ })).toBeVisible();
-    await expect(page.getByRole("link", { name: /Searches/ })).toBeVisible();
-    await expect(page.getByRole("link", { name: /Feedback/ })).toBeVisible();
+    await expect(shell.getByRole("link", { name: /Visitors/ })).toBeVisible();
+    await expect(shell.getByRole("link", { name: /Views/ })).toBeVisible();
+    await expect(shell.getByRole("link", { name: /Assistant/ })).toBeVisible();
+    await expect(shell.getByRole("link", { name: /Searches/ })).toBeVisible();
+    await expect(shell.getByRole("link", { name: /Feedback/ })).toBeVisible();
   });
 
   test("switching to Agents mode shows 2 sub-tabs", async ({ page }) => {


### PR DESCRIPTION
## Summary\n- keep the analytics shell on its intended dark surface inside the themed dashboard\n- scope dark utility overrides so light-mode app-shell token bridges do not make analytics text/cards disappear\n- add Playwright coverage for analytics readability in light dashboard theme and scope tab assertions to the analytics shell\n\n## Testing\n- npx biome check --write src/app/analytics/analytics-shell.tsx src/app/globals.css tests/e2e/analytics.spec.ts\n- npm test -- --run tests/analytics.test.ts tests/analytics-agents.test.ts tests/analytics-empty-state.test.tsx\n- npx playwright test tests/e2e/analytics.spec.ts tests/e2e/analytics-agents.spec.ts --project=default\n- npm run typecheck\n\nCloses #219