### PR TITLE
Promote GitHub sync UX copy

### DIFF
--- a/src/app/analytics/analytics-shell.tsx
+++ b/src/app/analytics/analytics-shell.tsx
@@ -326,7 +326,10 @@ export function AnalyticsShell({
   }
 
   return (
-    <div className="px-8 py-6">
+    <div
+      className="od-analytics-shell min-h-full bg-[#0e0f18] px-8 py-6 text-white"
+      data-testid="analytics-shell"
+    >
       {/* Header */}
       <h1 className="text-xl font-semibold text-white mb-5">Analytics</h1>
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -382,6 +382,78 @@ body {
   background-color: var(--od-accent-strong);
 }
 
+/* Analytics was built with dark utilities. Keep it dark inside the themed app
+   shell so light-mode token bridges do not turn the tab content invisible. */
+.od-app-shell .od-analytics-shell {
+  background-color: #0e0f18;
+  color: #ffffff;
+}
+
+.od-app-shell .od-analytics-shell .text-white,
+.od-app-shell .od-analytics-shell .text-white\/80 {
+  color: #ffffff;
+}
+
+.od-app-shell .od-analytics-shell .text-gray-300 {
+  color: #d1d5db;
+}
+
+.od-app-shell .od-analytics-shell .text-gray-400 {
+  color: #9ca3af;
+}
+
+.od-app-shell .od-analytics-shell .text-gray-500 {
+  color: #6b7280;
+}
+
+.od-app-shell .od-analytics-shell .text-gray-600 {
+  color: #4b5563;
+}
+
+.od-app-shell .od-analytics-shell .bg-\[\#1a1a1a\] {
+  background-color: #1a1a1a;
+}
+
+.od-app-shell .od-analytics-shell .bg-white\/\[0\.02\] {
+  background-color: rgba(255, 255, 255, 0.02);
+}
+
+.od-app-shell .od-analytics-shell .bg-white\/\[0\.04\] {
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+.od-app-shell .od-analytics-shell .bg-white\/\[0\.06\] {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.od-app-shell .od-analytics-shell .bg-white\/\[0\.1\] {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.od-app-shell .od-analytics-shell .bg-white\/\[0\.12\] {
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.od-app-shell .od-analytics-shell .border-white\/\[0\.04\] {
+  border-color: rgba(255, 255, 255, 0.04);
+}
+
+.od-app-shell .od-analytics-shell .border-white\/\[0\.08\] {
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.od-app-shell .od-analytics-shell .hover\:bg-white\/\[0\.02\]:hover {
+  background-color: rgba(255, 255, 255, 0.02);
+}
+
+.od-app-shell .od-analytics-shell .hover\:bg-white\/\[0\.06\]:hover {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.od-app-shell .od-analytics-shell .hover\:bg-white\/\[0\.08\]:hover {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
 @media (max-width: 768px) {
   .od-page {
     padding: 18px;

--- a/src/app/settings/deployment/github/github-app-client.tsx
+++ b/src/app/settings/deployment/github/github-app-client.tsx
@@ -162,7 +162,7 @@ export function GitHubAppSettingsClient({
   }, [installUrl]);
 
   const installActionLabel = !installUrl
-    ? "GitHub app setup required"
+    ? "GitHub sync unavailable"
     : hasConnections || (normalizedSelectedRepo && !selectedRepoConnected)
       ? "Update GitHub app access"
       : "Install GitHub app";
@@ -218,7 +218,7 @@ export function GitHubAppSettingsClient({
         title={
           installUrl
             ? undefined
-            : "Set GITHUB_APP_SLUG or GITHUB_APP_INSTALL_URL in the production environment first."
+            : "GitHub sync is not available yet. You can still publish and update docs manually."
         }
         className={clsx(
           "inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium shadow-sm transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2",
@@ -267,13 +267,13 @@ export function GitHubAppSettingsClient({
             />
             <div>
               <p className="font-semibold text-gray-950">
-                GitHub App setup is incomplete
+                GitHub sync is temporarily unavailable
               </p>
               <p className="mt-1 leading-6 text-amber-900">
-                OpenDocs needs a configured GitHub App slug or install URL
-                before users can connect repositories. The install action will
-                not send users to GitHub Marketplace; it stays here and shows
-                this setup error until the production app is configured.
+                OpenDocs can still import and publish your docs, but automatic
+                GitHub updates are not ready in this workspace yet. You can keep
+                working with manual imports while we finish enabling GitHub
+                sync.
               </p>
             </div>
           </div>
@@ -330,7 +330,7 @@ export function GitHubAppSettingsClient({
                     ? "This repository is included in the current GitHub app installation. Auto updates can run when changes land on the selected branch."
                     : installUrl
                       ? "Auto updates are disabled because this repository is not included in the current GitHub app installation. Update the app installation, grant access to this repository, then select it for this project."
-                      : "Auto updates are disabled because the production GitHub App install URL is not configured yet. Configure the app first, then grant repository access."}
+                      : "Auto updates are not available for this workspace yet. You can continue publishing with manual imports while GitHub sync is enabled."}
                 </p>
               </div>
 
@@ -394,14 +394,14 @@ export function GitHubAppSettingsClient({
         <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <h2 className="mb-2 text-base font-semibold text-gray-950">
-              Configure the GitHub app
+              Connect GitHub sync
             </h2>
             <p className="max-w-xl text-sm leading-6 text-gray-600">
               Use this page to connect the repo OpenDocs should watch for
-              documentation updates. This is the same production pattern used by
-              hosted docs platforms: install the GitHub App, authorize the right
-              organization or repository, then keep imports up to date from the
-              selected branch and path.
+              documentation updates. Once GitHub sync is available, install the
+              OpenDocs GitHub App, authorize the right organization or
+              repository, then keep imports up to date from the selected branch
+              and path.
             </p>
           </div>
           {!hasConnections && renderInstallAction("install-github-app-btn")}

--- a/src/app/settings/deployment/github/github-app-client.tsx
+++ b/src/app/settings/deployment/github/github-app-client.tsx
@@ -155,23 +155,17 @@ export function GitHubAppSettingsClient({
 
   const handleInstall = useCallback(() => {
     setError(null);
-    if (!installUrl) {
-      setError(
-        "GitHub App installation is not configured. Set GITHUB_APP_SLUG or GITHUB_APP_INSTALL_URL, then configure the app setup URL to /api/github-connections/callback.",
-      );
-      return;
-    }
+    if (!installUrl) return;
 
     setLoading(true);
     window.location.assign(installUrl);
   }, [installUrl]);
 
-  const installActionLabel =
-    hasConnections || (normalizedSelectedRepo && !selectedRepoConnected)
+  const installActionLabel = !installUrl
+    ? "GitHub app setup required"
+    : hasConnections || (normalizedSelectedRepo && !selectedRepoConnected)
       ? "Update GitHub app access"
-      : installUrl
-        ? "Install GitHub app"
-        : "GitHub app setup required";
+      : "Install GitHub app";
 
   const callbackNotice = useMemo(() => {
     if (typeof window === "undefined") return null;
@@ -211,30 +205,40 @@ export function GitHubAppSettingsClient({
     return null;
   }, []);
 
-  const renderInstallAction = (testId: string) => (
-    <button
-      type="button"
-      onClick={handleInstall}
-      disabled={loading || !isAdmin}
-      data-testid={testId}
-      className={clsx(
-        "inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium shadow-sm transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2",
-        isAdmin
-          ? installUrl
+  const renderInstallAction = (testId: string) => {
+    const isActionable = Boolean(installUrl && isAdmin);
+
+    return (
+      <button
+        type="button"
+        onClick={handleInstall}
+        disabled={loading || !isActionable}
+        data-testid={testId}
+        aria-disabled={!isActionable}
+        title={
+          installUrl
+            ? undefined
+            : "Set GITHUB_APP_SLUG or GITHUB_APP_INSTALL_URL in the production environment first."
+        }
+        className={clsx(
+          "inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium shadow-sm transition-colors focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2",
+          isActionable
             ? "bg-gray-950 text-white hover:bg-gray-800"
-            : "bg-amber-100 text-amber-950 hover:bg-amber-200"
-          : "cursor-not-allowed bg-gray-200 text-gray-500",
-      )}
-    >
-      {loading ? (
-        <Loader2 size={16} className="animate-spin" />
-      ) : (
-        <GitHubIcon size={16} />
-      )}
-      {installActionLabel}
-      {installUrl && <ExternalLink size={14} className="opacity-70" />}
-    </button>
-  );
+            : installUrl
+              ? "cursor-not-allowed bg-gray-200 text-gray-500"
+              : "cursor-not-allowed bg-amber-100 text-amber-950 opacity-80",
+        )}
+      >
+        {loading ? (
+          <Loader2 size={16} className="animate-spin" />
+        ) : (
+          <GitHubIcon size={16} />
+        )}
+        {installActionLabel}
+        {installUrl && <ExternalLink size={14} className="opacity-70" />}
+      </button>
+    );
+  };
 
   return (
     <div
@@ -324,7 +328,9 @@ export function GitHubAppSettingsClient({
                 <p className="mt-2 text-sm leading-6 text-gray-700">
                   {selectedRepoConnected
                     ? "This repository is included in the current GitHub app installation. Auto updates can run when changes land on the selected branch."
-                    : "Auto updates are disabled because this repository is not included in the current GitHub app installation. Update the app installation, grant access to this repository, then select it for this project."}
+                    : installUrl
+                      ? "Auto updates are disabled because this repository is not included in the current GitHub app installation. Update the app installation, grant access to this repository, then select it for this project."
+                      : "Auto updates are disabled because the production GitHub App install URL is not configured yet. Configure the app first, then grant repository access."}
                 </p>
               </div>
 

--- a/tests/e2e/analytics.spec.ts
+++ b/tests/e2e/analytics.spec.ts
@@ -16,15 +16,34 @@ test.describe("Analytics layout shell", () => {
     await expect(page.getByRole("button", { name: "Agents" })).toBeVisible();
   });
 
+  test("analytics content stays readable in light dashboard theme", async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      document.documentElement.setAttribute("data-theme", "light");
+      localStorage.setItem("opendocs-dashboard-theme", "light");
+    });
+    await page.reload();
+
+    const shell = page.getByTestId("analytics-shell");
+    await expect(shell).toBeVisible();
+    await expect(shell).toHaveCSS("background-color", "rgb(14, 15, 24)");
+    await expect(shell.getByRole("heading", { name: "Analytics" })).toHaveCSS(
+      "color",
+      "rgb(255, 255, 255)",
+    );
+  });
+
   test("Humans mode is active by default with 5 sub-tabs", async ({ page }) => {
-    const humansBtn = page.getByRole("button", { name: "Humans" });
+    const shell = page.getByTestId("analytics-shell");
+    const humansBtn = shell.getByRole("button", { name: "Humans" });
     await expect(humansBtn).toHaveAttribute("data-active", "true");
 
-    await expect(page.getByRole("link", { name: /Visitors/ })).toBeVisible();
-    await expect(page.getByRole("link", { name: /Views/ })).toBeVisible();
-    await expect(page.getByRole("link", { name: /Assistant/ })).toBeVisible();
-    await expect(page.getByRole("link", { name: /Searches/ })).toBeVisible();
-    await expect(page.getByRole("link", { name: /Feedback/ })).toBeVisible();
+    await expect(shell.getByRole("link", { name: /Visitors/ })).toBeVisible();
+    await expect(shell.getByRole("link", { name: /Views/ })).toBeVisible();
+    await expect(shell.getByRole("link", { name: /Assistant/ })).toBeVisible();
+    await expect(shell.getByRole("link", { name: /Searches/ })).toBeVisible();
+    await expect(shell.getByRole("link", { name: /Feedback/ })).toBeVisible();
   });
 
   test("switching to Agents mode shows 2 sub-tabs", async ({ page }) => {

--- a/tests/github-app-settings-client.test.tsx
+++ b/tests/github-app-settings-client.test.tsx
@@ -43,13 +43,18 @@ describe("GitHubAppSettingsClient", () => {
     expect(installButton?.disabled).toBe(true);
     expect(installButton?.getAttribute("aria-disabled")).toBe("true");
     expect(installButton?.getAttribute("title")).toContain(
-      "Set GITHUB_APP_SLUG or GITHUB_APP_INSTALL_URL",
+      "GitHub sync is not available yet",
     );
 
-    expect(container.textContent).toContain("GitHub app setup required");
+    expect(container.textContent).toContain("GitHub sync unavailable");
     expect(container.textContent).toContain(
-      "will not send users to GitHub Marketplace",
+      "GitHub sync is temporarily unavailable",
     );
+    expect(container.textContent).toContain(
+      "manual imports while we finish enabling GitHub sync",
+    );
+    expect(container.textContent).not.toContain("GITHUB_APP_SLUG");
+    expect(container.textContent).not.toContain("production environment");
     expect(container.textContent).not.toContain(
       "GitHub App installed successfully",
     );
@@ -117,7 +122,7 @@ describe("GitHubAppSettingsClient", () => {
     container.remove();
   });
 
-  it("shows setup-required copy instead of update-access when repository access is blocked and the app is unconfigured", () => {
+  it("shows customer-safe unavailable copy instead of update-access when repository access is blocked and the app is unconfigured", () => {
     const { container, root } = renderClient(null, {
       selectedRepoFullName: "namuh-eng/opensend",
       selectedSource: {
@@ -135,10 +140,12 @@ describe("GitHubAppSettingsClient", () => {
     ) as HTMLButtonElement | null;
     expect(updateButton).toBeTruthy();
     expect(updateButton?.disabled).toBe(true);
-    expect(container.textContent).toContain("GitHub app setup required");
+    expect(container.textContent).toContain("GitHub sync unavailable");
     expect(container.textContent).toContain(
-      "the production GitHub App install URL is not configured yet",
+      "Auto updates are not available for this workspace yet",
     );
+    expect(container.textContent).not.toContain("production GitHub App");
+    expect(container.textContent).not.toContain("install URL");
     expect(container.textContent).not.toContain("Update GitHub app access");
 
     act(() => root.unmount());

--- a/tests/github-app-settings-client.test.tsx
+++ b/tests/github-app-settings-client.test.tsx
@@ -34,20 +34,18 @@ function renderClient(
 }
 
 describe("GitHubAppSettingsClient", () => {
-  it("does not create a fake connection when the GitHub App install URL is missing", () => {
+  it("does not expose a clickable install action when the GitHub App install URL is missing", () => {
     const { container, root } = renderClient(null);
     const installButton = container.querySelector(
       '[data-testid="install-github-app-btn"]',
-    );
+    ) as HTMLButtonElement | null;
     expect(installButton).toBeTruthy();
-
-    act(() => {
-      installButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-
-    expect(container.textContent).toContain(
-      "GitHub App installation is not configured",
+    expect(installButton?.disabled).toBe(true);
+    expect(installButton?.getAttribute("aria-disabled")).toBe("true");
+    expect(installButton?.getAttribute("title")).toContain(
+      "Set GITHUB_APP_SLUG or GITHUB_APP_INSTALL_URL",
     );
+
     expect(container.textContent).toContain("GitHub app setup required");
     expect(container.textContent).toContain(
       "will not send users to GitHub Marketplace",
@@ -114,6 +112,34 @@ describe("GitHubAppSettingsClient", () => {
     expect(container.textContent).toContain("Public GitHub repo");
     expect(container.textContent).not.toContain("Selected repository");
     expect(container.textContent).not.toContain("before import");
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("shows setup-required copy instead of update-access when repository access is blocked and the app is unconfigured", () => {
+    const { container, root } = renderClient(null, {
+      selectedRepoFullName: "namuh-eng/opensend",
+      selectedSource: {
+        repoFullName: "namuh-eng/opensend",
+        owner: "namuh-eng",
+        repo: "opensend",
+        branch: "main",
+        path: "/",
+        sourceType: "public_repo",
+      },
+    });
+
+    const updateButton = container.querySelector(
+      '[data-testid="update-github-app-access-btn"]',
+    ) as HTMLButtonElement | null;
+    expect(updateButton).toBeTruthy();
+    expect(updateButton?.disabled).toBe(true);
+    expect(container.textContent).toContain("GitHub app setup required");
+    expect(container.textContent).toContain(
+      "the production GitHub App install URL is not configured yet",
+    );
+    expect(container.textContent).not.toContain("Update GitHub app access");
 
     act(() => root.unmount());
     container.remove();


### PR DESCRIPTION
## Summary\n- promote #224 to production main\n- removes operator-facing GitHub App env/setup copy from customer UI\n- keeps GitHub sync disabled until production app credentials are wired, but presents a customer-safe manual-import fallback\n\n## Testing\n- PR #224 CI passed: Production Build, TypeCheck & Lint, Unit Tests\n- local checks on #224: Biome, GitHub App settings/install/callback tests, typecheck