### PR TITLE
fix: hide internal generated docs from public surfaces

### DIFF
--- a/src/app/api/docs/[subdomain]/chat/route.ts
+++ b/src/app/api/docs/[subdomain]/chat/route.ts
@@ -27,6 +27,7 @@ import {
   getDocsAccessCookieName,
   hasValidDocsAccess,
 } from "@/lib/project-docs-access";
+import { filterPublicDocsVisiblePages } from "@/lib/public-docs-curation";
 
 const bedrock = new BedrockRuntimeClient({ region: "us-east-1" });
 const MODEL_ID = getAssistantBedrockModelId();
@@ -89,6 +90,7 @@ export async function POST(
     path: string;
     title: string;
     content: string | null;
+    frontmatter?: Record<string, unknown> | null;
   }> = [];
 
   if (userQuery) {
@@ -98,6 +100,7 @@ export async function POST(
         path: pages.path,
         title: pages.title,
         content: pages.content,
+        frontmatter: pages.frontmatter,
       })
       .from(pages)
       .where(
@@ -111,7 +114,11 @@ export async function POST(
           ),
         ),
       )
-      .limit(validation.retrievalPageSize);
+      .limit(Math.min(validation.retrievalPageSize * 3, 30));
+    contextPages = filterPublicDocsVisiblePages(contextPages).slice(
+      0,
+      validation.retrievalPageSize,
+    );
   }
 
   // ── Build system prompt ────────────────────────────────────────────────────

--- a/src/app/api/docs/[subdomain]/markdown/[...slug]/route.ts
+++ b/src/app/api/docs/[subdomain]/markdown/[...slug]/route.ts
@@ -7,6 +7,7 @@ import {
   getDocsAccessCookieName,
   hasValidDocsAccess,
 } from "@/lib/project-docs-access";
