### PR TITLE
fix: pass ALB health URL to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,4 +42,7 @@ jobs:
           NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
           NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.NEXT_PUBLIC_POSTHOG_HOST }}
           SENTRY_ENVIRONMENT: production
+          # Use the ALB directly for deploy verification. GitHub-hosted
+          # runners are blocked by Cloudflare on the public health URL.
+          HEALTH_URL: http://opendocs-alb-1587657213.us-east-1.elb.amazonaws.com/api/health
         run: bash scripts/deploy.sh


### PR DESCRIPTION
## Summary
- passes the known ALB health URL into the production deploy workflow
- avoids Cloudflare 403s from GitHub-hosted runners without requiring new ELB IAM permissions

## Validation
- direct ALB health returns `status=ok`, `version=68246a7`
- public production health returns `status=ok`