### PR TITLE
fix: render dashboard site preview

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,7 +9,7 @@ const nextConfig = {
           {
             key: "Content-Security-Policy",
             value:
-              "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://accounts.google.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
+              "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://accounts.google.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https:; frame-ancestors 'self'; base-uri 'self'; form-action 'self'",
           },
           {
             key: "Strict-Transport-Security",

--- a/src/app/dashboard/dashboard-home-client.tsx
+++ b/src/app/dashboard/dashboard-home-client.tsx
@@ -330,17 +330,30 @@ export function DashboardHomeClient({
         <>
           {/* Project overview section */}
           <div className="mb-[var(--od-section-gap)] flex gap-6 max-lg:flex-col">
-            {/* Preview thumbnail placeholder */}
-            <div className="od-card flex h-[170px] w-[300px] shrink-0 items-center justify-center overflow-hidden max-lg:w-full">
-              <div className="text-center">
-                <Globe
-                  size={28}
-                  className="mx-auto mb-2 text-[var(--od-text-subtle)]"
+            {/* Site preview */}
+            <div className="od-card relative h-[170px] w-[300px] shrink-0 overflow-hidden p-0 max-lg:w-full">
+              {projectIsLive && siteUrl !== "#" ? (
+                <iframe
+                  src={siteUrl}
+                  title={`Live preview for ${project.name} documentation`}
+                  data-testid="dashboard-site-preview-frame"
+                  className="h-full w-full border-0 bg-[var(--od-panel)]"
+                  loading="lazy"
+                  referrerPolicy="no-referrer-when-downgrade"
                 />
-                <p className="text-xs text-[var(--od-text-subtle)]">
-                  Site preview
-                </p>
-              </div>
+              ) : (
+                <div className="flex h-full items-center justify-center text-center">
+                  <div>
+                    <Globe
+                      size={28}
+                      className="mx-auto mb-2 text-[var(--od-text-subtle)]"
+                    />
+                    <p className="text-xs text-[var(--od-text-subtle)]">
+                      Site preview
+                    </p>
+                  </div>
+                </div>
+              )}
             </div>
 
             {/* Project info */}

--- a/tests/dashboard-site-preview.test.tsx
+++ b/tests/dashboard-site-preview.test.tsx
@@ -1,0 +1,91 @@
+import { DashboardHomeClient } from "@/app/dashboard/dashboard-home-client";
+import { type ComponentProps, act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+beforeAll(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({ topPages: [] }),
+      }),
+    ),
+  );
+});
+
+type DashboardProps = ComponentProps<typeof DashboardHomeClient>;
+
+const baseProps: DashboardProps = {
+  greeting: "Good evening",
+  firstName: "Ashley",
+  project: {
+    id: "project-1",
+    name: "exponential",
+    subdomain: "namuh-eng-exponential",
+    status: "active",
+    customDomain: null,
+    repoUrl: "https://github.com/namuh-eng/exponential",
+    repoBranch: "main",
+    repoPath: "/",
+  },
+  deployments: [
+    {
+      id: "deployment-1",
+      status: "succeeded",
+      branch: "main",
+      previewUrl: null,
+      commitSha: null,
+      commitMessage: "Initial deployment",
+      startedAt: null,
+      endedAt: null,
+      createdAt: "2026-05-17T03:00:00.000Z",
+    },
+  ],
+  previews: [],
+  publishedPages: [
+    { id: "page-1", path: "introduction", title: "Introduction" },
+  ],
+};
+
+function renderDashboard(overrides: Partial<DashboardProps> = {}) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(<DashboardHomeClient {...baseProps} {...overrides} />);
+  });
+
+  return { container, root };
+}
+
+describe("Dashboard site preview", () => {
+  it("embeds the live docs site instead of showing only the placeholder", () => {
+    const { container, root } = renderDashboard();
+
+    const iframe = container.querySelector<HTMLIFrameElement>(
+      '[data-testid="dashboard-site-preview-frame"]',
+    );
+
+    expect(iframe).toBeTruthy();
+    expect(iframe?.getAttribute("src")).toBe("/docs/namuh-eng-exponential");
+    expect(iframe?.getAttribute("title")).toBe(
+      "Live preview for exponential documentation",
+    );
+    expect(container.textContent).not.toContain("Site preview");
+
+    act(() => root.unmount());
+    container.remove();
+  });
+});

--- a/tests/security-headers.test.ts
+++ b/tests/security-headers.test.ts
@@ -22,7 +22,7 @@ describe("security headers", () => {
 
     expect(headers["Content-Security-Policy"]).toContain("default-src 'self'");
     expect(headers["Content-Security-Policy"]).toContain(
-      "frame-ancestors 'none'",
+      "frame-ancestors 'self'",
     );
     expect(headers["Content-Security-Policy"]).toContain("base-uri 'self'");
     expect(headers["Strict-Transport-Security"]).toBe(


### PR DESCRIPTION
## Summary\n- Replace the dashboard preview placeholder with a live docs iframe when the project is live\n- Allow same-origin framing in CSP so the dashboard can embed published docs\n- Add regression coverage for the iframe and CSP header\n\n## Verification\n- npm test -- --run tests/dashboard-site-preview.test.tsx tests/security-headers.test.ts\n- make check\n- make test\n- curl -I http://localhost:3025/docs/namuh-eng-exponential (verified Content-Security-Policy includes frame-ancestors 'self')