+import { isPublicDocsVisiblePage } from "@/lib/public-docs-curation";
 
 export async function GET(
   request: NextRequest,
@@ -43,7 +44,12 @@ export async function GET(
   }
 
   const [page] = await db
-    .select({ title: pages.title, content: pages.content })
+    .select({
+      path: pages.path,
+      title: pages.title,
+      content: pages.content,
+      frontmatter: pages.frontmatter,
+    })
     .from(pages)
     .where(
       and(
@@ -54,7 +60,7 @@ export async function GET(
     )
     .limit(1);
 
-  if (!page) {
+  if (!page || !isPublicDocsVisiblePage(page)) {
     return new NextResponse("Page not found", { status: 404 });
   }
 

--- a/src/app/api/docs/[subdomain]/route.ts
+++ b/src/app/api/docs/[subdomain]/route.ts
@@ -7,6 +7,7 @@ import {
   getDocsAccessCookieName,
   hasValidDocsAccess,
 } from "@/lib/project-docs-access";
+import { filterPublicDocsVisiblePages } from "@/lib/public-docs-curation";
 
 /** GET /api/docs/[subdomain] — public endpoint to fetch all published pages for a docs site */
 export async function GET(
@@ -73,6 +74,6 @@ export async function GET(
       subdomain: projectData.subdomain,
       settings: redactProjectAuthenticationSettings(projectData.settings),
     },
-    pages: publishedPages,
+    pages: filterPublicDocsVisiblePages(publishedPages),
   });
 }

--- a/src/app/api/docs/[subdomain]/search/route.ts
+++ b/src/app/api/docs/[subdomain]/search/route.ts
@@ -26,6 +26,7 @@ import {
   getDocsAccessCookieName,
   hasValidDocsAccess,
 } from "@/lib/project-docs-access";
+import { isPublicDocsVisiblePage } from "@/lib/public-docs-curation";
 import { extractSnippet, getBreadcrumb } from "@/lib/search";
 
 interface RouteContext {
@@ -186,6 +187,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
       title: pages.title,
       description: pages.description,
       content: pages.content,
+      frontmatter: pages.frontmatter,
     })
     .from(pages)
     .where(
@@ -209,21 +211,23 @@ export async function GET(request: NextRequest, context: RouteContext) {
         ELSE 3
       END`,
     )
-    .limit(limit);
+    .limit(Math.min(limit * 3, 100));
 
-  const formatted: RankedSearchResult[] = results.map((r) => ({
-    path: r.path,
-    title: r.title,
-    description: r.description,
-    snippet: extractSnippet(r.content, query),
-    breadcrumb: getBreadcrumb(r.path),
-    rank: rankMatch(query, {
-      title: r.title,
+  const formatted: RankedSearchResult[] = results
+    .filter(isPublicDocsVisiblePage)
+    .map((r) => ({
       path: r.path,
+      title: r.title,
       description: r.description,
-      content: r.content,
-    }),
-  }));
+      snippet: extractSnippet(r.content, query),
+      breadcrumb: getBreadcrumb(r.path),
+      rank: rankMatch(query, {
+        title: r.title,
+        path: r.path,
+        description: r.description,
+        content: r.content,
+      }),
+    }));
 
   const generatedResults = getGeneratedApiSearchResults(
     docsSettings.openApiSpec as Record<string, unknown> | undefined,

--- a/src/app/api/docs/[subdomain]/sitemap/route.ts
+++ b/src/app/api/docs/[subdomain]/sitemap/route.ts
@@ -2,6 +2,7 @@ import { and, eq } from "drizzle-orm";
 import { getPublicAppUrl } from "@/lib/app-url";
 import { db } from "@/lib/db";
 import { pages, projects } from "@/lib/db/schema";
+import { filterPublicDocsVisiblePages } from "@/lib/public-docs-curation";
 
 const APP_URL = getPublicAppUrl();
 
@@ -31,13 +32,15 @@ export async function GET(
   const publishedPages = await db
     .select({
       path: pages.path,
+      title: pages.title,
+      frontmatter: pages.frontmatter,
       updatedAt: pages.updatedAt,
     })
     .from(pages)
     .where(and(eq(pages.projectId, project.id), eq(pages.isPublished, true)));
 
   // 3. Build XML
-  const sitemapEntries = publishedPages
+  const sitemapEntries = filterPublicDocsVisiblePages(publishedPages)
     .map((page) => {
       const url = `${APP_URL}/docs/${subdomain}/${page.path === "introduction" ? "" : page.path}`;
       const lastMod = page.updatedAt

--- a/src/app/docs/[subdomain]/[...slug]/page.tsx
+++ b/src/app/docs/[subdomain]/[...slug]/page.tsx
@@ -63,6 +63,10 @@ import {
   getDocsAccessCookieName,
   hasValidDocsAccess,
 } from "@/lib/project-docs-access";
+import {
+  filterPublicDocsVisiblePages,
+  isPublicDocsVisiblePage,
+} from "@/lib/public-docs-curation";
 import { buildPageMetadata } from "@/lib/seo";
 import {
   buildVariablesMap,
@@ -186,7 +190,7 @@ export async function generateMetadata({
     )
     .limit(1);
 
-  if (pageResult.length === 0) {
+  if (pageResult.length === 0 || !isPublicDocsVisiblePage(pageResult[0])) {
     if (findRedirect(docsConfig.advanced.redirects, pagePath)) return {};
 
     const spec = docsSettings.openApiSpec as
@@ -371,15 +375,17 @@ export default async function DocsPage({
     locale,
     langConfig.defaultLanguage,
   );
-  const allPages = localizedPages.map((p) => ({
-    id: p.id,
-    path: p.path,
-    title: p.title,
-    description: p.description,
-    content: p.content,
-    frontmatter: p.frontmatter,
-    isPublished: p.isPublished,
-  }));
+  const allPages = filterPublicDocsVisiblePages(
+    localizedPages.map((p) => ({
+      id: p.id,
+      path: p.path,
+      title: p.title,
+      description: p.description,
+      content: p.content,
+      frontmatter: p.frontmatter,
+      isPublished: p.isPublished,
+    })),
+  );
 
   // Check for redirects before looking up the page
   const redirectDest = findRedirect(docsConfig.advanced.redirects, pagePath);
@@ -476,7 +482,7 @@ export default async function DocsPage({
     });
 
     // Resolve snippets and variables before rendering
-    const snippetPages = allPages
+    const snippetPages = allPagesRaw
       .filter((p) => p.path.startsWith("snippets/"))
       .map((p) => ({ path: p.path, content: p.content || "" }));
 

--- a/src/app/docs/[subdomain]/page.tsx
+++ b/src/app/docs/[subdomain]/page.tsx
@@ -8,6 +8,7 @@ import {
   getDocsAccessCookieName,
   hasValidDocsAccess,
 } from "@/lib/project-docs-access";
+import { isPublicDocsVisiblePage } from "@/lib/public-docs-curation";
 
 interface DocsIndexProps {
   params: Promise<{ subdomain: string }>;
@@ -29,7 +30,7 @@ export default async function DocsIndex({
     .limit(1);
 
   if (projectResult.length === 0) {
-    notFound();
+    return notFound();
   }
 
   const cookieStore = await cookies();
@@ -50,7 +51,11 @@ export default async function DocsIndex({
 
   // 1. Try to find 'introduction' first
   const introductionPage = await db
-    .select({ path: pages.path })
+    .select({
+      path: pages.path,
+      title: pages.title,
+      frontmatter: pages.frontmatter,
+    })
     .from(pages)
     .where(
       and(
@@ -61,13 +66,20 @@ export default async function DocsIndex({
     )
     .limit(1);
 
-  if (introductionPage.length > 0) {
-    redirect(`/docs/${subdomain}/${introductionPage[0].path}`);
+  if (
+    introductionPage.length > 0 &&
+    isPublicDocsVisiblePage(introductionPage[0])
+  ) {
+    return redirect(`/docs/${subdomain}/${introductionPage[0].path}`);
   }
 
   // 2. Fallback to alphabetically first page
   const firstPage = await db
-    .select({ path: pages.path })
+    .select({
+      path: pages.path,
+      title: pages.title,
+      frontmatter: pages.frontmatter,
+    })
     .from(pages)
     .where(
       and(
@@ -76,11 +88,12 @@ export default async function DocsIndex({
       ),
     )
     .orderBy(pages.path)
-    .limit(1);
+    .limit(20);
 
-  if (firstPage.length > 0) {
-    redirect(`/docs/${subdomain}/${firstPage[0].path}`);
+  const firstVisiblePage = firstPage.find(isPublicDocsVisiblePage);
+  if (firstVisiblePage) {
+    return redirect(`/docs/${subdomain}/${firstVisiblePage.path}`);
   }
 
-  notFound();
+  return notFound();
 }

--- a/src/app/docs/[subdomain]/sitemap.xml/route.ts
+++ b/src/app/docs/[subdomain]/sitemap.xml/route.ts
@@ -3,6 +3,7 @@ import { getPublicAppUrl } from "@/lib/app-url";
 import { db } from "@/lib/db";
 import { pages, projects } from "@/lib/db/schema";
 import { isProjectPasswordProtected } from "@/lib/project-publication-auth";
+import { filterPublicDocsVisiblePages } from "@/lib/public-docs-curation";
 import { generateSitemapEntries, renderSitemapXml } from "@/lib/seo";
 
 const APP_URL = getPublicAppUrl();
@@ -50,7 +51,11 @@ export async function GET(
     )
     .orderBy(pages.path);
 
-  const entries = generateSitemapEntries(allPages, APP_URL, subdomain);
+  const entries = generateSitemapEntries(
+    filterPublicDocsVisiblePages(allPages),
+    APP_URL,
+    subdomain,
+  );
   const xml = renderSitemapXml(entries);
 
   return new Response(xml, {

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -22,6 +22,7 @@ async function getPublishedDocsProjects() {
         pagePath: pages.path,
         pageTitle: pages.title,
         pageDescription: pages.description,
+        pageFrontmatter: pages.frontmatter,
       })
       .from(projects)
       .innerJoin(pages, eq(pages.projectId, projects.id))

--- a/src/lib/docs-entry.ts
+++ b/src/lib/docs-entry.ts
@@ -1,3 +1,5 @@
+import { isPublicDocsVisiblePage } from "@/lib/public-docs-curation";
+
 export interface DocsEntryRow {
   projectId: string;
   projectName: string;
@@ -5,6 +7,7 @@ export interface DocsEntryRow {
   pagePath: string;
   pageTitle: string;
   pageDescription: string | null;
+  pageFrontmatter?: Record<string, unknown> | null;
 }
 
 export interface DocsEntryProject {
@@ -37,6 +40,15 @@ export function buildDocsEntryProjects(
 
   for (const row of rows) {
     if (!row.subdomain || !row.pagePath) continue;
+    if (
+      !isPublicDocsVisiblePage({
+        path: row.pagePath,
+        title: row.pageTitle,
+        frontmatter: row.pageFrontmatter,
+      })
+    ) {
+      continue;
+    }
 
     const candidate = {
       id: row.projectId,

--- a/src/lib/github-docs-import.ts
+++ b/src/lib/github-docs-import.ts
@@ -2,6 +2,7 @@ import { extractFrontmatter } from "@/lib/editor";
 import { parseGitHubUrl } from "@/lib/git-settings";
 import { normalizeMarkdownContent } from "@/lib/markdown-normalization";
 import { titleFromPath } from "@/lib/pages";
+import { isPublicDocsVisiblePage } from "@/lib/public-docs-curation";
 
 export interface ImportedGitHubDocPage {
   path: string;
@@ -173,21 +174,8 @@ function normalizeGitHubMarkdownContent(
   );
 }
 
-const EXCLUDED_PATHS = [
-  /^agents\.md$/i,
-  /^claude\.md$/i,
-  /^memory\.md$/i,
-  /^soul\.md$/i,
-  /^tools\.md$/i,
-  /^\.github\//i,
-  /^agent_docs\//i,
-  /^memory\//i,
-  /^private\//i,
-  /^node_modules\//i,
-];
-
 function isExcludedPath(filePath: string): boolean {
-  return EXCLUDED_PATHS.some((pattern) => pattern.test(filePath));
+  return !isPublicDocsVisiblePage({ path: filePath });
 }
 
 export async function importGitHubDocs(
@@ -267,6 +255,9 @@ export async function importGitHubDocs(
         titleFromPath(pagePath),
       );
       const title = toTitle(content, pagePath);
+      if (!isPublicDocsVisiblePage({ path: pagePath, title })) {
+        return null;
+      }
       return {
         path: pagePath,
         title,

--- a/src/lib/mdx-renderer.ts
+++ b/src/lib/mdx-renderer.ts
@@ -3,6 +3,11 @@
  * builds docs navigation, and resolves pages from slugs.
  */
 
+import {
+  isBrokenGeneratedBadge,
+  isPublicDocsVisiblePage,
+} from "@/lib/public-docs-curation";
+
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 export interface ContentBlock {
@@ -234,7 +239,9 @@ function renderInline(text: string): string {
   result = result.replace(
     /!\[([^\]]*)\]\(([^)]+)\)/g,
     (_match, alt: string, rawUrl: string) =>
-      `<img src="${safeUrlAttribute(rawUrl)}" alt="${alt}" />`,
+      isBrokenGeneratedBadge(alt, rawUrl)
+        ? ""
+        : `<img src="${safeUrlAttribute(rawUrl)}" alt="${alt}" />`,
   );
 
   // Links
@@ -848,6 +855,7 @@ export function renderComponentBlock(block: ContentBlock): string {
 
     // Badge — inline colored status pill
     case "Badge": {
+      if (isBrokenGeneratedBadge(content, props.href ?? props.url)) return "";
       const color = props.color || "default";
       return `<span class="badge badge-${escapeHtml(color)}">${parseMdxToHtml(content).replace(/<\/?p>/g, "")}</span>`;
     }
@@ -887,8 +895,9 @@ export function buildDocsNav(
   const groups = new Map<string, DocsNavItem[]>();
 
   for (const page of pageList) {
-    // Skip snippet pages — they are reusable content, not navigable pages
+    // Skip snippet/internal pages — they are reusable or operational content, not navigable pages
     if (page.path.startsWith("snippets/")) continue;
+    if (!isPublicDocsVisiblePage(page)) continue;
     const segments = page.path.split("/");
 
     // Extract API method from frontmatter if present (e.g. "GET /plants" → "GET")

--- a/src/lib/public-docs-curation.ts
+++ b/src/lib/public-docs-curation.ts
@@ -1,0 +1,136 @@
+export interface PublicDocsCurationPage {
+  path?: string | null;
+  title?: string | null;
+  frontmatter?: Record<string, unknown> | null;
+}
+
+const INTERNAL_PATH_PREFIXES = [
+  ".claude/",
+  ".codex/",
+  ".cursor/",
+  ".github/",
+  ".omx/",
+  "agent_docs/",
+  "memory/",
+  "node_modules/",
+  "private/",
+  "ralph/",
+  "ralph-hardening/",
+  "target-doc/",
+  "target-docs/",
+  "target_docs/",
+];
+
+const INTERNAL_EXACT_PATHS = new Set([
+  ".claude",
+  "agents",
+  "claude",
+  "memory",
+  "soul",
+  "tools",
+]);
+
+const INTERNAL_ARTIFACT_PATTERNS = [
+  /(?:^|[-_/\s])ralph(?:[-_/\s]|$)/i,
+  /(?:^|[-_/\s])target[-_\s]?docs?(?:[-_/\s]|$)/i,
+  /(?:^|[-_/\s])qa[-_\s]?loop(?:[-_/\s]|$)/i,
+  /(?:^|[-_/\s])build[-_\s]?loop(?:[-_/\s]|$)/i,
+  /(?:^|[-_/\s])inspect[-_\s]?loop(?:[-_/\s]|$)/i,
+  /(?:^|[-_/\s])onboard[-_\s]?prompt(?:[-_/\s]|$)/i,
+  /(?:^|[-_/\s])build[-_\s]?prompt(?:[-_/\s]|$)/i,
+  /(?:^|[-_/\s])inspect[-_\s]?prompt(?:[-_/\s]|$)/i,
+  /(?:^|[-_/\s])qa[-_\s]?prompt(?:[-_/\s]|$)/i,
+  /(?:^|[-_/\s])code[-_\s]?duplication[-_\s]?fix[-_\s]?prompt(?:[-_/\s]|$)/i,
+  /(?:^|[-_/\s])build[-_\s]?guide(?:[-_/\s]|$)/i,
+  /(?:^|[-_/\s])build[-_\s]?spec(?:[-_/\s]|$)/i,
+  /(?:^|[-_/\s])ever[-_\s]?cli(?:[-_/\s]|$)/i,
+  /(?:^|[-_/\s])browser[-_\s]?control(?:[-_/\s]|$)/i,
+  /(?:^|[-_/\s])site[-_\s]?map(?:[-_/\s]|$)/i,
+  /(?:^|[-_/\s])documentation[-_\s]?index(?:[-_/\s]|$)/i,
+  /(?:^|[-_/\s])generated[-_\s]?(?:artifact|dump|output)s?(?:[-_/\s]|$)/i,
+];
+
+export function normalizePublicDocsPath(path?: string | null): string {
+  return (path ?? "")
+    .trim()
+    .replace(/\\/g, "/")
+    .replace(/^\/+/, "")
+    .replace(/\.(md|mdx)$/i, "")
+    .toLowerCase();
+}
+
+function curationOverride(frontmatter?: Record<string, unknown> | null) {
+  if (!frontmatter) return null;
+
+  if (
+    frontmatter.publicDocs === true ||
+    frontmatter.opendocsPublic === true ||
+    frontmatter.curation === "public" ||
+    frontmatter.curation === "include"
+  ) {
+    return true;
+  }
+
+  if (
+    frontmatter.publicDocs === false ||
+    frontmatter.internal === true ||
+    frontmatter.private === true ||
+    frontmatter.curation === "internal" ||
+    frontmatter.curation === "exclude"
+  ) {
+    return false;
+  }
+
+  return null;
+}
+
+export function isInternalPublicDocsPath(path?: string | null): boolean {
+  const normalized = normalizePublicDocsPath(path);
+  if (!normalized) return false;
+
+  if (INTERNAL_EXACT_PATHS.has(normalized)) return true;
+  if (INTERNAL_PATH_PREFIXES.some((prefix) => normalized.startsWith(prefix))) {
+    return true;
+  }
+
+  return INTERNAL_ARTIFACT_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+export function isInternalPublicDocsTitle(title?: string | null): boolean {
+  const normalized = (title ?? "").trim();
+  if (!normalized) return false;
+  return INTERNAL_ARTIFACT_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+export function isPublicDocsVisiblePage(page: PublicDocsCurationPage): boolean {
+  const override = curationOverride(page.frontmatter);
+  if (override !== null) return override;
+
+  if (isInternalPublicDocsPath(page.path)) return false;
+  if (isInternalPublicDocsTitle(page.title)) return false;
+
+  return true;
+}
+
+export function filterPublicDocsVisiblePages<T extends PublicDocsCurationPage>(
+  pageList: T[],
+): T[] {
+  return pageList.filter(isPublicDocsVisiblePage);
+}
+
+export function isBrokenGeneratedBadge(
+  label?: string | null,
+  url?: string | null,
+) {
+  const haystack = `${label ?? ""} ${url ?? ""}`
+    .toLowerCase()
+    .replace(/%20/g, " ")
+    .replace(/[-_]+/g, " ");
+
+  return (
+    haystack.includes("repo not found") ||
+    haystack.includes("repository not found") ||
+    /\binvalid\s+(?:badge|repo|repository)\b/.test(haystack) ||
+    /\bbadge\s+invalid\b/.test(haystack)
+  );
+}

--- a/src/lib/public-docs-llms.ts
+++ b/src/lib/public-docs-llms.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { pages, projects } from "@/lib/db/schema";
 import { generateLlmsFullTxt, generateLlmsTxt } from "@/lib/llms-txt";
+import { filterPublicDocsVisiblePages } from "@/lib/public-docs-curation";
 
 export type PublicLlmsType = "index" | "full";
 
@@ -30,10 +31,13 @@ export async function getPublicDocsLlmsResponse(
       path: pages.path,
       title: pages.title,
       content: pages.content,
+      frontmatter: pages.frontmatter,
     })
     .from(pages)
     .where(and(eq(pages.projectId, project.id), eq(pages.isPublished, true)))
     .orderBy(pages.path);
+
+  const visiblePages = filterPublicDocsVisiblePages(publishedPages);
 
   const baseUrl = buildPublicDocsBaseUrl(
     new URL(request.url).origin,
@@ -41,8 +45,8 @@ export async function getPublicDocsLlmsResponse(
   );
   const content =
     type === "full"
-      ? generateLlmsFullTxt(project.name, baseUrl, publishedPages)
-      : generateLlmsTxt(project.name, baseUrl, publishedPages);
+      ? generateLlmsFullTxt(project.name, baseUrl, visiblePages)
+      : generateLlmsTxt(project.name, baseUrl, visiblePages);
 
   return new NextResponse(content, {
     status: 200,

--- a/tests/docs-entry.test.ts
+++ b/tests/docs-entry.test.ts
@@ -48,4 +48,36 @@ describe("buildDocsEntryProjects", () => {
       ]),
     ).toEqual([]);
   });
+
+  it("skips internal generated docs when selecting public entry cards", () => {
+    expect(
+      buildDocsEntryProjects([
+        {
+          projectId: "project-1",
+          projectName: "Test Project",
+          subdomain: "test-project",
+          pagePath: "ralph/build-loop-prompt",
+          pageTitle: "Build Loop Prompt",
+          pageDescription: null,
+        },
+        {
+          projectId: "project-1",
+          projectName: "Test Project",
+          subdomain: "test-project",
+          pagePath: "quickstart",
+          pageTitle: "Quickstart",
+          pageDescription: "Start here",
+        },
+      ]),
+    ).toEqual([
+      {
+        id: "project-1",
+        name: "Test Project",
+        subdomain: "test-project",
+        href: "/docs/test-project/quickstart",
+        pageTitle: "Quickstart",
+        pageDescription: "Start here",
+      },
+    ]);
+  });
 });

--- a/tests/docs-search-route.test.ts
+++ b/tests/docs-search-route.test.ts
@@ -101,4 +101,37 @@ describe("GET /api/docs/[subdomain]/search", () => {
       title: "Get Plants",
     });
   });
+
+  it("filters internal published artifacts from public search results", async () => {
+    selectMock.mockReturnValueOnce(mockProjectLookup({})).mockReturnValueOnce(
+      mockPageSearch([
+        {
+          path: "ralph/qa-loop-prompt",
+          title: "QA Loop Prompt",
+          description: null,
+          content: "plants internal runbook",
+          frontmatter: null,
+        },
+        {
+          path: "quickstart",
+          title: "Quickstart",
+          description: null,
+          content: "plants public guide",
+          frontmatter: null,
+        },
+      ]),
+    );
+
+    const { GET } = await import("@/app/api/docs/[subdomain]/search/route");
+    const response = await GET(
+      makeRequest("http://localhost/api/docs/test-project/search?q=plants"),
+      { params: Promise.resolve({ subdomain: "test-project" }) },
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual([
+      expect.objectContaining({ path: "quickstart", title: "Quickstart" }),
+    ]);
+  });
 });

--- a/tests/github-docs-import.test.ts
+++ b/tests/github-docs-import.test.ts
@@ -403,6 +403,47 @@ ${"```"}
     }
   });
 
