### PR TITLE
docs: add self-hosting guide and sync env-var documentation with code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,59 +1,75 @@
-# Database -- connection string from Neon, RDS, Cloud SQL, etc.
+# ── Required ────────────────────────────────────────────────────────────────
+
+# Database — connection string from Neon, RDS, Cloud SQL, etc.
 DATABASE_URL=postgresql://user:password@host:5432/dbname
+# Set to "true" for managed Postgres providers that require TLS
 DB_SSL=true
-DB_PASSWORD=your-db-password
 
-# Cloud provider region (AWS, GCP, Azure)
-AWS_REGION=us-east-1
-
-# AI models -- powered by AWS Bedrock (uses aws-cli credentials, no separate API key needed)
-# Ensure `aws configure` is set and Bedrock model access is enabled in your region
-AWS_BEDROCK_REGION=us-east-1
-
-# Cloudflare -- CDN and edge caching (optional, only if clone needs edge layer)
-CLOUDFLARE_API_TOKEN=
-CLOUDFLARE_ZONE_ID=
-
-# Auth -- Better Auth
+# Auth — Better Auth
 BETTER_AUTH_SECRET=generate-with-openssl-rand-base64-32
 BETTER_AUTH_URL=http://localhost:3015
 
-# Auth -- Google OAuth
-# IMPORTANT: You must also configure these in Google Cloud Console:
-#   1. Go to https://console.cloud.google.com/apis/credentials
-#   2. Add Authorized redirect URI: http://localhost:3015/api/auth/callback/google
-#   3. For production, also add: https://your-domain.com/api/auth/callback/google
-#   4. Set OAuth consent screen to "External" + Published
-#      OR add your test Google account as a test user
-#   5. If using Ever CLI for QA: add the Google account your browser
-#      is logged into as a test user (Ever uses the existing browser session)
+# App — public origin (must match BETTER_AUTH_URL)
+NEXT_PUBLIC_APP_URL=http://localhost:3015
+
+# ── Required in production ──────────────────────────────────────────────────
+
+# Docs/API-playground proxy host allowlist (comma-separated). The proxy fails
+# closed in production when this is unset.
+DOCS_PROXY_ALLOWED_HOSTS=
+
+# ── Google OAuth (optional — Google login unavailable without it) ───────────
+# Configure in Google Cloud Console (https://console.cloud.google.com/apis/credentials):
+#   1. Add Authorized redirect URI: http://localhost:3015/api/auth/callback/google
+#   2. For production, also add: https://your-domain.com/api/auth/callback/google
+#   3. Set OAuth consent screen to "External" + Published, or add test users
 AUTH_GOOGLE_ID=your-google-client-id
 AUTH_GOOGLE_SECRET=your-google-client-secret
-GITHUB_APP_ID=your-github-app-id
-GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
-# GitHub App install/setup
-# Configure the GitHub App "Setup URL" to:
-#   http://localhost:3015/api/github-connections/callback
-# Production/staging should use the deployed origin, e.g.:
-#   https://opendocs.namuh.co/api/github-connections/callback
+
+# ── AWS storage & AI (optional — uploads and AI assistant) ──────────────────
+# Credentials resolve via the standard AWS SDK chain (`aws configure`, role, env).
+AWS_REGION=us-east-1
+S3_BUCKET=your-doc-assets-bucket
+# Bedrock model for the AI assistant (default: us.anthropic.claude-sonnet-4-20250514-v1:0).
+# Bedrock model access must be enabled in your region.
+ASSISTANT_BEDROCK_MODEL_ID=
+
+# ── GitHub App (optional — GitHub import/sync) ──────────────────────────────
+# Set the GitHub App "Setup URL" to:
+#   http://localhost:3015/api/github-connections/callback (dev)
+#   https://your-domain.com/api/github-connections/callback (production)
 # The settings page uses GITHUB_APP_INSTALL_URL when set; otherwise it builds
 # https://github.com/apps/<GITHUB_APP_SLUG>/installations/new.
