### PR TITLE
Add docs config compatibility model

### DIFF
--- a/src/lib/docs-config.ts
+++ b/src/lib/docs-config.ts
@@ -11,6 +11,13 @@ import {
   DEFAULT_CONTEXTUAL_AI_MENU,
 } from "./contextual-ai-menu";
 
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue =
+  | JsonPrimitive
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+export type JsonObject = Record<string, JsonValue>;
+
 // ── Section IDs ──────────────────────────────────────────────────────────
 
 export const CONFIG_SECTION_IDS = [
@@ -168,6 +175,52 @@ export interface RedirectEntry {
   destination: string;
 }
 
+export interface NavigationItem {
+  label: string;
+  path?: string;
+  href?: string;
+  pages?: string[];
+  groups?: NavigationItem[];
+}
+
+export interface NavigationConfig {
+  tabs: NavigationItem[];
+  groups: NavigationItem[];
+  anchors: TopbarLink[];
+}
+
+export interface ApiSpecConfig {
+  name: string;
+  url?: string;
+  file?: string;
+  navigation?: string;
+  version?: string;
+}
+
+export interface DocsAuthConfig {
+  mode: "public" | "password" | "org" | "groups" | "sso";
+  groups: string[];
+  ssoProvider?: string;
+}
+
+export interface DocsSeoConfig {
+  title: string;
+  description: string;
+  robots: string;
+  noindex: boolean;
+}
+
+export interface DocsLocalizationConfig {
+  languages: string[];
+  defaultLanguage: string;
+  versions: string[];
+  defaultVersion: string;
+}
+
+export interface ErrorPagesConfig {
+  notFoundPath: string;
+}
+
 export interface AdvancedConfig {
   seoTitle: string;
   seoDescription: string;
@@ -188,7 +241,15 @@ export interface DocsConfig {
   integrations: IntegrationsConfig;
   apiDocs: ApiDocsConfig;
   advanced: AdvancedConfig;
+  navigation: NavigationConfig;
+  apiSpecs: ApiSpecConfig[];
+  auth: DocsAuthConfig;
+  seo: DocsSeoConfig;
+  localization: DocsLocalizationConfig;
+  errorPages: ErrorPagesConfig;
   contextualAiMenu: ContextualAiMenuConfig;
+  /** Unknown top-level fields from imported docs.json-like files, preserved for round-trip compatibility. */
+  unknownFields: JsonObject;
 }
 
 // ── Defaults ─────────────────────────────────────────────────────────────
@@ -259,6 +320,35 @@ export const DEFAULT_ADVANCED: AdvancedConfig = {
   redirects: [],
 };
 
+export const DEFAULT_NAVIGATION: NavigationConfig = {
+  tabs: [],
+  groups: [],
+  anchors: [],
+};
+
+export const DEFAULT_AUTH: DocsAuthConfig = {
+  mode: "public",
+  groups: [],
+};
+
+export const DEFAULT_SEO: DocsSeoConfig = {
+  title: "",
+  description: "",
+  robots: "index,follow",
+  noindex: false,
+};
+
+export const DEFAULT_LOCALIZATION: DocsLocalizationConfig = {
+  languages: [],
+  defaultLanguage: "",
+  versions: [],
+  defaultVersion: "",
+};
+
+export const DEFAULT_ERROR_PAGES: ErrorPagesConfig = {
+  notFoundPath: "",
+};
+
 export const DEFAULT_DOCS_CONFIG: DocsConfig = {
   overview: DEFAULT_OVERVIEW,
   visualBranding: DEFAULT_VISUAL_BRANDING,
@@ -270,21 +360,194 @@ export const DEFAULT_DOCS_CONFIG: DocsConfig = {
   integrations: DEFAULT_INTEGRATIONS,
   apiDocs: DEFAULT_API_DOCS,
   advanced: DEFAULT_ADVANCED,
+  navigation: DEFAULT_NAVIGATION,
+  apiSpecs: [],
+  auth: DEFAULT_AUTH,
+  seo: DEFAULT_SEO,
+  localization: DEFAULT_LOCALIZATION,
+  errorPages: DEFAULT_ERROR_PAGES,
   contextualAiMenu: DEFAULT_CONTEXTUAL_AI_MENU,
+  unknownFields: {},
 };
 
 // ── Merge helper ─────────────────────────────────────────────────────────
 
-/** Deep-merge a partial config with defaults (one level deep per section). */
+const KNOWN_IMPORT_KEYS = new Set([
+  ...Object.keys(DEFAULT_DOCS_CONFIG),
+  "name",
+  "description",
+  "baseUrl",
+  "colors",
+  "logo",
+  "navbar",
+  "topbar",
+  "navigation",
+  "tabs",
+  "anchors",
+  "api",
+  "apis",
+  "openapi",
+  "redirects",
+  "seo",
+  "auth",
+  "authentication",
+  "languages",
+  "versions",
+  "errors",
+  "errorPages",
+]);
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+}
+
+function normalizeTopbarLinks(value: unknown): TopbarLink[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    const link = asRecord(entry);
+    const label = asString(link.label) ?? asString(link.name);
+    const url = asString(link.url) ?? asString(link.href);
+    return label && url ? [{ label, url }] : [];
+  });
+}
+
+function normalizeNavigationItems(value: unknown): NavigationItem[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap<NavigationItem>((entry) => {
+    if (typeof entry === "string") return [{ label: entry, path: entry }];
+    const item = asRecord(entry);
+    const label =
+      asString(item.label) ?? asString(item.name) ?? asString(item.group);
+    if (!label) return [];
+    return [
+      {
+        label,
+        path: asString(item.path),
+        href: asString(item.href),
+        pages: asStringArray(item.pages),
+        groups: normalizeNavigationItems(item.groups),
+      },
+    ];
+  });
+}
+
+function normalizeRedirects(value: unknown): RedirectEntry[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => {
+      const redirect = asRecord(entry);
+      const source = asString(redirect.source) ?? asString(redirect.from);
+      const destination =
+        asString(redirect.destination) ??
+        asString(redirect.to) ??
+        asString(redirect.target);
+      return source && destination ? [{ source, destination }] : [];
+    });
+  }
+  return Object.entries(asRecord(value)).flatMap(([source, destination]) =>
+    typeof destination === "string" ? [{ source, destination }] : [],
+  );
+}
+
+function normalizeApiSpecs(value: unknown): ApiSpecConfig[] {
+  if (typeof value === "string") return [{ name: "API", url: value }];
+  if (!Array.isArray(value)) return [];
+  return value.flatMap<ApiSpecConfig>((entry, index) => {
+    if (typeof entry === "string")
+      return [{ name: `API ${index + 1}`, url: entry }];
+    const spec = asRecord(entry);
+    const url =
+      asString(spec.url) ?? asString(spec.spec) ?? asString(spec.path);
+    const file = asString(spec.file);
+    if (!url && !file) return [];
+    return [
+      {
+        name: asString(spec.name) ?? asString(spec.label) ?? `API ${index + 1}`,
+        url,
+        file,
+        navigation: asString(spec.navigation),
+        version: asString(spec.version),
+      },
+    ];
+  });
+}
+
+function normalizeUnknownFields(partial: Record<string, unknown>): JsonObject {
+  const unknownFields = asRecord(partial.unknownFields) as JsonObject;
+  const preserved: JsonObject = { ...unknownFields };
+  for (const [key, value] of Object.entries(partial)) {
+    if (!KNOWN_IMPORT_KEYS.has(key)) preserved[key] = value as JsonValue;
+  }
+  return preserved;
+}
+
+/** Deep-merge a partial config with defaults and normalize docs.json-like keys. */
 export function mergeDocsConfig(
   partial: Partial<Record<string, unknown>> | undefined,
 ): DocsConfig {
   if (!partial) return { ...DEFAULT_DOCS_CONFIG };
+  const colors = asRecord(partial.colors);
+  const logo = asRecord(partial.logo);
+  const navbar = asRecord(partial.navbar ?? partial.topbar);
+  const footerConfig = asRecord(partial.footer);
+  const navigation = asRecord(partial.navigation);
+  const api = asRecord(partial.api ?? partial.openapi);
+  const seo = asRecord(partial.seo);
+  const auth = asRecord(partial.auth ?? partial.authentication);
+  const errors = asRecord(partial.errors ?? partial.errorPages);
+  const localization = asRecord(partial.localization);
   return {
-    overview: { ...DEFAULT_OVERVIEW, ...((partial.overview as object) ?? {}) },
+    overview: {
+      ...DEFAULT_OVERVIEW,
+      ...((partial.overview as object) ?? {}),
+      name:
+        asString(partial.name) ??
+        (partial.overview as OverviewConfig)?.name ??
+        DEFAULT_OVERVIEW.name,
+      description:
+        asString(partial.description) ??
+        (partial.overview as OverviewConfig)?.description ??
+        DEFAULT_OVERVIEW.description,
+      baseUrl:
+        asString(partial.baseUrl) ??
+        (partial.overview as OverviewConfig)?.baseUrl ??
+        DEFAULT_OVERVIEW.baseUrl,
+    },
     visualBranding: {
       ...DEFAULT_VISUAL_BRANDING,
       ...((partial.visualBranding as object) ?? {}),
+      primaryColor:
+        asString(colors.primary) ??
+        asString(colors.primaryColor) ??
+        (partial.visualBranding as VisualBrandingConfig)?.primaryColor ??
+        DEFAULT_VISUAL_BRANDING.primaryColor,
+      lightColor:
+        asString(colors.light) ??
+        (partial.visualBranding as VisualBrandingConfig)?.lightColor ??
+        DEFAULT_VISUAL_BRANDING.lightColor,
+      darkColor:
+        asString(colors.dark) ??
+        (partial.visualBranding as VisualBrandingConfig)?.darkColor ??
+        DEFAULT_VISUAL_BRANDING.darkColor,
+      logoLightPath:
+        asString(logo.light) ??
+        (partial.visualBranding as VisualBrandingConfig)?.logoLightPath ??
+        DEFAULT_VISUAL_BRANDING.logoLightPath,
+      logoDarkPath:
+        asString(logo.dark) ??
+        (partial.visualBranding as VisualBrandingConfig)?.logoDarkPath ??
+        DEFAULT_VISUAL_BRANDING.logoDarkPath,
     },
     typography: {
       ...DEFAULT_TYPOGRAPHY,
@@ -293,15 +556,32 @@ export function mergeDocsConfig(
     headerTopbar: {
       ...DEFAULT_HEADER_TOPBAR,
       ...((partial.headerTopbar as object) ?? {}),
-      topbarLinks: Array.isArray(
-        (partial.headerTopbar as HeaderTopbarConfig)?.topbarLinks,
-      )
-        ? (partial.headerTopbar as HeaderTopbarConfig).topbarLinks
-        : DEFAULT_HEADER_TOPBAR.topbarLinks,
+      logoPath:
+        asString(navbar.logo) ??
+        (partial.headerTopbar as HeaderTopbarConfig)?.logoPath ??
+        DEFAULT_HEADER_TOPBAR.logoPath,
+      topbarLinks:
+        normalizeTopbarLinks(navbar.links).length > 0
+          ? normalizeTopbarLinks(navbar.links)
+          : Array.isArray(
+                (partial.headerTopbar as HeaderTopbarConfig)?.topbarLinks,
+              )
+            ? (partial.headerTopbar as HeaderTopbarConfig).topbarLinks
+            : DEFAULT_HEADER_TOPBAR.topbarLinks,
     },
     footer: {
       ...DEFAULT_FOOTER,
       ...((partial.footer as object) ?? {}),
+      brandName:
+        asString(footerConfig.brandName) ??
+        asString(footerConfig.name) ??
+        (partial.footer as FooterConfig)?.brandName ??
+        DEFAULT_FOOTER.brandName,
+      brandUrl:
+        asString(footerConfig.brandUrl) ??
+        asString(footerConfig.url) ??
+        (partial.footer as FooterConfig)?.brandUrl ??
+        DEFAULT_FOOTER.brandUrl,
       socialLinks: Array.isArray((partial.footer as FooterConfig)?.socialLinks)
         ? (partial.footer as FooterConfig).socialLinks
         : DEFAULT_FOOTER.socialLinks,
@@ -326,13 +606,125 @@ export function mergeDocsConfig(
     apiDocs: {
       ...DEFAULT_API_DOCS,
       ...((partial.apiDocs as object) ?? {}),
+      openApiSpecUrl:
+        asString(api.url) ??
+        asString(api.spec) ??
+        asString(partial.openapi) ??
+        (partial.apiDocs as ApiDocsConfig)?.openApiSpecUrl ??
+        DEFAULT_API_DOCS.openApiSpecUrl,
     },
     advanced: {
       ...DEFAULT_ADVANCED,
       ...((partial.advanced as object) ?? {}),
-      redirects: Array.isArray((partial.advanced as AdvancedConfig)?.redirects)
-        ? (partial.advanced as AdvancedConfig).redirects
-        : DEFAULT_ADVANCED.redirects,
+      seoTitle:
+        asString(seo.title) ??
+        (partial.advanced as AdvancedConfig)?.seoTitle ??
+        DEFAULT_ADVANCED.seoTitle,
+      seoDescription:
+        asString(seo.description) ??
+        (partial.advanced as AdvancedConfig)?.seoDescription ??
+        DEFAULT_ADVANCED.seoDescription,
+      redirects:
+        normalizeRedirects(partial.redirects).length > 0
+          ? normalizeRedirects(partial.redirects)
+          : Array.isArray((partial.advanced as AdvancedConfig)?.redirects)
+            ? (partial.advanced as AdvancedConfig).redirects
+            : DEFAULT_ADVANCED.redirects,
+    },
+    navigation: {
+      ...DEFAULT_NAVIGATION,
+      ...((partial.navigation as object) ?? {}),
+      tabs:
+        normalizeNavigationItems(navigation.tabs).length > 0
+          ? normalizeNavigationItems(navigation.tabs)
+          : Array.isArray((partial.navigation as NavigationConfig)?.tabs)
+            ? (partial.navigation as NavigationConfig).tabs
+            : normalizeNavigationItems(partial.tabs),
+      groups:
+        normalizeNavigationItems(navigation.groups).length > 0
+          ? normalizeNavigationItems(navigation.groups)
+          : Array.isArray((partial.navigation as NavigationConfig)?.groups)
+            ? (partial.navigation as NavigationConfig).groups
+            : normalizeNavigationItems(partial.navigation),
+      anchors:
+        normalizeTopbarLinks(navigation.anchors).length > 0
+          ? normalizeTopbarLinks(navigation.anchors)
+          : Array.isArray((partial.navigation as NavigationConfig)?.anchors)
+            ? (partial.navigation as NavigationConfig).anchors
+            : normalizeTopbarLinks(partial.anchors),
+    },
+    apiSpecs:
+      normalizeApiSpecs(partial.apis).length > 0
+        ? normalizeApiSpecs(partial.apis)
+        : Array.isArray(partial.apiSpecs)
+          ? (partial.apiSpecs as ApiSpecConfig[])
+          : normalizeApiSpecs(api.specs),
+    auth: {
+      ...DEFAULT_AUTH,
+      ...((partial.auth as object) ?? {}),
+      mode:
+        (asString(auth.mode) as DocsAuthConfig["mode"] | undefined) ??
+        (asString(auth.type) as DocsAuthConfig["mode"] | undefined) ??
+        (partial.auth as DocsAuthConfig)?.mode ??
+        DEFAULT_AUTH.mode,
+      groups:
+        asStringArray(auth.groups).length > 0
+          ? asStringArray(auth.groups)
+          : Array.isArray((partial.auth as DocsAuthConfig)?.groups)
+            ? (partial.auth as DocsAuthConfig).groups
+            : DEFAULT_AUTH.groups,
+      ssoProvider:
+        asString(auth.ssoProvider) ??
+        (partial.auth as DocsAuthConfig)?.ssoProvider,
+    },
+    seo: {
+      ...DEFAULT_SEO,
+      ...((partial.seo as object) ?? {}),
+      title:
+        asString(seo.title) ??
+        (partial.seo as DocsSeoConfig)?.title ??
+        DEFAULT_SEO.title,
+      description:
+        asString(seo.description) ??
+        (partial.seo as DocsSeoConfig)?.description ??
+        DEFAULT_SEO.description,
+      noindex:
+        typeof seo.noindex === "boolean"
+          ? seo.noindex
+          : ((partial.seo as DocsSeoConfig)?.noindex ?? DEFAULT_SEO.noindex),
+    },
+    localization: {
+      ...DEFAULT_LOCALIZATION,
+      ...localization,
+      languages:
+        asStringArray(partial.languages).length > 0
+          ? asStringArray(partial.languages)
+          : asStringArray(localization.languages).length > 0
+            ? asStringArray(localization.languages)
+            : Array.isArray(
+                  (partial.localization as DocsLocalizationConfig)?.languages,
+                )
+              ? (partial.localization as DocsLocalizationConfig).languages
+              : DEFAULT_LOCALIZATION.languages,
+      versions:
+        asStringArray(partial.versions).length > 0
+          ? asStringArray(partial.versions)
+          : asStringArray(localization.versions).length > 0
+            ? asStringArray(localization.versions)
+            : Array.isArray(
+                  (partial.localization as DocsLocalizationConfig)?.versions,
+                )
+              ? (partial.localization as DocsLocalizationConfig).versions
+              : DEFAULT_LOCALIZATION.versions,
+    },
+    errorPages: {
+      ...DEFAULT_ERROR_PAGES,
+      ...((partial.errorPages as object) ?? {}),
+      notFoundPath:
+        asString(errors.notFoundPath) ??
+        asString(errors["404"]) ??
+        (partial.errorPages as ErrorPagesConfig)?.notFoundPath ??
+        DEFAULT_ERROR_PAGES.notFoundPath,
     },
     contextualAiMenu: {
       ...DEFAULT_CONTEXTUAL_AI_MENU,
@@ -343,6 +735,7 @@ export function mergeDocsConfig(
         ? (partial.contextualAiMenu as ContextualAiMenuConfig).tools
         : DEFAULT_CONTEXTUAL_AI_MENU.tools,
     },
+    unknownFields: normalizeUnknownFields(partial),
   };
 }
 
@@ -363,27 +756,48 @@ export function getDocsThemeCssVars(
 
 // ── Validation ───────────────────────────────────────────────────────────
 
+export interface ValidationIssue {
+  path: string;
+  message: string;
+}
+
 export type ValidationResult =
   | { valid: true }
-  | { valid: false; error: string };
+  | { valid: false; error: string; errors: ValidationIssue[] };
+
+function invalid(errors: ValidationIssue[]): ValidationResult {
+  return {
+    valid: false,
+    error: errors[0]?.message ?? "Invalid config",
+    errors,
+  };
+}
 
 export function validateDocsConfig(config: DocsConfig): ValidationResult {
-  // Visual branding colors
+  const errors: ValidationIssue[] = [];
+  const addIssue = (path: string, message: string) =>
+    errors.push({ path, message });
+
   for (const key of ["primaryColor", "lightColor", "darkColor"] as const) {
     if (
       config.visualBranding[key] &&
       !isValidHexColor(config.visualBranding[key])
     ) {
-      return { valid: false, error: `Invalid hex color for ${key}` };
+      addIssue(`visualBranding.${key}`, `Invalid hex color for ${key}`);
     }
   }
 
-  // Theme
-  if (!["light", "dark", "system"].includes(config.visualBranding.theme)) {
-    return { valid: false, error: "Theme must be light, dark, or system" };
+  if (
+    !config.visualBranding.logoLightPath &&
+    !config.visualBranding.logoDarkPath
+  ) {
+    // Logos are optional, but keeping this as non-blocking avoids noisy imports.
   }
 
-  // Code block theme
+  if (!["light", "dark", "system"].includes(config.visualBranding.theme)) {
+    addIssue("visualBranding.theme", "Theme must be light, dark, or system");
+  }
+
   const validCodeThemes = [
     "github-dark",
     "monokai",
@@ -392,26 +806,29 @@ export function validateDocsConfig(config: DocsConfig): ValidationResult {
     "nord",
   ];
   if (!validCodeThemes.includes(config.contentFeatures.codeBlockTheme)) {
-    return { valid: false, error: "Invalid code block theme" };
+    addIssue("contentFeatures.codeBlockTheme", "Invalid code block theme");
   }
 
-  // Icon library
   const validIconLibs = ["lucide", "fontawesome", "heroicons", "none"];
   if (!validIconLibs.includes(config.contentFeatures.iconLibrary)) {
-    return { valid: false, error: "Invalid icon library" };
+    addIssue("contentFeatures.iconLibrary", "Invalid icon library");
   }
 
-  // Topbar links
-  for (const link of config.headerTopbar.topbarLinks) {
+  config.headerTopbar.topbarLinks.forEach((link, index) => {
     if (!link.label.trim()) {
-      return { valid: false, error: "Topbar link label cannot be empty" };
+      addIssue(
+        `headerTopbar.topbarLinks.${index}.label`,
+        "Topbar link label cannot be empty",
+      );
     }
     if (!link.url.trim()) {
-      return { valid: false, error: "Topbar link URL cannot be empty" };
+      addIssue(
+        `headerTopbar.topbarLinks.${index}.url`,
+        "Topbar link URL cannot be empty",
+      );
     }
-  }
+  });
 
-  // Footer social links
   const validSocialTypes = [
     "x",
     "github",
@@ -420,35 +837,67 @@ export function validateDocsConfig(config: DocsConfig): ValidationResult {
     "slack",
     "website",
   ];
-  for (const link of config.footer.socialLinks) {
+  config.footer.socialLinks.forEach((link, index) => {
     if (!validSocialTypes.includes(link.type)) {
-      return { valid: false, error: `Invalid social link type: ${link.type}` };
+      addIssue(
+        `footer.socialLinks.${index}.type`,
+        `Invalid social link type: ${link.type}`,
+      );
     }
     if (!link.url.trim()) {
-      return { valid: false, error: "Social link URL cannot be empty" };
+      addIssue(
+        `footer.socialLinks.${index}.url`,
+        "Social link URL cannot be empty",
+      );
     }
+  });
+
+  config.advanced.redirects.forEach((redirect, index) => {
+    if (!redirect.source.trim()) {
+      addIssue(
+        `advanced.redirects.${index}.source`,
+        "Redirect source path cannot be empty",
+      );
+    }
+    if (!redirect.destination.trim()) {
+      addIssue(
+        `advanced.redirects.${index}.destination`,
+        "Redirect destination path cannot be empty",
+      );
+    }
+    if (redirect.source === redirect.destination) {
+      addIssue(
+        `advanced.redirects.${index}`,
+        `Redirect source and destination cannot be the same: ${redirect.source}`,
+      );
+    }
+  });
+
+  config.apiSpecs.forEach((spec, index) => {
+    if (!spec.name.trim()) {
+      addIssue(`apiSpecs.${index}.name`, "API spec name cannot be empty");
+    }
+    if (!spec.url?.trim() && !spec.file?.trim()) {
+      addIssue(`apiSpecs.${index}`, "API spec must include a URL or file path");
+    }
+  });
+
+  if (
+    !["public", "password", "org", "groups", "sso"].includes(config.auth.mode)
+  ) {
+    addIssue(
+      "auth.mode",
+      "Auth mode must be public, password, org, groups, or sso",
+    );
+  }
+  if (config.auth.mode === "groups" && config.auth.groups.length === 0) {
+    addIssue(
+      "auth.groups",
+      "Group-restricted auth requires at least one group",
+    );
   }
 
-  // Redirects
-  for (const r of config.advanced.redirects) {
-    if (!r.source.trim()) {
-      return { valid: false, error: "Redirect source path cannot be empty" };
-    }
-    if (!r.destination.trim()) {
-      return {
-        valid: false,
-        error: "Redirect destination path cannot be empty",
-      };
-    }
-    if (r.source === r.destination) {
-      return {
-        valid: false,
-        error: `Redirect source and destination cannot be the same: ${r.source}`,
-      };
-    }
-  }
-
-  return { valid: true };
+  return errors.length > 0 ? invalid(errors) : { valid: true };
 }
 
 // ── Export / Import helpers ──────────────────────────────────────────────

--- a/tests/docs-config.test.ts
+++ b/tests/docs-config.test.ts
@@ -320,3 +320,89 @@ describe("sectionIdToConfigKey", () => {
     expect(sectionIdToConfigKey("api-docs")).toBe("apiDocs");
   });
 });
+
+// ── docs-platform compatibility ─────────────────────────────────────────
+
+describe("docs-platform config compatibility", () => {
+  it("imports common docs.json primitives into typed OpenDocs config", () => {
+    const result = importDocsConfigJson(
+      JSON.stringify({
+        name: "Platform Docs",
+        description: "Modern docs baseline",
+        colors: { primary: "#3366FF", light: "#FFFFFF", dark: "#050505" },
+        logo: { light: "/logo-light.svg", dark: "/logo-dark.svg" },
+        navbar: { links: [{ label: "API", href: "/api-reference" }] },
+        navigation: {
+          tabs: [
+            {
+              label: "Guides",
+              groups: [{ label: "Start", pages: ["quickstart"] }],
+            },
+          ],
+          anchors: [{ label: "Support", url: "https://support.example.com" }],
+        },
+        apis: [
+          {
+            name: "Public API",
+            url: "/openapi.json",
+            navigation: "API Reference",
+          },
+          { name: "Admin API", file: "admin-openapi.json", version: "2026-05" },
+        ],
+        redirects: { "/old": "/new" },
+        seo: {
+          title: "SEO title",
+          description: "SEO description",
+          noindex: true,
+        },
+        auth: { mode: "groups", groups: ["engineering", "support"] },
+        languages: ["en", "ko"],
+        versions: ["v1", "v2"],
+        errors: { "404": "/not-found" },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.config.overview.name).toBe("Platform Docs");
+    expect(result.config.visualBranding.primaryColor).toBe("#3366FF");
+    expect(result.config.headerTopbar.topbarLinks).toEqual([
+      { label: "API", url: "/api-reference" },
+    ]);
+    expect(result.config.navigation.tabs[0]?.groups?.[0]?.pages).toEqual([
+      "quickstart",
+    ]);
+    expect(result.config.apiSpecs).toHaveLength(2);
+    expect(result.config.advanced.redirects).toEqual([
+      { source: "/old", destination: "/new" },
+    ]);
+    expect(result.config.auth).toMatchObject({
+      mode: "groups",
+      groups: ["engineering", "support"],
+    });
+    expect(result.config.localization.languages).toEqual(["en", "ko"]);
+    expect(result.config.errorPages.notFoundPath).toBe("/not-found");
+  });
+
+  it("preserves unknown top-level fields for round-trip compatibility", () => {
+    const result = importDocsConfigJson(
+      JSON.stringify({
+        name: "Docs",
+        experimentalFeature: { enabled: true, rollout: 50 },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.config.unknownFields.experimentalFeature).toEqual({
+      enabled: true,
+      rollout: 50,
+    });
+
+    const exported = JSON.parse(exportDocsConfigJson(result.config));
+    expect(exported.unknownFields.experimentalFeature).toEqual({
+      enabled: true,
+      rollout: 50,
+    });
+  });
+});


### PR DESCRIPTION
## Summary\n- add typed docs-platform compatibility fields for navigation, API specs, auth, SEO, localization, error pages, and unknown-field preservation\n- normalize common docs.json-like import shapes into OpenDocs config without dropping unsupported top-level fields\n- return path-specific config validation issues while keeping the existing single error string for UI compatibility\n- add docs-config parity tests for representative modern docs-platform config import and unknown-field round-trip preservation\n\nCloses #246 partially; this is the first P0 config/schema compatibility slice.\n\n## Verification\n- make check\n- make test