### PR TITLE
Fix GitHub app configure route

### DIFF
--- a/src/app/products/agent/agent-settings-client.tsx
+++ b/src/app/products/agent/agent-settings-client.tsx
@@ -5,6 +5,8 @@ import { clsx } from "clsx";
 import { Bot, ExternalLink, GitBranch, Loader2, Shield, X } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 
+const GITHUB_APP_SETTINGS_HREF = "/settings/deployment/github";
+
 interface AgentSettingsState {
   agentEnabled: boolean;
   slackConnected: boolean;
@@ -258,7 +260,7 @@ export function AgentSettingsClient({
                   </div>
                 </div>
                 <a
-                  href="/docs/agent"
+                  href={GITHUB_APP_SETTINGS_HREF}
                   className="text-sm text-emerald-400 hover:text-emerald-300 transition-colors inline-flex items-center gap-1"
                   data-testid="configure-github-link"
                 >
@@ -301,13 +303,13 @@ export function AgentSettingsClient({
                   </div>
                 </div>
               ) : !settings.githubAppInstalled ? (
-                <button
-                  type="button"
+                <a
+                  href={GITHUB_APP_SETTINGS_HREF}
                   className="mt-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500 transition-colors"
                   data-testid="install-github-btn"
                 >
                   Install the GitHub app
-                </button>
+                </a>
               ) : null}
             </div>
           </section>

--- a/tests/agent-settings-client.test.tsx
+++ b/tests/agent-settings-client.test.tsx
@@ -1,0 +1,64 @@
+import { AgentSettingsClient } from "@/app/products/agent/agent-settings-client";
+import { type ComponentProps, act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+const defaultSettings: ComponentProps<
+  typeof AgentSettingsClient
+>["initialSettings"] = {
+  agentEnabled: true,
+  slackConnected: false,
+  slackWorkspace: null,
+  githubAppInstalled: false,
+  connectedRepos: [],
+};
+
+function renderClient(
+  overrides: Partial<ComponentProps<typeof AgentSettingsClient>> = {},
+) {
+  const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: false,
+  } as Response);
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <AgentSettingsClient
+        initialPlan="pro"
+        initialSettings={defaultSettings}
+        {...overrides}
+      />,
+    );
+  });
+
+  return { container, root, fetchMock };
+}
+
+describe("AgentSettingsClient", () => {
+  it("links GitHub app actions to the real settings page instead of the missing docs page", () => {
+    const { container, root, fetchMock } = renderClient();
+
+    expect(
+      container
+        .querySelector('[data-testid="configure-github-link"]')
+        ?.getAttribute("href"),
+    ).toBe("/settings/deployment/github");
+    expect(
+      container
+        .querySelector('[data-testid="install-github-btn"]')
+        ?.getAttribute("href"),
+    ).toBe("/settings/deployment/github");
+
+    act(() => root.unmount());
+    container.remove();
+    fetchMock.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- Route the Agent page's Configure GitHub app link to the real GitHub app settings page instead of missing /docs/agent
- Make the uninstalled-state Install GitHub app action navigate to the same settings flow
- Add a regression test for both Agent page GitHub app actions

Closes #233

## Verification
- npm test -- tests/agent-settings-client.test.tsx
- npm run typecheck
- npm run lint