+GITHUB_APP_ID=your-github-app-id
+GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
 GITHUB_APP_SLUG=your-github-app-slug
 GITHUB_APP_INSTALL_URL=
+# Production webhooks fail closed without a verified secret/signature
+GITHUB_WEBHOOK_SECRET=your-github-webhook-secret
 
-# Stripe billing -- required only for billing API routes and webhooks
+# ── Stripe billing (optional — app runs in free/dev billing state without) ──
+# See docs/deployment/stripe-billing.md for webhook setup and local testing.
 STRIPE_SECRET_KEY=sk_test_your-stripe-secret-key
 STRIPE_WEBHOOK_SECRET=whsec_your-stripe-webhook-secret
 STRIPE_PRICE_ID=price_your-recurring-price-id
 # Optional multi-plan mappings for paid access decisions
-STRIPE_PRO_PRICE_ID=price_your-pro-price-id
-STRIPE_ENTERPRISE_PRICE_ID=price_your-enterprise-price-id
+STRIPE_PRO_PRICE_ID=
+STRIPE_ENTERPRISE_PRICE_ID=
 
-# App
-NEXT_PUBLIC_APP_URL=http://localhost:3015
+# ── Observability (optional — zero outbound calls when unset) ───────────────
+# NEXT_PUBLIC_* values are inlined at BUILD time (Docker: pass as --build-arg).
+SENTRY_DSN=
+SENTRY_ENVIRONMENT=
+SENTRY_RELEASE=
+SENTRY_TRACES_SAMPLE_RATE=
+POSTHOG_API_KEY=
+POSTHOG_HOST=
+NEXT_PUBLIC_SENTRY_DSN=
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=
 
-# Test account — Google account for build/QA agent auth (Ever CLI uses this)
-TEST_ACCOUNT_EMAIL=your-google-email@gmail.com
-
-# Dashboard -- simple auth key for the admin dashboard
-DASHBOARD_KEY=your-dashboard-key
+# ── Infra scripts only (not read by the app) ────────────────────────────────
+# scripts/preflight.sh — RDS master password (auto-generated if missing)
+DB_PASSWORD=
+# scripts/generate-demo-keys.sh — master key for local demo API key generation
+DASHBOARD_KEY=

--- a/README.md
+++ b/README.md
@@ -43,9 +43,7 @@ Production is currently configured with:
 - Public API redaction for sensitive docs auth settings
 - Security headers regression coverage
 
-Latest observed production health check returned `status: ok` on deployed version `78375da` with database and storage checks passing. The active integration branch is `staging`, with recent updates through `b39ed4c` covering GitHub App configuration routing, customer-safe GitHub sync unavailable states, analytics fixes, assistant search configuration UX, and docs visual branding fixes.
-
-Recent verified release checks have included:
+The active integration branch is `staging`. Standard release verification includes:
 
 - `npm run lint`
 - `npm run typecheck`
@@ -112,6 +110,10 @@ npm run dev
 
 The local dev server runs on http://localhost:3015.
 
+### Self-hosting
+
+For a full production self-hosting walkthrough — Docker build/run, the complete environment-variable reference, database migrations, reverse-proxy setup, and upgrades — see [`docs/self-hosting.md`](docs/self-hosting.md).
+
 ### For humans
 
 Use this README as the high-level product and operator guide:
@@ -152,12 +154,13 @@ Use this repository like a production product codebase, not a throwaway clone:
 
 ## Environment variables
 