+  it("excludes public-docs internal prompts, target dumps, and generated artifacts", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes("/git/trees/")) {
+        return {
+          ok: true,
+          json: async () => ({
+            tree: [
+              { path: "README.md", type: "blob" },
+              { path: ".claude/README.md", type: "blob" },
+              { path: "ralph/qa-loop-prompt.md", type: "blob" },
+              {
+                path: "target-docs/linear-documentation-index.md",
+                type: "blob",
+              },
+              { path: "docs/build-loop-prompt.md", type: "blob" },
+            ],
+          }),
+        };
+      }
+
+      return {
+        ok: true,
+        text: async () =>
+          url.includes("README.md") && !url.includes(".claude")
+            ? "# README"
+            : "# Internal Artifact",
+      };
+    });
+
+    const { importGitHubDocs } = await import("@/lib/github-docs-import");
+    const result = await importGitHubDocs({
+      repoUrl: "https://github.com/acme/docs",
+      fetchImpl: fetchMock as unknown as typeof fetch,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.pages.map((page) => page.path)).toEqual(["introduction"]);
+    }
+  });
+
   it("handles relative images inside nested docs folders", async () => {
     const fetchMock = vi.fn(async (url: string) => {
       if (url.includes("/git/trees/")) {

--- a/tests/public-docs-curation.test.ts
+++ b/tests/public-docs-curation.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { buildDocsNav, renderMdxContent } from "@/lib/mdx-renderer";
+import {
+  filterPublicDocsVisiblePages,
+  isBrokenGeneratedBadge,
+  isPublicDocsVisiblePage,
+} from "@/lib/public-docs-curation";
+
+describe("public docs curation", () => {
+  it("hides internal operational paths and generated artifact titles by default", () => {
+    const pages = [
+      { path: "introduction", title: "Introduction" },
+      { path: ".claude/settings", title: "Claude settings" },
+      { path: "ralph/build-loop-prompt", title: "Build Loop Prompt" },
+      {
+        path: "target-docs/linear-documentation-index",
+        title: "Linear Documentation Index",
+      },
+      { path: "docs/qa-loop-prompt", title: "QA Loop Prompt" },
+      {
+        path: "tools/ever-cli-browser-control",
+        title: "Ever CLI — Browser Control",
+      },
+    ];
+
+    expect(filterPublicDocsVisiblePages(pages)).toEqual([
+      { path: "introduction", title: "Introduction" },
+    ]);
+  });
+
+  it("allows explicit public docs curation overrides", () => {
+    expect(
+      isPublicDocsVisiblePage({
+        path: "target-docs/reference",
+        title: "Public reference",
+        frontmatter: { publicDocs: true },
+      }),
+    ).toBe(true);
+
+    expect(
+      isPublicDocsVisiblePage({
+        path: "guides/internal-rollout",
+        title: "Internal rollout",
+        frontmatter: { internal: true },
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps internal pages out of generated docs navigation", () => {
+    const nav = buildDocsNav([
+      { id: "1", path: "introduction", title: "Introduction" },
+      { id: "2", path: "ralph/qa-loop-prompt", title: "QA Loop Prompt" },
+      { id: "3", path: "guides/getting-started", title: "Getting Started" },
+    ]);
+
+    expect(JSON.stringify(nav)).toContain("Introduction");
+    expect(JSON.stringify(nav)).toContain("Getting Started");
+    expect(JSON.stringify(nav)).not.toContain("QA Loop Prompt");
+  });
+
+  it("detects and suppresses broken generated badge images", () => {
+    expect(isBrokenGeneratedBadge("repo not found", undefined)).toBe(true);
+    expect(
+      isBrokenGeneratedBadge(
+        "Repo",
+        "https://img.shields.io/badge/repo-not_found-red",
+      ),
+    ).toBe(true);
+    expect(isBrokenGeneratedBadge("build passing", undefined)).toBe(false);
+
+    const html = renderMdxContent(
+      "![repo not found](https://img.shields.io/badge/repo-not%20found-red) ![build passing](https://img.shields.io/badge/build-passing-green)",
+    );
+
+    expect(html).not.toContain("repo not found");
+    expect(html).toContain("build passing");
+  });
+});


### PR DESCRIPTION
## Summary
- Ports the verified public docs curation fix onto current production `main`
- Keeps internal/generated docs out of public import/read surfaces: docs routes, sidebar/nav, search, chat context, sitemap, markdown export, LLMS export, and `/docs` entry selection
- Filters broken generated badge image URLs from MDX rendering

## Validation
- `make check`
- `make test` (1908 passed)

## Notes
- This is the production-main port of #261 because `staging` is currently diverged/stale relative to `main`.
- Private QA artifacts were not committed.
