### PR TITLE
chore(observability): add Sentry smoke-test endpoint

### DIFF
--- a/src/app/api/__sentry-test/route.ts
+++ b/src/app/api/__sentry-test/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: Request) {
+  if (req.headers.get("x-sentry-smoke") !== "1") {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+  throw new Error("sentry-smoke-test:opendocs");
+}


### PR DESCRIPTION
## Summary
- Adds temporary `GET /api/__sentry-test` gated by `x-sentry-smoke: 1` header
- Used to confirm prod events route to the opendocs Sentry project
- Will be removed in a follow-up PR once verified

## Test plan
- [ ] After deploy, hit production `/api/__sentry-test` with header → event lands in opendocs Sentry project
- [ ] Endpoint returns 403 without the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)