-Copy `.env.example` to `.env` for local development. Production should provide these through the deployment environment or secrets manager.
+Copy `.env.example` to `.env` for local development. Production should provide these through the deployment environment or secrets manager. The complete per-feature reference (including what degrades when each optional var is unset) lives in [`docs/self-hosting.md`](docs/self-hosting.md).
 
 ### Required core settings
 
 ```bash
 DATABASE_URL=postgresql://user:password@host:5432/dbname
+DB_SSL=true                        # "true" for managed Postgres requiring TLS
 NEXT_PUBLIC_APP_URL=http://localhost:3015
 BETTER_AUTH_URL=http://localhost:3015
 BETTER_AUTH_SECRET=your-random-secret
@@ -181,27 +184,6 @@ GITHUB_APP_PRIVATE_KEY=your-github-app-private-key
 GITHUB_APP_SLUG=your-github-app-slug
 # Optional override if the default slug URL is not correct:
 GITHUB_APP_INSTALL_URL=https://github.com/apps/your-github-app-slug/installations/new
-STRIPE_SECRET_KEY=sk_test_your-stripe-secret-key
-STRIPE_WEBHOOK_SECRET=whsec_your-stripe-webhook-secret
-STRIPE_PRICE_ID=price_your-recurring-price-id
-```
-
-Stripe billing API routes are documented in `docs/deployment/stripe-billing.md`, including local Stripe CLI webhook forwarding with:
-
-```bash
-stripe login
-stripe listen --forward-to localhost:3015/api/billing/stripe/webhook
-```
-
-### Billing (optional, commercial hosted plans)
-
-The billing settings page calls the application billing API for Stripe Checkout and Customer Portal redirects. Configure these in the billing API lane when paid plans are enabled; local UI tests do not require live Stripe credentials.
-
-```bash
-STRIPE_SECRET_KEY=
-STRIPE_WEBHOOK_SECRET=
-STRIPE_PRICE_ID_PRO=
-STRIPE_CUSTOMER_PORTAL_RETURN_URL=
 ```
 
 Google OAuth must include this production redirect URI:
@@ -218,15 +200,19 @@ https://opendocs.namuh.co/api/github-connections/callback
 
 For staging, use the staging origin with the same path.
 
-### AWS and storage
+### AWS storage and AI
 
 ```bash
 AWS_REGION=us-east-1
-AWS_BEDROCK_REGION=us-east-1
 S3_BUCKET=your-doc-assets-bucket
+# Bedrock model for the AI assistant
+# (default: us.anthropic.claude-sonnet-4-20250514-v1:0)
+ASSISTANT_BEDROCK_MODEL_ID=
 ```
 
-### Billing
+AWS credentials resolve through the standard SDK chain. Bedrock model access must be enabled in the configured region for AI features.
+
+### Billing (optional)
 
 Stripe billing is optional for local open-source development. Without Stripe
 configuration, the app keeps running with free/dev billing state; production
@@ -234,10 +220,35 @@ paid-feature gates should be wired to fail closed until a valid subscription is
 synced.
 
 ```bash
-STRIPE_SECRET_KEY=
-STRIPE_WEBHOOK_SECRET=
+STRIPE_SECRET_KEY=sk_test_your-stripe-secret-key
+STRIPE_WEBHOOK_SECRET=whsec_your-stripe-webhook-secret
+STRIPE_PRICE_ID=price_your-recurring-price-id
+# Optional multi-plan mappings for paid access decisions
 STRIPE_PRO_PRICE_ID=
 STRIPE_ENTERPRISE_PRICE_ID=
+```
+
+Stripe billing API routes are documented in [`docs/deployment/stripe-billing.md`](docs/deployment/stripe-billing.md), including local Stripe CLI webhook forwarding with:
+
+```bash
+stripe login
+stripe listen --forward-to localhost:3015/api/billing/stripe/webhook
+```
+
+### Observability (optional)
+
+Sentry and PostHog are wired but fully no-op when unconfigured — a default build makes zero outbound telemetry calls. `NEXT_PUBLIC_*` values are inlined at build time (for Docker, pass them as `--build-arg`).
+
+```bash
+SENTRY_DSN=
+SENTRY_ENVIRONMENT=
+SENTRY_RELEASE=
+SENTRY_TRACES_SAMPLE_RATE=
+POSTHOG_API_KEY=
+POSTHOG_HOST=
+NEXT_PUBLIC_SENTRY_DSN=
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=
 ```
 
 ### Docs proxy allowlist
