### PR TITLE
chore: format wrangler example

### DIFF
--- a/wrangler.example.jsonc
+++ b/wrangler.example.jsonc
@@ -28,7 +28,9 @@
     }
   ],
   "durable_objects": {
-    "bindings": [{ "name": "OPENDOCS_CONTAINER", "class_name": "OpenDocsContainer" }]
+    "bindings": [
+      { "name": "OPENDOCS_CONTAINER", "class_name": "OpenDocsContainer" }
+    ]
   },
   "migrations": [{ "tag": "v1", "new_sqlite_classes": ["OpenDocsContainer"] }],
   // Non-secret runtime vars. Secrets are set once with `wrangler secret put <NAME>`:


### PR DESCRIPTION
## Summary\n- Format the durable object binding in wrangler.example.jsonc so Biome passes\n\n## Verification\n- make check\n\n## Context\n- Follow-up to PR #273: that docs PR merged successfully, but its post-merge CI run failed because Biome reported this pre-existing format issue.