@@ -270,9 +281,22 @@ docker build \
   -t opendocs:local .
 ```
 
-For the current AWS production runbook, see:
+The container listens on port 3000 internally. Run database migrations (`npm run db:migrate`) against the same `DATABASE_URL` before first boot, then:
 
-- [`docs/deployment/opendocs-production.md`](docs/deployment/opendocs-production.md)
+```bash
+docker run -d -p 3015:3000 \
+  -e DATABASE_URL=... \
+  -e BETTER_AUTH_SECRET=... \
+  -e BETTER_AUTH_URL=https://your-domain.com \
+  -e NEXT_PUBLIC_APP_URL=https://your-domain.com \
+  -e DOCS_PROXY_ALLOWED_HOSTS=your-domain.com \
+  opendocs:local
+```
+
+For deployment guides, see:
+
+- [`docs/self-hosting.md`](docs/self-hosting.md) — general self-hosting guide (Docker, env reference, migrations, upgrades)
+- [`docs/deployment/opendocs-production.md`](docs/deployment/opendocs-production.md) — internal AWS production runbook for opendocs.namuh.co
 
 ---
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,193 @@
+# Self-hosting OpenDocs
+
+OpenDocs is licensed under the [Elastic License 2.0](../LICENSE): you can use, modify, and self-host it freely, but you may not offer it as a hosted service to third parties.
+
+This guide covers running your own OpenDocs instance — locally, with Docker, or behind a reverse proxy in production. For the reference AWS deployment used for opendocs.namuh.co, see [`deployment/opendocs-production.md`](deployment/opendocs-production.md) (internal runbook).
+
+## Prerequisites
+
+- **PostgreSQL 14+** — any provider (RDS, Neon, Cloud SQL, or a local container). This is the only hard infrastructure dependency.
+- **Node.js 20+** (bare-metal) or **Docker** (container deployment).
+- **Optional AWS credentials** — only needed for file uploads (S3) and the AI assistant/search (Bedrock). Everything else works without AWS.
+
+Optional integrations (the app boots and degrades cleanly without each of them):
+
+| Feature | Needs | Without it |
+| --- | --- | --- |
+| Google sign-in | Google OAuth client | Google login button is unavailable |
+| File/image uploads | S3 bucket + AWS credentials | Uploads unavailable; `/api/health` reports storage unavailable |
+| AI assistant & search | AWS Bedrock model access | AI features unavailable |
+| GitHub sync | GitHub App | GitHub import/sync shows an unavailable state |
+| Billing | Stripe account | App runs in free/dev billing state |
+| Error/product analytics | Sentry / PostHog | No-op; the app makes zero outbound telemetry calls |
+
+## Quick start (local)
+
+```bash
+git clone https://github.com/namuh-eng/opendocs.git
+cd opendocs
+npm install
+cp .env.example .env
+# Set at minimum: DATABASE_URL, BETTER_AUTH_SECRET
+npm run db:push        # create the schema (dev) — use db:migrate for real deployments
+npm run dev            # http://localhost:3015
+```
+
+## Environment variables
+
+### Required (all environments)
+
+```bash
+DATABASE_URL=postgresql://user:password@host:5432/opendocs
+DB_SSL=true                                  # set to "true" for managed Postgres (RDS, Neon, …)
+BETTER_AUTH_SECRET=$(openssl rand -base64 32)
+NEXT_PUBLIC_APP_URL=https://docs.example.com # your public origin
+BETTER_AUTH_URL=https://docs.example.com     # same origin as above
+```
+
+`NEXT_PUBLIC_APP_URL` and `BETTER_AUTH_URL` must be the public origin users reach the app on (scheme included). For local development both are `http://localhost:3015`.
+
+### Required in production
+
+Deployments with `NODE_ENV=production` additionally fail closed without:
+
+```bash
+DOCS_PROXY_ALLOWED_HOSTS=docs.example.com,api.yourservice.com
+```
+
+The docs/API-playground proxy refuses all requests in production unless the target host is on this comma-separated allowlist. Signed docs-access cookies also require `BETTER_AUTH_SECRET` in production — protected docs will not unlock without it.
+
+### Google OAuth (optional)
+
+```bash
+AUTH_GOOGLE_ID=your-google-oauth-client-id
+AUTH_GOOGLE_SECRET=your-google-oauth-client-secret
+```
+
+In the Google Cloud Console, the OAuth client needs the redirect URI `https://docs.example.com/api/auth/callback/google` (and the `http://localhost:3015/...` equivalent for development).
+
+### AWS storage and AI (optional)
+
+```bash
+AWS_REGION=us-east-1
+S3_BUCKET=your-doc-assets-bucket
+# Override the assistant model (default: us.anthropic.claude-sonnet-4-20250514-v1:0)
+ASSISTANT_BEDROCK_MODEL_ID=
+```
+
+AWS credentials are resolved through the standard SDK chain (instance role, `aws configure`, env vars). Bedrock model access must be enabled for your region in the AWS console.
+
+### GitHub App (optional)
+
+```bash
+GITHUB_APP_ID=your-github-app-id
+GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
+GITHUB_APP_SLUG=your-github-app-slug
+GITHUB_APP_INSTALL_URL=          # optional override for the install URL
+GITHUB_WEBHOOK_SECRET=your-github-webhook-secret
+```
+
+Set the GitHub App's **Setup URL** to `https://docs.example.com/api/github-connections/callback`. In production, incoming webhooks are rejected unless `GITHUB_WEBHOOK_SECRET` is set and the signature verifies.
+
+### Stripe billing (optional)
+
+```bash
+STRIPE_SECRET_KEY=sk_live_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+STRIPE_PRICE_ID=price_...        # recurring subscription price used by checkout
+STRIPE_PRO_PRICE_ID=             # optional multi-plan mapping
+STRIPE_ENTERPRISE_PRICE_ID=      # optional multi-plan mapping
+```
+
+See [`deployment/stripe-billing.md`](deployment/stripe-billing.md) for the webhook setup and local Stripe CLI testing.
+
+### Observability (optional)
+
+OpenDocs ships with Sentry and PostHog wiring that is a complete no-op when unconfigured — a default build makes zero outbound telemetry calls.
+
+```bash
+# Server-side
+SENTRY_DSN=
+SENTRY_ENVIRONMENT=
+SENTRY_RELEASE=
+SENTRY_TRACES_SAMPLE_RATE=
+POSTHOG_API_KEY=
+POSTHOG_HOST=
+
+# Client-side — NEXT_PUBLIC_* values are inlined at BUILD time.
+# For Docker they must be passed as --build-arg, not runtime env.
+NEXT_PUBLIC_SENTRY_DSN=
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=
+```
+
+## Database migrations
+
+The repo tracks generated Drizzle migrations in `drizzle/`. The container does **not** run migrations on boot — run them as a deploy step against the same `DATABASE_URL`:
+
+```bash
+npm run db:migrate   # apply tracked migrations (production)
+npm run db:push      # push schema directly (dev/throwaway databases only)
+```
+
+## Docker
+
+### Build
+
+`NEXT_PUBLIC_*` values and the auth URL are baked into the client bundle at build time, so pass them as build args:
+
+```bash
+docker build \
+  --build-arg NEXT_PUBLIC_APP_URL=https://docs.example.com \
+  --build-arg BETTER_AUTH_URL=https://docs.example.com \
+  -t opendocs:latest .
+```
+
+Add `--build-arg NEXT_PUBLIC_SENTRY_DSN=... --build-arg NEXT_PUBLIC_POSTHOG_KEY=...` if you want client-side observability.
+
+### Run
+
+The container listens on port **3000** internally:
+
+```bash
+docker run -d --name opendocs -p 3015:3000 \
+  -e DATABASE_URL=postgresql://user:password@host:5432/opendocs \
+  -e DB_SSL=true \
+  -e BETTER_AUTH_SECRET=your-random-secret \
+  -e BETTER_AUTH_URL=https://docs.example.com \
+  -e NEXT_PUBLIC_APP_URL=https://docs.example.com \
+  -e DOCS_PROXY_ALLOWED_HOSTS=docs.example.com \
+  -e AWS_REGION=us-east-1 \
+  -e S3_BUCKET=your-doc-assets-bucket \
+  opendocs:latest
+```
+
+Add the optional integration vars from the reference above as needed. Remember to run migrations before first boot.
+
+### Bare-metal production (no Docker)
+
+The build produces a standalone Next.js server:
+
+```bash
+npm ci
+NEXT_PUBLIC_APP_URL=https://docs.example.com BETTER_AUTH_URL=https://docs.example.com npm run build
+PORT=3015 HOSTNAME=0.0.0.0 node .next/standalone/server.js
+```
+
+Static assets must be served alongside the standalone output — copy `.next/static` to `.next/standalone/.next/static` and `public/` to `.next/standalone/public` (the Dockerfile shows the exact layout).
+
+## Reverse proxy and health checks
+
+- Terminate TLS at your proxy/load balancer and forward to the container port. `NEXT_PUBLIC_APP_URL`/`BETTER_AUTH_URL` must match the public HTTPS origin, not the internal address.
+- Point health checks at `GET /api/health` — it returns `status`, the running version, and database/storage check results.
+
+## Upgrading
+
+```bash
+git pull
+npm ci
+npm run db:migrate
+# rebuild (docker build … or npm run build) and restart
+```
+
+Before upgrading a production instance, check the release notes/commits for new required environment variables.


### PR DESCRIPTION
## What

- **New `docs/self-hosting.md`** — full self-hosting walkthrough: Docker build/run (container port 3000, `NEXT_PUBLIC_*` as build args), complete env-var reference with fail-closed production behaviors, migration step, reverse-proxy/health-check notes, bare-metal standalone instructions, and upgrade procedure.
- **README** — collapsed the three conflicting Stripe env blocks into the single set the code actually reads (`STRIPE_PRICE_ID`, `STRIPE_PRO_PRICE_ID`, `STRIPE_ENTERPRISE_PRICE_ID`); removed dead `STRIPE_PRICE_ID_PRO`/`STRIPE_CUSTOMER_PORTAL_RETURN_URL`/`AWS_BEDROCK_REGION`; added `DB_SSL`, `ASSISTANT_BEDROCK_MODEL_ID`, and the new Sentry/PostHog observability vars; dropped stale deployed-version hashes; added a `docker run` example and self-hosting links.
- **`.env.example`** — added missing live vars (`DOCS_PROXY_ALLOWED_HOSTS`, `S3_BUCKET`, `GITHUB_WEBHOOK_SECRET`, observability); removed dead vars (`CLOUDFLARE_*`, `TEST_ACCOUNT_EMAIL`, `AWS_BEDROCK_REGION`); kept `DB_PASSWORD`/`DASHBOARD_KEY` labeled as infra-script-only.

## Why

The repo promised self-hosting (license, README) but had no usable self-hosting doc — the only deployment guide is the internal AWS runbook. Env-var docs had drifted from the code in several places (verified by grepping every `process.env` read in `src`).

## Verification

Docs-only change. Verified every documented var against actual code reads (`src/lib/stripe.ts`, `src/lib/deploy.ts`, `src/lib/db/index.ts`, `src/lib/assistant-model.ts`, `src/lib/s3.ts`, Dockerfile, `scripts/deploy.sh`); all relative doc links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)